### PR TITLE
refactor: break circular imports between hrfunc.py and hrtree.py (pha…

### DIFF
--- a/src/hrfunc/_utils.py
+++ b/src/hrfunc/_utils.py
@@ -1,0 +1,79 @@
+"""
+Internal utilities shared between hrfunc.py and hrtree.py.
+
+Lives in its own module to break the circular import that used to exist
+between hrfunc.py (imports hrtree) and hrtree.py (imported hrfunc back
+for standardize_name, _is_oxygenated, and __file__).
+
+Nothing in this module should import from hrfunc.py or hrtree.py.
+"""
+
+import os
+import re
+
+
+_LIB_DIR = os.path.dirname(os.path.abspath(__file__))
+
+
+def standardize_name(ch_name):
+    """
+    Standardize channel names to a common format for processing.
+
+    Arguments:
+        ch_name (str) - Original channel name
+
+    Returns:
+        ch_name (str) - Standardized channel name
+    """
+    ch_name = re.sub(r'[_\-\s]+', '_', ch_name.lower())
+    oxygenation = _is_oxygenated(ch_name)
+    if oxygenation:
+        ch_name = ch_name[:-3] + 'hbo'
+    else:
+        ch_name = ch_name[:-3] + 'hbr'
+    return ch_name
+
+
+def _is_oxygenated(ch_name):
+    """
+    Check whether the channel is HbR or HbO.
+
+    Arguments:
+        ch_name (str) - Channel name to check
+
+    Returns:
+        bool - True if oxygenated, False if deoxygenated
+
+    Raises:
+        ValueError - If channel name has no recognizable oxygenation pattern
+        LookupError - If wavelength digits are present but out of range
+    """
+    if ch_name[-2] == 'b':
+        split = ch_name.split('hb')
+        if split[1][0] == 'o':
+            return True
+        elif split[1][0] == 'r':
+            return False
+        else:
+            raise ValueError(
+                f"Channel {ch_name} oxygenation status could not be determined, "
+                "ensure each channel has appropriate naming scheme with HbO/HbR included"
+            )
+    elif ch_name[-1] == '0':
+        try:
+            wavelength = int(ch_name[-3:])
+        except (ValueError, TypeError):
+            raise LookupError(f"Failed to evaluate oxygenation status of channel {ch_name}")
+        if 760 <= wavelength <= 780:
+            return False
+        elif 830 <= wavelength <= 850:
+            return True
+        else:
+            raise LookupError(
+                f"Wavelength found, but failed to evaluate oxygenation status of channel {ch_name}"
+            )
+    else:
+        raise ValueError(
+            f"Could not determine oxygenation for channel {ch_name}: "
+            "no hb suffix or recognized wavelength pattern"
+        )

--- a/src/hrfunc/hrfunc.py
+++ b/src/hrfunc/hrfunc.py
@@ -1,8 +1,8 @@
 import scipy.linalg, scipy.stats, json, mne, random, re, os, nilearn, time
-import hrfunc
 import numpy as np
 import matplotlib.pyplot as plt
 from .hrtree import tree, HRF
+from ._utils import standardize_name, _is_oxygenated, _LIB_DIR
 from concurrent.futures import ThreadPoolExecutor, TimeoutError
 from itertools import compress
 from glob import glob
@@ -43,7 +43,7 @@ def load_montage(json_filename, rich = False, **kwargs):
         json_contents = json.load(file)
 
     # Initialize an empty montage object
-    montage = hrfunc.montage(**kwargs)
+    _montage = montage(**kwargs)
 
     # Grab info from json contents
     first_hrf = json_contents[list(json_contents.keys())[0]]
@@ -53,8 +53,8 @@ def load_montage(json_filename, rich = False, **kwargs):
     ch_names = ['-'.join(key.split('-')[:-1]) for key in json_contents.keys()]
 
     # Assess which channels are oxygenated and deoxygenated
-    montage.hbo_channels = [ch for ch in ch_names if _is_oxygenated(ch) == True]
-    montage.hbr_channels = [ch for ch in ch_names if _is_oxygenated(ch) == False]
+    _montage.hbo_channels = [ch for ch in ch_names if _is_oxygenated(ch) == True]
+    _montage.hbr_channels = [ch for ch in ch_names if _is_oxygenated(ch) == False]
 
     # Update montage with saved info
     for key, channel in json_contents.items():
@@ -86,21 +86,21 @@ def load_montage(json_filename, rich = False, **kwargs):
         # Insert hrf into tree and attach pointer to channel
         oxygenation = _is_oxygenated(ch_name)
         if oxygenation:
-            montage.channels[ch_name] = montage.hbo_tree.insert(estimated_hrf)
+            _montage.channels[ch_name] = _montage.hbo_tree.insert(estimated_hrf)
             # Add context to tree
-            for context in montage.context:
-                montage.hbo_tree.hasher.add(context, montage.channels[ch_name])
+            for context in _montage.context:
+                _montage.hbo_tree.hasher.add(context, _montage.channels[ch_name])
         elif oxygenation == False:
-            montage.channels[ch_name] = montage.hbr_tree.insert(estimated_hrf)
+            _montage.channels[ch_name] = _montage.hbr_tree.insert(estimated_hrf)
             # Add context to tree
-            for context in montage.context:
-                montage.hbr_tree.hasher.add(context, montage.channels[ch_name])
-    
-    montage.sfreq = sfreq # Sampling frequency
+            for context in _montage.context:
+                _montage.hbr_tree.hasher.add(context, _montage.channels[ch_name])
 
-    montage.configured = True
+    _montage.sfreq = sfreq # Sampling frequency
 
-    return montage
+    _montage.configured = True
+
+    return _montage
 
 class montage(tree):
     """
@@ -130,7 +130,7 @@ class montage(tree):
         self.root = None # Set an empty root
 
         # Save runtime parameters to object
-        self.lib_dir = os.path.dirname(hrfunc.__file__)
+        self.lib_dir = _LIB_DIR
 
         # Set data context
         self.context = {
@@ -834,50 +834,3 @@ def polynomial_detrend(raw, order = 1):
         raw_detrended._data[idx] = y_detrended
 
     return raw_detrended
- 
-def standardize_name(ch_name):
-    """
-    Standardize channel names to a common format for processing
-    
-    Arguments:
-        ch_name (str) - Original channel name
-        
-    Returns:
-        ch_name (str) - Standardized channel name"""
-    ch_name = re.sub(r'[_\-\s]+', '_', ch_name.lower())
-    oxygenation = _is_oxygenated(ch_name)
-    if oxygenation:
-        ch_name = ch_name[:-3] + 'hbo'
-    else:
-        ch_name = ch_name[:-3] + 'hbr'
-    return ch_name
-
-def _is_oxygenated(ch_name):
-    """ Check in whether the channel is HbR or HbO 
-    
-    Arguments:
-        ch_name (str) - Channel name to check
-    
-    Returns:
-        bool - True if oxygenated, False if deoxygenated"""
-    if ch_name[-2] == 'b':
-        split = ch_name.split('hb')
-        if split[1][0] == 'o': # If oxygenated channel
-            return True
-        elif split[1][0] == 'r': # If deoxygenated channel
-            return False
-        else:
-            raise ValueError(f"Channel {ch_name} oxygenation status could not be determines, ensure each channel has appropriate naming scheme with HbO/HbR included")
-    elif ch_name[-1] == '0':
-        try:
-            wavelength = int(ch_name[-3:])
-        except (ValueError, TypeError):
-            raise LookupError(f"Failed to evaluate oxygenation status of channel {ch_name}")
-        if wavelength >= 760 and wavelength <= 780:
-            return False
-        elif wavelength >= 830 and wavelength <= 850:
-            return True
-        else:
-            raise LookupError(f"Wavelength found, but failed to evaluate oxygenation status of channel {ch_name}")
-    else:
-        raise ValueError(f"Could not determine oxygenation for channel {ch_name}: no hb suffix or recognized wavelength pattern")

--- a/src/hrfunc/hrtree.py
+++ b/src/hrfunc/hrtree.py
@@ -1,5 +1,6 @@
 import json, random, math, re, nilearn, scipy, os
-from . import hrhash, hrfunc
+from . import hrhash
+from ._utils import standardize_name, _is_oxygenated, _LIB_DIR
 import matplotlib.pyplot as plt
 import numpy as np
 from scipy.interpolate import interp1d
@@ -39,7 +40,7 @@ class tree:
             - branched (bool) - Whether the tree has been branched on a specific context
         """
         # Find hrfunc install library
-        self.lib_dir = os.path.dirname(hrfunc.__file__)
+        self.lib_dir = _LIB_DIR
 
         self.hrf_filename = hrf_filename
 
@@ -98,7 +99,7 @@ class tree:
 
 
             # Skip if oxygenation/deoxygenation filtering requested
-            oxygenation = hrfunc._is_oxygenated(ch_name)
+            oxygenation = _is_oxygenated(ch_name)
             if oxygenated == False and oxygenation:
                 continue
             if oxygenated and oxygenation == False:
@@ -606,8 +607,8 @@ class HRF:
         self.doi = doi
 
         # Clean and add channel name
-        self.ch_name = hrfunc.standardize_name(ch_name)
-        self.oxygenation = hrfunc._is_oxygenated(self.ch_name)
+        self.ch_name = standardize_name(ch_name)
+        self.oxygenation = _is_oxygenated(self.ch_name)
 
         # Attach passed into info to class 
         self.sfreq = sfreq

--- a/tests/test_phase2.py
+++ b/tests/test_phase2.py
@@ -1,0 +1,153 @@
+"""
+Targeted unit tests for refactor/circular-imports-phase2.
+
+Verifies that the circular import hrfunc.py ↔ hrtree.py has been broken
+by moving shared helpers into hrfunc._utils, and that all existing
+functionality using standardize_name / _is_oxygenated / _LIB_DIR still
+resolves correctly through the new import path.
+"""
+
+import os
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# No circular imports
+# ---------------------------------------------------------------------------
+
+class TestNoCircularImports:
+    def test_hrfunc_does_not_self_import(self):
+        """hrfunc.py must not contain `import hrfunc` anymore."""
+        import hrfunc.hrfunc as hf
+        source_path = hf.__file__
+        with open(source_path) as f:
+            source = f.read()
+        # Check for the specific self-import pattern, not references in strings/comments
+        for line in source.splitlines():
+            stripped = line.strip()
+            if stripped.startswith('#'):
+                continue
+            assert stripped != 'import hrfunc', (
+                "hrfunc.py still contains `import hrfunc` self-import"
+            )
+
+    def test_hrtree_does_not_import_hrfunc(self):
+        """hrtree.py must not import from hrfunc anymore."""
+        import hrfunc.hrtree as ht
+        source_path = ht.__file__
+        with open(source_path) as f:
+            source = f.read()
+        for line in source.splitlines():
+            stripped = line.strip()
+            if stripped.startswith('#'):
+                continue
+            assert 'from . import hrhash, hrfunc' not in stripped, (
+                "hrtree.py still contains circular `from . import hrhash, hrfunc`"
+            )
+            assert 'from .hrfunc import' not in stripped, (
+                "hrtree.py still has a direct hrfunc import"
+            )
+
+    def test_utils_module_is_importable_directly(self):
+        """_utils.py exists and is directly importable."""
+        from hrfunc import _utils
+        assert hasattr(_utils, 'standardize_name')
+        assert hasattr(_utils, '_is_oxygenated')
+        assert hasattr(_utils, '_LIB_DIR')
+
+    def test_utils_does_not_import_hrfunc_or_hrtree(self):
+        """_utils.py must stay dependency-free of hrfunc.py and hrtree.py."""
+        from hrfunc import _utils
+        with open(_utils.__file__) as f:
+            source = f.read()
+        for line in source.splitlines():
+            stripped = line.strip()
+            if stripped.startswith('#') or stripped.startswith('"""'):
+                continue
+            assert 'from .hrfunc' not in stripped
+            assert 'from .hrtree' not in stripped
+            assert 'import hrfunc.hrfunc' not in stripped
+            assert 'import hrfunc.hrtree' not in stripped
+
+
+# ---------------------------------------------------------------------------
+# _LIB_DIR resolves to the package directory
+# ---------------------------------------------------------------------------
+
+class TestLibDirConstant:
+    def test_lib_dir_points_to_package(self):
+        """_LIB_DIR must resolve to the src/hrfunc directory containing hrfs/."""
+        from hrfunc._utils import _LIB_DIR
+        assert os.path.isdir(_LIB_DIR)
+        # The bundled library JSONs must be reachable from _LIB_DIR
+        assert os.path.isfile(os.path.join(_LIB_DIR, 'hrfs', 'hbo_hrfs.json'))
+        assert os.path.isfile(os.path.join(_LIB_DIR, 'hrfs', 'hbr_hrfs.json'))
+
+    def test_montage_lib_dir_matches_utils(self):
+        """montage.__init__ sets self.lib_dir to _LIB_DIR."""
+        from hrfunc.hrfunc import montage
+        from hrfunc._utils import _LIB_DIR
+        m = montage()
+        assert m.lib_dir == _LIB_DIR
+
+    def test_tree_lib_dir_matches_utils(self):
+        """tree.__init__ sets self.lib_dir to _LIB_DIR."""
+        from hrfunc.hrtree import tree
+        from hrfunc._utils import _LIB_DIR
+        t = tree()
+        assert t.lib_dir == _LIB_DIR
+
+
+# ---------------------------------------------------------------------------
+# standardize_name + _is_oxygenated still resolve through both files
+# ---------------------------------------------------------------------------
+
+class TestHelperResolution:
+    def test_hrfunc_uses_utils_helpers(self):
+        """hrfunc.py imports standardize_name and _is_oxygenated from _utils."""
+        from hrfunc import _utils
+        import hrfunc.hrfunc as hf
+        # After the refactor, hrfunc.hrfunc.standardize_name should be the
+        # same function object as hrfunc._utils.standardize_name
+        assert hf.standardize_name is _utils.standardize_name
+        assert hf._is_oxygenated is _utils._is_oxygenated
+
+    def test_hrtree_uses_utils_helpers(self):
+        """hrtree.py imports standardize_name and _is_oxygenated from _utils."""
+        from hrfunc import _utils
+        import hrfunc.hrtree as ht
+        assert ht.standardize_name is _utils.standardize_name
+        assert ht._is_oxygenated is _utils._is_oxygenated
+
+    def test_standardize_name_still_works(self):
+        """Regression: standardize_name behavior unchanged after move."""
+        from hrfunc._utils import standardize_name
+        # A simple hbo channel should round-trip through normalization
+        result = standardize_name('S1-D1 hbo')
+        assert result.endswith('hbo')
+
+    def test_is_oxygenated_still_works(self):
+        """Regression: _is_oxygenated behavior unchanged after move."""
+        from hrfunc._utils import _is_oxygenated
+        assert _is_oxygenated('s1_d1_hbo') is True
+        assert _is_oxygenated('s1_d1_hbr') is False
+        with pytest.raises(ValueError):
+            _is_oxygenated('s1_d1_xyz')
+
+
+# ---------------------------------------------------------------------------
+# load_montage still works with the renamed local variable
+# ---------------------------------------------------------------------------
+
+class TestLoadMontageLocalRename:
+    def test_load_montage_uses_bundled_library_file(self, tmp_path):
+        """load_montage must still successfully construct a montage via
+        the module-level `montage` class even though its local variable
+        was renamed to `_montage` to avoid UnboundLocalError."""
+        from hrfunc.hrfunc import load_montage
+        from hrfunc._utils import _LIB_DIR
+        # Use the bundled hbo_hrfs.json as a known-good input
+        bundled = os.path.join(_LIB_DIR, 'hrfs', 'hbo_hrfs.json')
+        m = load_montage(bundled)
+        assert m is not None
+        assert m.configured is True


### PR DESCRIPTION
…se 2)

Before: hrfunc.py self-imported via `import hrfunc` and hrtree.py imported back via `from . import hrhash, hrfunc`. The system only worked because cross-references happened inside method bodies rather than at module load time — fragile and confusing.

Changes:
- New src/hrfunc/_utils.py holds standardize_name(), _is_oxygenated(), and the _LIB_DIR constant. Dependency-free of hrfunc.py and hrtree.py.
- hrfunc.py: drops `import hrfunc` self-import; drops the duplicate standardize_name/_is_oxygenated definitions (now live in _utils); uses _LIB_DIR instead of hrfunc.__file__.
- hrtree.py: drops `from . import hrfunc`; imports helpers from _utils; uses _LIB_DIR instead of hrfunc.__file__.
- load_montage: local variable `montage` renamed to `_montage` so the right-hand side `montage(**kwargs)` can resolve to the module-level class without hitting Python's UnboundLocalError rule.

Adds tests/test_phase2.py: 12 regression tests covering circular-import absence, _LIB_DIR resolution, helper identity through both modules, and load_montage still working after the local rename.

Full suite: 57 passed, 1 xfailed (unchanged from before refactor).