### PR TITLE
fix: restore polynomial_detrend order=3 in preprocess_fnirs

### DIFF
--- a/src/hrfunc/hrfunc.py
+++ b/src/hrfunc/hrfunc.py
@@ -797,7 +797,7 @@ def preprocess_fnirs(scan, deconvolution = False):
 
     # If running deconvolution, polynomial detrend to remove pysiological without cutting into the frequency spectrum
     if deconvolution:
-        od = polynomial_detrend(od, order=1)
+        od = polynomial_detrend(od, order=3)
 
     # haemoglobin conversion using Beer Lambert Law 
     haemo = mne.preprocessing.nirs.beer_lambert_law(od.copy(), ppf=0.1)


### PR DESCRIPTION
The order=1 (linear) value was an exploratory change and not intentional. Internal docs specify order 3 (cubic), which is the correct choice for removing physiological drift without cutting into the HRF frequency spectrum.

Resolves Q2 from the Phase 1 open-questions list.