### PR TITLE
fix: input validation guards at API boundaries (M1, M2a, M2b, M3, H1)

### DIFF
--- a/src/hrfunc/_utils.py
+++ b/src/hrfunc/_utils.py
@@ -24,7 +24,21 @@ def standardize_name(ch_name):
 
     Returns:
         ch_name (str) - Standardized channel name
+
+    Raises:
+        TypeError - If ch_name is not a string
+        ValueError - If ch_name is too short to carry an oxygenation suffix
     """
+    if not isinstance(ch_name, str):
+        raise TypeError(
+            f"standardize_name expected a str, got {type(ch_name).__name__}"
+        )
+    if len(ch_name) < 3:
+        raise ValueError(
+            f"Channel name {ch_name!r} is too short to standardize; "
+            "expected at least 3 characters carrying an oxygenation suffix "
+            "(e.g. 'hbo', 'hbr', or wavelength digits)"
+        )
     ch_name = re.sub(r'[_\-\s]+', '_', ch_name.lower())
     oxygenation = _is_oxygenated(ch_name)
     if oxygenation:

--- a/src/hrfunc/hrfunc.py
+++ b/src/hrfunc/hrfunc.py
@@ -42,11 +42,23 @@ def load_montage(json_filename, rich = False, **kwargs):
     with open(json_filename, 'r') as file:
         json_contents = json.load(file)
 
+    if not isinstance(json_contents, dict) or len(json_contents) == 0:
+        raise ValueError(
+            f"load_montage: {json_filename!r} must contain a non-empty JSON "
+            "object keyed by '<ch_name>-<doi>'"
+        )
+
     # Initialize an empty montage object
     _montage = montage(**kwargs)
 
     # Grab info from json contents
-    first_hrf = json_contents[list(json_contents.keys())[0]]
+    first_key = next(iter(json_contents))
+    first_hrf = json_contents[first_key]
+    if not isinstance(first_hrf, dict) or 'sfreq' not in first_hrf:
+        raise ValueError(
+            f"load_montage: first entry {first_key!r} is missing required "
+            "field 'sfreq'"
+        )
     sfreq = first_hrf['sfreq']
 
     # Assess channel names
@@ -57,6 +69,7 @@ def load_montage(json_filename, rich = False, **kwargs):
     _montage.hbr_channels = [ch for ch in ch_names if _is_oxygenated(ch) == False]
 
     # Update montage with saved info
+    required_top = ('hrf_mean', 'hrf_std', 'sfreq', 'location', 'context')
     for key, channel in json_contents.items():
         key_split = key.split('-')
         doi = key_split.pop()
@@ -66,9 +79,37 @@ def load_montage(json_filename, rich = False, **kwargs):
         if ch_name == 'canonical':
             continue
 
+        if not isinstance(channel, dict):
+            raise ValueError(
+                f"load_montage: entry {key!r} must be a JSON object, "
+                f"got {type(channel).__name__}"
+            )
+        for field in required_top:
+            if field not in channel:
+                raise ValueError(
+                    f"load_montage: entry {key!r} is missing required field "
+                    f"{field!r}"
+                )
+        if not isinstance(channel['context'], dict):
+            raise ValueError(
+                f"load_montage: entry {key!r} has non-object 'context' field"
+            )
+        if 'duration' not in channel['context']:
+            raise ValueError(
+                f"load_montage: entry {key!r} is missing required field "
+                "'context.duration'"
+            )
+
         if rich == False:
             channel['estimates'] = []
             channel['locations'] = []
+        else:
+            for field in ('estimates', 'locations'):
+                if field not in channel:
+                    raise ValueError(
+                        f"load_montage: entry {key!r} is missing required "
+                        f"field {field!r} (rich=True)"
+                    )
 
         # create an empty HRF object
         estimated_hrf = HRF(
@@ -261,8 +302,17 @@ class montage(tree):
 
         if isinstance(duration, int): duration = float(duration)
 
+        if duration <= 0:
+            raise ValueError(f"ERROR: duration must be > 0, got {duration}")
+
         if isinstance(events, list) is False:
             raise ValueError(f"ERROR: Events passed in must be of type list, object of type {type(events)} was passed in...")
+
+        if len(events) == 0:
+            raise ValueError("ERROR: events list must not be empty")
+
+        if lmbda <= 0:
+            raise ValueError(f"ERROR: lmbda must be > 0 for Tikhonov regularization, got {lmbda}")
 
         # Check montage still needs to be configured
         if self.configured is False:
@@ -357,6 +407,9 @@ class montage(tree):
             nirx_obj (mne raw object) - Raw with deconvolved neural activity, or None if skipped
         """
 
+        if lmbda <= 0:
+            raise ValueError(f"ERROR: lmbda must be > 0 for Tikhonov regularization, got {lmbda}")
+
         # Check montage still needs to be configured
         if self.configured is False:
             self.configure(nirx_obj)
@@ -418,8 +471,22 @@ class montage(tree):
 
             if 'global' in ch_name: continue # Skip if global hrf estimate
 
-            # If canonical HRF requested
-            if hrf_model == 'canonical' or len(hrf.trace) == 0:
+            # Detect degenerate HRF traces that would produce NaN (zero-length,
+            # missing, or all-zeros) so we fall back to canonical instead of
+            # silently dividing by zero in the deconvolution closure (H1).
+            trace_invalid = (
+                hrf.trace is None
+                or len(hrf.trace) == 0
+                or np.max(np.abs(hrf.trace)) == 0
+            )
+            if trace_invalid and hrf_model != 'canonical':
+                print(
+                    f"WARNING: HRF trace for channel {ch_name} is empty or all-zero; "
+                    "falling back to canonical HRF"
+                )
+
+            # If canonical HRF requested (or forced by a degenerate trace)
+            if hrf_model == 'canonical' or trace_invalid:
                 print(f"WARNING: Using canonical HRF for channel {ch_name} in {nirx_obj}")
                 estimate_hrf = hrf # Temporarily replace HRF
                 if _is_oxygenated(ch_name): # with oxygenated canonical

--- a/tests/test_input_validation.py
+++ b/tests/test_input_validation.py
@@ -1,0 +1,237 @@
+"""
+Targeted unit tests for fix/input-validation (M1, M2a, M2b, M3, H1).
+
+Goal: reject degenerate inputs at API boundaries with clear errors instead
+of cryptic crashes deep in the math. Each fix gets at least one passing
+input test (validator accepts valid data) and one failing input test
+(validator rejects bad data with a clean exception).
+
+No fNIRS data files are required. Montage-level tests construct a bare
+montage() so only the top-of-function validators fire — we do not reach
+configure() / MNE preprocessing.
+"""
+
+import inspect
+import json
+import pytest
+import numpy as np
+
+
+# ---------------------------------------------------------------------------
+# M1: standardize_name short-name guard (_utils.py)
+# ---------------------------------------------------------------------------
+
+class TestStandardizeNameGuard:
+    def test_valid_hbo_channel_name_passes(self):
+        from hrfunc._utils import standardize_name
+        assert standardize_name("S1_D1 hbo") == "s1_d1_hbo"
+
+    def test_valid_hbr_channel_name_passes(self):
+        from hrfunc._utils import standardize_name
+        assert standardize_name("S1_D1 hbr") == "s1_d1_hbr"
+
+    def test_empty_string_raises_valueerror(self):
+        from hrfunc._utils import standardize_name
+        with pytest.raises(ValueError, match="too short"):
+            standardize_name("")
+
+    def test_two_char_name_raises_valueerror(self):
+        from hrfunc._utils import standardize_name
+        with pytest.raises(ValueError, match="too short"):
+            standardize_name("S1")
+
+    def test_non_string_raises_typeerror(self):
+        from hrfunc._utils import standardize_name
+        with pytest.raises(TypeError):
+            standardize_name(None)
+
+
+# ---------------------------------------------------------------------------
+# M2a: estimate_hrf — duration<=0 and empty events
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def bare_montage():
+    """A montage with library trees loaded but no nirx_obj. Only top-of-
+    function validators run; configure() / preprocess_fnirs are not invoked."""
+    from hrfunc.hrfunc import montage
+    return montage()
+
+
+class TestEstimateHrfDurationGuard:
+    def test_positive_duration_passes_validator(self, bare_montage):
+        # Valid duration + valid events should pass the early validators and
+        # then fail later in configure() (no nirx_obj). We catch whatever
+        # happens after the validators and only assert it's not our ValueError.
+        with pytest.raises(Exception) as exc_info:
+            bare_montage.estimate_hrf(None, [1, 0, 0], duration=30.0, lmbda=1e-3)
+        assert "duration must be" not in str(exc_info.value)
+        assert "events list must not be empty" not in str(exc_info.value)
+        assert "lmbda must be" not in str(exc_info.value)
+
+    def test_zero_duration_raises(self, bare_montage):
+        with pytest.raises(ValueError, match="duration must be > 0"):
+            bare_montage.estimate_hrf(None, [1, 0, 0], duration=0)
+
+    def test_negative_duration_raises(self, bare_montage):
+        with pytest.raises(ValueError, match="duration must be > 0"):
+            bare_montage.estimate_hrf(None, [1, 0, 0], duration=-5.0)
+
+
+class TestEstimateHrfEmptyEventsGuard:
+    def test_empty_events_raises(self, bare_montage):
+        with pytest.raises(ValueError, match="events list must not be empty"):
+            bare_montage.estimate_hrf(None, [], duration=30.0)
+
+    def test_non_list_events_raises(self, bare_montage):
+        with pytest.raises(ValueError, match="must be of type list"):
+            bare_montage.estimate_hrf(None, np.array([1, 0, 0]), duration=30.0)
+
+
+# ---------------------------------------------------------------------------
+# M2b: lmbda<=0 in both estimate_hrf and estimate_activity
+# ---------------------------------------------------------------------------
+
+class TestLmbdaGuard:
+    def test_estimate_hrf_zero_lmbda_raises(self, bare_montage):
+        with pytest.raises(ValueError, match="lmbda must be > 0"):
+            bare_montage.estimate_hrf(None, [1, 0, 0], duration=30.0, lmbda=0)
+
+    def test_estimate_hrf_negative_lmbda_raises(self, bare_montage):
+        with pytest.raises(ValueError, match="lmbda must be > 0"):
+            bare_montage.estimate_hrf(None, [1, 0, 0], duration=30.0, lmbda=-1e-3)
+
+    def test_estimate_activity_zero_lmbda_raises(self, bare_montage):
+        with pytest.raises(ValueError, match="lmbda must be > 0"):
+            bare_montage.estimate_activity(None, lmbda=0)
+
+    def test_estimate_activity_negative_lmbda_raises(self, bare_montage):
+        with pytest.raises(ValueError, match="lmbda must be > 0"):
+            bare_montage.estimate_activity(None, lmbda=-1e-4)
+
+    def test_estimate_activity_positive_lmbda_passes_validator(self, bare_montage):
+        with pytest.raises(Exception) as exc_info:
+            bare_montage.estimate_activity(None, lmbda=1e-4)
+        assert "lmbda must be" not in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# M3: load_montage JSON schema validation
+# ---------------------------------------------------------------------------
+
+def _minimal_entry(duration=30.0, sfreq=7.81):
+    return {
+        "hrf_mean": [0.0, 0.1, 0.2, 0.1, 0.0],
+        "hrf_std": [0.0, 0.0, 0.0, 0.0, 0.0],
+        "sfreq": sfreq,
+        "location": [0.01, 0.02, 0.03],
+        "context": {"duration": duration},
+        "estimates": [],
+        "locations": [],
+    }
+
+
+class TestLoadMontageSchemaValidation:
+    def test_valid_entry_loads_successfully(self, tmp_path):
+        from hrfunc.hrfunc import load_montage
+        path = tmp_path / "m.json"
+        path.write_text(json.dumps({"S1_D1 hbo-10.0/doi": _minimal_entry()}))
+        m = load_montage(str(path))
+        assert m is not None
+
+    def test_missing_hrf_mean_raises_valueerror(self, tmp_path):
+        from hrfunc.hrfunc import load_montage
+        entry = _minimal_entry()
+        del entry["hrf_mean"]
+        path = tmp_path / "m.json"
+        path.write_text(json.dumps({"S1_D1 hbo-10.0/doi": entry}))
+        with pytest.raises(ValueError, match="hrf_mean"):
+            load_montage(str(path))
+
+    def test_missing_sfreq_raises_valueerror(self, tmp_path):
+        from hrfunc.hrfunc import load_montage
+        entry = _minimal_entry()
+        del entry["sfreq"]
+        path = tmp_path / "m.json"
+        # first_hrf read at top of load_montage also touches sfreq; a missing
+        # sfreq should surface a clean KeyError or our ValueError. We assert
+        # the per-entry validator is the one that speaks when we get past the
+        # top read by giving the first entry sfreq and corrupting a second.
+        good = {"S1_D1 hbo-10.0/doi": _minimal_entry()}
+        good["S1_D2 hbo-10.0/doi"] = entry
+        path.write_text(json.dumps(good))
+        with pytest.raises(ValueError, match="sfreq"):
+            load_montage(str(path))
+
+    def test_missing_location_raises_valueerror(self, tmp_path):
+        from hrfunc.hrfunc import load_montage
+        entry = _minimal_entry()
+        del entry["location"]
+        path = tmp_path / "m.json"
+        path.write_text(json.dumps({"S1_D1 hbo-10.0/doi": entry}))
+        with pytest.raises(ValueError, match="location"):
+            load_montage(str(path))
+
+    def test_missing_context_duration_raises_valueerror(self, tmp_path):
+        from hrfunc.hrfunc import load_montage
+        entry = _minimal_entry()
+        entry["context"] = {}  # empty context, no duration
+        path = tmp_path / "m.json"
+        path.write_text(json.dumps({"S1_D1 hbo-10.0/doi": entry}))
+        with pytest.raises(ValueError, match="context.duration"):
+            load_montage(str(path))
+
+    def test_nondict_entry_raises_valueerror(self, tmp_path):
+        from hrfunc.hrfunc import load_montage
+        path = tmp_path / "m.json"
+        # first entry valid (to satisfy top-of-function reads), second broken
+        payload = {
+            "S1_D1 hbo-10.0/doi": _minimal_entry(),
+            "S1_D2 hbo-10.0/doi": "not-a-dict",
+        }
+        path.write_text(json.dumps(payload))
+        with pytest.raises(ValueError, match="must be a JSON object"):
+            load_montage(str(path))
+
+
+# ---------------------------------------------------------------------------
+# H1: HRF zero-trace guard in estimate_activity deconvolution closure
+# ---------------------------------------------------------------------------
+
+class TestZeroTraceGuard:
+    """The pre-fix estimate_activity closure did
+        hrf_kernel = hrf.trace / np.max(np.abs(hrf.trace))
+    which produces NaN when hrf.trace is all zeros. H1 adds a guard that
+    detects None / empty / all-zero traces before the division and falls
+    back to the canonical HRF, emitting a warning."""
+
+    def test_all_zero_trace_would_produce_nan_without_guard(self):
+        """Sanity check — demonstrates the silent-NaN failure mode the
+        guard exists to prevent."""
+        trace = np.zeros(10)
+        with np.errstate(invalid='ignore', divide='ignore'):
+            kernel = trace / np.max(np.abs(trace))
+        assert np.all(np.isnan(kernel))
+
+    def test_guard_present_in_source(self):
+        from hrfunc.hrfunc import montage
+        src = inspect.getsource(montage.estimate_activity)
+        assert "trace_invalid" in src, (
+            "H1 guard missing: estimate_activity must detect degenerate HRF "
+            "traces before dividing by max(abs(trace))"
+        )
+        assert "np.max(np.abs(hrf.trace)) == 0" in src
+        assert "hrf.trace is None" in src
+
+    def test_guard_falls_back_to_canonical(self):
+        from hrfunc.hrfunc import montage
+        src = inspect.getsource(montage.estimate_activity)
+        # When trace_invalid, the outer loop should take the same branch
+        # hrf_model == 'canonical' takes (swap in hbo_tree.root.right /
+        # hbr_tree.root.right). Confirm the condition is wired up.
+        assert "hrf_model == 'canonical' or trace_invalid" in src
+
+    def test_guard_emits_warning(self):
+        from hrfunc.hrfunc import montage
+        src = inspect.getsource(montage.estimate_activity)
+        assert "empty or all-zero" in src


### PR DESCRIPTION
Reject degenerate inputs at API entry points with clear errors instead of cryptic crashes deep in the math. Part of v1.2.0 correctness release; stacks on fix/estimate-activity-threading.

M1 - standardize_name (src/hrfunc/_utils.py)
  - TypeError on non-str, ValueError on names shorter than 3 chars
  - Prevents IndexError crash on ch_name[:-3] / ch_name[-2] access

M2a - montage.estimate_hrf (src/hrfunc/hrfunc.py)
  - Reject duration <= 0
  - Reject empty events list
  - Fires before any data loading or preprocessing

M2b - montage.estimate_hrf and estimate_activity
  - Reject lmbda <= 0 in both methods (Tikhonov regularization requires > 0)
  - Both guards placed at top of function before configure()

M3 - load_montage
  - Top-level guard: reject non-dict or empty JSON payload
  - First-entry guard: first_hrf must be a dict containing sfreq
  - Per-entry schema validation: hrf_mean, hrf_std, sfreq, location, context all required; context must be a dict with duration
  - rich=True additionally requires estimates and locations
  - Raises ValueError naming the offending entry key AND the missing field
  - Does not return a partially-loaded montage; caller discards on exception (M5 snapshot/restore is scoped to fix/state-lifecycle)

H1 - montage.estimate_activity deconvolution closure
  - Detect degenerate HRF traces (None, empty, or all-zero) before hrf_kernel = hrf.trace / np.max(np.abs(hrf.trace)), which would silently produce NaN on all-zero input
  - Fall back to the canonical HRF via the existing tree.root.right path and emit a warning naming the channel
  - Strict superset of the previous len(hrf.trace) == 0 check

Tests: tests/test_input_validation.py
  - 24 targeted unit tests, fast, no fNIRS data files required
  - Each fix has at least one valid-input test and one invalid-input test
  - H1 verified via source inspection (full apply_function path needs MNE Raw); sanity test demonstrates the silent-NaN failure mode the guard prevents
  - bare_montage fixture exercises top-of-function validators without reaching configure() or MNE preprocessing

Full targeted gate: pytest tests/test_phase1a.py tests/test_phase1bc.py tests/test_phase2.py tests/test_threading.py tests/test_input_validation.py -> 91 passed, 1 xfailed (filter remove-path, unblocks in fix/tree-delete-filter)

Gotchas:
- standardize_name TypeError (not ValueError) on non-str input, matching Python convention for type vs value errors
- load_montage on empty dict now raises ValueError instead of IndexError; observable behavior change but strictly a cleaner failure mode
- When user passes hrf_model='canonical' the existing "Using canonical HRF" warning is preserved unconditionally; the H1 fallback adds a preceding "empty or all-zero" warning only when forced by trace_invalid
- The canonical fallback in H1 relies on tree.root.right being the canonical HRF; this will be replaced by a lazy generator in fix/canonical-hrf-sfreq (S4) later in the chain — keeping the existing path for scope discipline