### PR TITLE
fix: propagate success state out of deconvolution closure + 30s timeo…

### DIFF
--- a/src/hrfunc/hrfunc.py
+++ b/src/hrfunc/hrfunc.py
@@ -337,7 +337,7 @@ class montage(tree):
             optode.locations.append(list(channel['loc'][:3]))
 
 
-    def estimate_activity(self, nirx_obj, lmbda = 1e-4, hrf_model = 'toeplitz', preprocess = True, cond_thresh = None, timeout = 1500):
+    def estimate_activity(self, nirx_obj, lmbda = 1e-4, hrf_model = 'toeplitz', preprocess = True, cond_thresh = None, timeout = 30):
         """
         Deconvlve a fNIRS scan using estimated HRF's localized to optodes location
         to gain a neural activity estimate
@@ -347,23 +347,35 @@ class montage(tree):
             lmbda (float) - Regularization parameter to apply during deconvolution
             hrf_model (str) - HRF model to use during deconvolution, either 'toeplitz' for localized HRF's or 'canonical' for a standard canonical HRF
             preprocess (bool) - If True, preprocess the fNIRS data before estimating the neural activity
-        
+            cond_thresh (float or None) - Condition number threshold for falling back to pinv in solve_lstsq
+            timeout (float) - Seconds to wait for a single channel's lstsq solve before dropping that channel.
+                Default 30 is a generous ceiling — realistic fNIRS inputs solve in tens of milliseconds,
+                so this fires only on genuinely pathological matrices. Can be tightened once empirical
+                solve-time data is collected from real runs.
+
         Returns:
-            None
+            nirx_obj (mne raw object) - Raw with deconvolved neural activity, or None if skipped
         """
 
         # Check montage still needs to be configured
         if self.configured is False:
             self.configure(nirx_obj)
-            
+
         nirx_obj.load_data()
         if preprocess:
             nirx_obj = preprocess_fnirs(nirx_obj, deconvolution=True)
             if nirx_obj is None:
                 return None  # Skip subject if all channels are bad
 
+        # success is declared at estimate_activity scope so the nested deconvolution
+        # closure can write to it via `nonlocal` — otherwise success=True/False inside
+        # the closure would create a closure-local and the outer drop-channel check
+        # would always read None (ND-003).
+        success = None
+
         # Define hrf deconvolve function to pass nirx object
         def deconvolution(nirx):
+            nonlocal success
 
             # Normalize input z-score
             mean = np.mean(nirx)
@@ -387,35 +399,25 @@ class montage(tree):
             # Solve the inverse problem with regularization
             lhs = A.T @ A + float(lmbda) * np.eye(A.shape[1])
             rhs = A.T @ Y
-            
+
             with ThreadPoolExecutor(max_workers=1) as executor:
                 future = executor.submit(self.solve_lstsq, lhs, rhs, cond_thresh)
                 try:
                     deconvolved_signal = future.result(timeout)
                     success = True
-
                 except TimeoutError:
-                    print("lstsq failed to converge and estimate neural activity, dropping channel")
+                    print(f"lstsq exceeded {timeout}s timeout, dropping channel")
                     deconvolved_signal = nirx
                     success = False
-            
-            """
-            start = time.time()
-            deconvolved_signal = self.solve_lstsq(lhs, rhs)
-            end = time.time()
-            print(f"Elapsed time: {end - start:.6f} seconds")
-            """
-            # Denormalize neural signal estimate - EXCLUDING TO KEEP IN A.U.
-            #deconvolved_signal = deconvolved_signal * std + mean
 
             return deconvolved_signal # Return recovered neural signal
 
         # Apply deconvolution and return the nirx object
         for ch_name, hrf in self.channels.items():
-            success = None
+            success = None  # reset per channel so stale state can't leak from prior iteration
 
             if 'global' in ch_name: continue # Skip if global hrf estimate
-            
+
             # If canonical HRF requested
             if hrf_model == 'canonical' or len(hrf.trace) == 0:
                 print(f"WARNING: Using canonical HRF for channel {ch_name} in {nirx_obj}")
@@ -430,12 +432,12 @@ class montage(tree):
                 standard_ch_name = standardize_name(nirx_channel['ch_name'])
                 if ch_name == standard_ch_name:
                     break
-                
+
             print(f"Deconvolving channel {ch_name}...") # Apply deconvolution
             nirx_obj.apply_function(deconvolution, picks = [nirx_channel['ch_name']]) # Apply deconvolution for channel
 
-            # Remove channel is neural activity estimation failed to converge
-            if success == False:
+            # Remove channel if neural activity estimation failed to converge
+            if success is False:
                 nirx_obj.drop_channels([nirx_channel['ch_name']])
 
             # Replace the canonical HRF estimate temporarily used with the HRF estimate

--- a/tests/test_threading.py
+++ b/tests/test_threading.py
@@ -1,0 +1,135 @@
+"""
+Targeted unit tests for fix/estimate-activity-threading (ND-003 + ND-004).
+
+ND-003: `success` variable set inside the nested `deconvolution` closure was
+        not visible to the outer channel loop — the `if success == False`
+        check always read None, so channels were never actually dropped on
+        timeout. Fixed by adding `nonlocal success` and declaring `success`
+        at estimate_activity scope before the closure is defined.
+
+ND-004: `timeout=1500` default was 25 minutes, not 1.5 seconds.
+        Fixed to `timeout=30` (see Q1 decision in open questions memory).
+
+These tests exercise the scoping and signature without needing real fNIRS
+data. The full estimate_activity path still requires an MNE Raw object,
+which is covered by integration tests (currently disabled).
+"""
+
+import inspect
+import pytest
+import numpy as np
+
+
+# ---------------------------------------------------------------------------
+# ND-004: timeout default is 30s
+# ---------------------------------------------------------------------------
+
+class TestTimeoutDefault:
+    def test_estimate_activity_timeout_default_is_30(self):
+        """The timeout parameter default must be 30 (seconds), not 1500."""
+        from hrfunc.hrfunc import montage
+        sig = inspect.signature(montage.estimate_activity)
+        assert sig.parameters['timeout'].default == 30
+
+    def test_timeout_is_still_a_parameter(self):
+        """timeout must remain user-configurable, not hardcoded."""
+        from hrfunc.hrfunc import montage
+        sig = inspect.signature(montage.estimate_activity)
+        assert 'timeout' in sig.parameters
+
+
+# ---------------------------------------------------------------------------
+# ND-003: success variable propagates from closure to outer scope
+# ---------------------------------------------------------------------------
+
+class TestSuccessNonlocal:
+    def test_deconvolution_closure_declares_nonlocal_success(self):
+        """The fix for ND-003 is a `nonlocal success` in the closure.
+        Without it, success=True/False inside the closure is a no-op for
+        the outer drop-channel check."""
+        from hrfunc.hrfunc import montage
+        source = inspect.getsource(montage.estimate_activity)
+        assert 'nonlocal success' in source, (
+            "deconvolution closure must declare `nonlocal success` — "
+            "without it, ND-003 re-regresses and channels are never dropped"
+        )
+
+    def test_success_initialized_before_closure_definition(self):
+        """For `nonlocal` to bind cleanly, `success = None` must appear in
+        estimate_activity's body before `def deconvolution`."""
+        from hrfunc.hrfunc import montage
+        source = inspect.getsource(montage.estimate_activity)
+        # Find the first occurrence of each
+        success_init_idx = source.find('success = None')
+        def_deconv_idx = source.find('def deconvolution')
+        assert success_init_idx != -1, "success must be initialized to None somewhere"
+        assert def_deconv_idx != -1, "deconvolution closure must exist"
+        assert success_init_idx < def_deconv_idx, (
+            "`success = None` must appear before `def deconvolution` so that "
+            "`nonlocal success` resolves to estimate_activity's scope"
+        )
+
+    def test_drop_channel_check_uses_is_false(self):
+        """After the fix, the drop check reads `success is False`, not `== False`.
+        This is a PEP 8 style fix for clarity, not a correctness fix."""
+        from hrfunc.hrfunc import montage
+        source = inspect.getsource(montage.estimate_activity)
+        assert 'success is False' in source
+        assert 'success == False' not in source
+
+
+# ---------------------------------------------------------------------------
+# Functional scope smoke test — closure + nonlocal mechanics
+# ---------------------------------------------------------------------------
+
+class TestNonlocalMechanics:
+    """Verifies the `nonlocal` pattern actually propagates state correctly,
+    independent of the full estimate_activity call path. This is a sanity
+    check on the Python semantics we're relying on."""
+
+    def test_nonlocal_write_visible_to_outer(self):
+        """Demonstrates the exact pattern used in estimate_activity:
+        outer function defines success, nested closure writes to it
+        via `nonlocal`, outer function reads the updated value."""
+        def outer():
+            success = None
+            def inner():
+                nonlocal success
+                success = True
+            inner()
+            return success
+
+        assert outer() is True
+
+    def test_nonlocal_without_declaration_does_not_propagate(self):
+        """Without `nonlocal`, the inner assignment creates a closure-local.
+        This is exactly the bug ND-003 described."""
+        def outer():
+            success = None
+            def inner():
+                success = True  # no nonlocal — local to inner
+            inner()
+            return success
+
+        assert outer() is None  # bug reproduction
+
+
+# ---------------------------------------------------------------------------
+# Regression: estimate_activity signature and return contract
+# ---------------------------------------------------------------------------
+
+class TestEstimateActivityContract:
+    def test_returns_nirx_obj_on_success_path(self):
+        """phase 1c fix 1.16: estimate_activity must return nirx_obj (not None)
+        when it completes normally. Checked via source inspection since a
+        real call needs an MNE Raw object."""
+        from hrfunc.hrfunc import montage
+        source = inspect.getsource(montage.estimate_activity)
+        assert 'return nirx_obj' in source
+
+    def test_returns_none_when_all_channels_bad(self):
+        """When preprocess_fnirs returns None (all channels bad), estimate_activity
+        must return None early and not attempt deconvolution."""
+        from hrfunc.hrfunc import montage
+        source = inspect.getsource(montage.estimate_activity)
+        assert 'return None' in source


### PR DESCRIPTION
…ut (ND-003, ND-004)

ND-003: The nested `deconvolution(nirx)` closure inside estimate_activity was setting `success = True/False` inside its try/except. Because there was no `nonlocal` declaration, those assignments created a closure-local variable, invisible to the outer channel loop. The subsequent `if success == False: drop_channels(...)` check always read the outer loop's `success = None`, so channels that timed out were NEVER actually dropped — the original (undeconvolved) signal was left in the Raw object and silently passed downstream as if it were deconvolved neural activity.

Fix: hoist `success = None` to estimate_activity scope before `def deconvolution` so `nonlocal success` binds cleanly to the enclosing function's variable. Keep a per-iteration `success = None` reset inside the channel loop so stale state can't leak between channels.

ND-004: The default `timeout=1500` in estimate_activity was intended as a snap timeout but evaluates to 25 minutes. A pathological lstsq solve could block the entire pipeline for 25 minutes per channel before the drop path fired.

Fix: change default to `timeout=30`. Per Q1 decision, this is a generous ceiling — `np.linalg.lstsq` on realistic fNIRS inputs runs in tens of milliseconds, so 30s fires only on genuinely pathological matrices. The parameter stays user-configurable so power users can tighten or relax it. Docstring explains the rationale and that this may be tightened once we have empirical solve-time data from real runs.

Also: changed `if success == False` to `if success is False` for PEP 8; expanded the TimeoutError print to include the actual timeout value.

Adds tests/test_threading.py: 9 tests covering the nonlocal declaration, success hoisting, default timeout value, and the underlying Python scoping mechanics the fix relies on. Full suite: 66 passed, 1 xfailed.