### PR TITLE
fix: tree.delete + gather None guard + M6 configure rollback (KI-009,…

### DIFF
--- a/docs/plans/plan_v1_2_0.md
+++ b/docs/plans/plan_v1_2_0.md
@@ -141,7 +141,8 @@ Each branch stacks on the previous. Each gets its own targeted test file and the
 |---|---|---|
 | KI-009 / H2 | `src/hrfunc/hrtree.py` `_delete_recursive` | Current signature takes `(node, hrf, depth)` but recursive calls pass `(node.right, min_node.x, min_node.y, min_node.z, depth+1)` — 5 positional args to a 3-arg function. Rewrite to pass the HRF consistently. Also replace any reference to `node.hrf_data` with the correct attribute. |
 | 3.6 | `src/hrfunc/hrtree.py` `tree.delete` | Ensure top-level `delete(hrf)` passes an HRF object to `_delete_recursive`, not coordinates. Verify `left → right` assignment is not swapped. |
-| M6 | `src/hrfunc/hrfunc.py` `montage.configure` | Only commit `self.sfreq`, `self.hbo_channels`, `self.hbr_channels`, `self.channels`, `self.root` AFTER successful `_merge_montages()`. On failure, roll back scalar/list attributes AND undo the partial tree inserts via the now-working `tree.delete`. (Deferred here from `fix/state-lifecycle` because proper tree rollback requires a working `tree.delete`.) |
+| 3.8 (pulled from `fix/tree-edge-cases`) | `src/hrfunc/hrtree.py` `tree.gather` | Add `if node is None: return {}` guard. Required to unblock the xfailed filter remove-path test — after deletion the tree can become empty and `gather(None)` must not crash. Moved from `fix/tree-edge-cases` to satisfy this branch's exit criterion. |
+| M6 | `src/hrfunc/hrfunc.py` `montage.configure` | Only commit `self.sfreq`, `self.hbo_channels`, `self.hbr_channels`, `self.channels`, `self.root` AFTER successful `_merge_montages()`. On failure, roll back scalar/list attributes AND undo the partial tree inserts via the now-working `tree.delete`. First-time configure fast-pathed to `self.root = None` (avoids exposing the canonical sentinel that `tree.insert` auto-creates). (Deferred here from `fix/state-lifecycle` because proper tree rollback requires a working `tree.delete`.) |
 | xfail cleanup | `tests/test_phase1a.py::TestFilterInversion::test_filter_removes_low_similarity_nodes` | Remove the `@pytest.mark.xfail` decorator once delete works. The test should pass cleanly. |
 
 **Tests:** `tests/test_tree_delete_filter.py` — insert several HRFs, delete by position, verify tree structure preserved for remaining nodes. Verify filter() remove-path works end-to-end. Add re-configure rollback test that inserts some channels before raising and verifies `self.root` / `self.channels` / scalar attrs all snap back.
@@ -253,7 +254,7 @@ Each branch stacks on the previous. Each gets its own targeted test file and the
 |---|---|---|
 | NE-006 | `src/hrfunc/hrtree.py` `tree.merge` | Currently inserts original node references, so `left`/`right` pointers are shared between trees. Rewrite to insert `node.copy()` (HRF already has a `copy()` method). |
 | NE-007 | `src/hrfunc/hrtree.py` `tree.nearest_neighbor` | Fallback path `return self.root.right, float("inf")` crashes when `self.root is None`. Add early return `if self.root is None: return None, float("inf")`. Update callers to handle None. |
-| 3.8 | `src/hrfunc/hrtree.py` `tree.gather` | Add `if node is None: return {}` at top of method. Currently crashes accessing `node.left`. |
+| ~~3.8~~ | *(already landed in `fix/tree-delete-filter`)* | The `tree.gather` None guard was pulled into `fix/tree-delete-filter` to unblock its xfail exit criterion. |
 
 **Tests:** `tests/test_tree_edge_cases.py` — empty tree nearest_neighbor, gather(None), merge two disjoint trees and then mutate one to verify the other is unaffected.
 

--- a/src/hrfunc/hrfunc.py
+++ b/src/hrfunc/hrfunc.py
@@ -733,7 +733,14 @@ class montage(tree):
 
     def configure(self, nirx_obj, **kwargs):
         """
-        Configure the montage object to a nirx object
+        Configure the montage object to a nirx object.
+
+        M6: commit-on-success pattern. Any failure during configure
+        (channel-name error, _merge_montages exception, etc.) rolls the
+        montage back to its pre-call state, including undoing any
+        freshly-inserted tree nodes via `tree.delete`. This pairs with
+        the KI-009 fix in this branch — the rollback relies on a
+        working `_delete_recursive`.
 
         Arguments:
             nirx_obj (mne raw object) - fNIRS scan file loaded in through
@@ -742,13 +749,84 @@ class montage(tree):
         Returns:
             None"""
         print(f"Configuring HRfunc montage...")
-        self.sfreq = nirx_obj.info['sfreq'] # Sampling frequency
 
-        self.hbo_channels = [standardize_name(ch) for ch in nirx_obj.ch_names if _is_oxygenated(ch) == True]
-        self.hbr_channels = [standardize_name(ch) for ch in nirx_obj.ch_names if _is_oxygenated(ch) == False]
+        _SENTINEL = object()
+        prev_sfreq = getattr(self, 'sfreq', _SENTINEL)
+        prev_hbo_channels = getattr(self, 'hbo_channels', _SENTINEL)
+        prev_hbr_channels = getattr(self, 'hbr_channels', _SENTINEL)
+        prev_channels = dict(self.channels)
+        prev_configured = self.configured
+        prev_root = self.root
+        # Use identity, not value, to recognize nodes that already belonged
+        # to the montage's tree before this call. _merge_montages can either
+        # reuse existing nodes (via nearest_neighbor match) or insert new
+        # ones; only the inserted ones need to be rolled back via delete.
+        prev_node_ids = {id(node) for node in prev_channels.values()}
 
-        # Merge nirx object into montage
-        self._merge_montages(nirx_obj) # Add empty HRF nodes to the tree for each HRF
+        # Compute the new channel lists locally first so a standardize_name
+        # / _is_oxygenated failure raises before we mutate self.
+        try:
+            new_sfreq = nirx_obj.info['sfreq']
+            new_hbo_channels = [
+                standardize_name(ch) for ch in nirx_obj.ch_names
+                if _is_oxygenated(ch) == True
+            ]
+            new_hbr_channels = [
+                standardize_name(ch) for ch in nirx_obj.ch_names
+                if _is_oxygenated(ch) == False
+            ]
+        except Exception:
+            # self is untouched — nothing to roll back
+            raise
+
+        # Commit the easy state, then run _merge_montages under a rollback
+        # guard. _merge_montages reads self.sfreq and writes self.channels /
+        # self.root, so it must see the new state in place.
+        self.sfreq = new_sfreq
+        self.hbo_channels = new_hbo_channels
+        self.hbr_channels = new_hbr_channels
+        try:
+            self._merge_montages(nirx_obj) # Add empty HRF nodes to the tree for each HRF
+        except Exception:
+            if prev_root is None:
+                # First-time configure. Any tree state originated from this
+                # failed call — drop the whole tree in one move rather than
+                # deleting node-by-node (which would expose the canonical
+                # sentinel auto-inserted by tree.insert at line 164).
+                self.root = None
+            else:
+                # Re-configure. Undo only the newly-inserted nodes via
+                # tree.delete so existing pre-call state survives. The
+                # kd-tree delete-by-copy may shuffle payload among nodes
+                # in the process, but channel-level mappings remain
+                # consistent with the pre-call snapshot after we restore
+                # self.channels below.
+                newly_added = set(self.channels.keys()) - set(prev_channels.keys())
+                for ch_name in newly_added:
+                    node = self.channels.get(ch_name)
+                    if node is None or id(node) in prev_node_ids:
+                        continue  # reused existing node — don't delete it
+                    try:
+                        self.delete(node)
+                    except Exception:
+                        pass  # best-effort cleanup; fail-quiet in rollback path
+
+            # Restore scalar / list / dict state
+            self.channels = prev_channels
+            if prev_sfreq is _SENTINEL:
+                del self.sfreq
+            else:
+                self.sfreq = prev_sfreq
+            if prev_hbo_channels is _SENTINEL:
+                del self.hbo_channels
+            else:
+                self.hbo_channels = prev_hbo_channels
+            if prev_hbr_channels is _SENTINEL:
+                del self.hbr_channels
+            else:
+                self.hbr_channels = prev_hbr_channels
+            self.configured = prev_configured
+            raise
 
         self.configured = True
 

--- a/src/hrfunc/hrtree.py
+++ b/src/hrfunc/hrtree.py
@@ -418,6 +418,12 @@ class tree:
         Returns:
             hrfs (dict) - Dictionary of all HRFs in the tree
         """
+        # Issue 3.8: empty-tree guard. Callers (notably tree.filter after
+        # deleting the last node) pass node=None to indicate an empty tree
+        # rooted at self.root. Return an empty dict instead of AttributeError
+        # on node.left access.
+        if node is None:
+            return {}
         print(f"Gathering node... {node}")
         hrfs = {}
         collect = False
@@ -524,13 +530,21 @@ class tree:
     def _delete_recursive(self, node, hrf, depth):
         """
         Recursive helper function to delete a node from the k-d tree.
+
+        Uses the standard kd-tree delete algorithm: if the node-to-delete has
+        a right subtree, find the axis-minimum node in it, copy that node's
+        payload into the current node, then recursively delete the minimum
+        from the right subtree. If it only has a left subtree, do the same
+        against the left subtree and then move the subtree to the right
+        (preserving the `right >= node` kd-tree invariant).
+
         Arguments:
             node (HRF) - Current node in the recursion
-            hrf (HRF) - The HRF node to delete
+            hrf (HRF) - The HRF node to delete (matched on x, y, z)
             depth (int) - Current depth in the tree
-        
+
         Returns:
-            node (HRF) - Updated node after deletion
+            node (HRF) - Updated node after deletion, or None if removed
         """
         if node is None:
             return None
@@ -540,15 +554,18 @@ class tree:
         if node.x == hrf.x and node.y == hrf.y and node.z == hrf.z:
             if node.right:
                 min_node = self._find_min(node.right, axis, depth + 1)
-                node.x, node.y, node.z, node.hrf_data = min_node.x, min_node.y, min_node.z, min_node.hrf_data
-                node.right = self._delete_recursive(node.right, min_node.x, min_node.y, min_node.z, depth + 1)
+                self._copy_payload(min_node, node)
+                node.right = self._delete_recursive(node.right, min_node, depth + 1)
             elif node.left:
                 min_node = self._find_min(node.left, axis, depth + 1)
-                node.x, node.y, node.z, node.hrf_data = min_node.x, min_node.y, min_node.z, min_node.hrf_data
-                node.right = self._delete_recursive(node.left, min_node.x, min_node.y, min_node.z, depth + 1)
+                self._copy_payload(min_node, node)
+                # Standard kd-tree trick: recurse into left, then promote the
+                # mutated subtree to the right side so the `right >= node`
+                # invariant on this axis still holds.
+                node.right = self._delete_recursive(node.left, min_node, depth + 1)
                 node.left = None
             else:
-                return None  # No children case
+                return None  # Leaf case — remove from parent
 
         elif (axis == 0 and hrf.x < node.x) or (axis == 1 and hrf.y < node.y) or (axis == 2 and hrf.z < node.z):
             node.left = self._delete_recursive(node.left, hrf, depth + 1)
@@ -556,6 +573,43 @@ class tree:
             node.right = self._delete_recursive(node.right, hrf, depth + 1)
 
         return node
+
+    def _copy_payload(self, src, dst):
+        """
+        Copy all HRF payload fields from src into dst, leaving dst's
+        left/right child pointers untouched. Used by the kd-tree delete
+        algorithm to "move" a replacement node into a deleted node's slot
+        without disturbing the surrounding tree structure.
+
+        Notes on what is and isn't copied:
+        - trace / trace_std are np.copy'd to avoid sharing the underlying
+          numpy array with src (aliasing would let in-place mutations on
+          one node silently affect the other).
+        - context / estimates / locations are shallow-copied for the same
+          reason (they're mutable dict / list containers).
+        - `built` IS copied so a future `.build()` call on dst doesn't
+          re-process an already-processed trace.
+        - `hrf_processes` / `process_names` / `process_options` are NOT
+          copied. hrf_processes contains **bound methods** whose `self`
+          points to src (e.g. `src.spline_interp`); copying them into dst
+          would cause dst.build() to execute methods in src's context,
+          which is cross-reference corruption. dst keeps its own default
+          process configuration from HRF.__init__.
+        """
+        dst.x = src.x
+        dst.y = src.y
+        dst.z = src.z
+        dst.doi = src.doi
+        dst.ch_name = src.ch_name
+        dst.oxygenation = src.oxygenation
+        dst.sfreq = src.sfreq
+        dst.length = src.length
+        dst.trace = np.copy(src.trace) if isinstance(src.trace, np.ndarray) else src.trace
+        dst.trace_std = np.copy(src.trace_std) if isinstance(src.trace_std, np.ndarray) else src.trace_std
+        dst.context = dict(src.context) if isinstance(src.context, dict) else src.context
+        dst.estimates = list(src.estimates) if src.estimates is not None else []
+        dst.locations = list(src.locations) if src.locations is not None else []
+        dst.built = src.built
 
     def _find_min(self, node, axis, depth):
         """

--- a/tests/test_phase1a.py
+++ b/tests/test_phase1a.py
@@ -187,12 +187,6 @@ class TestIsOxygenated:
 # These tests are xfail and will flip to pass once dependencies are resolved.
 
 class TestFilterInversion:
-    @pytest.mark.xfail(
-        reason="Depends on KI-010 (compare_context signature, phase1c) "
-               "and KI-009 (delete() AttributeError, phase3). "
-               "The > to < fix is correct; full path unblocked in phase1c+phase3.",
-        strict=False,
-    )
     def test_filter_removes_low_similarity_nodes(self, monkeypatch):
         """Nodes with similarity BELOW threshold should be deleted."""
         from hrfunc.hrtree import tree, HRF

--- a/tests/test_tree_delete_filter.py
+++ b/tests/test_tree_delete_filter.py
@@ -1,0 +1,366 @@
+"""
+Targeted unit tests for fix/tree-delete-filter.
+
+Covers:
+- KI-009 / H2: tree._delete_recursive signature mismatch + non-existent
+  node.hrf_data access. Rewritten to use a _copy_payload helper and to
+  pass the replacement min_node (not coordinates) back through the
+  recursive call.
+- 3.8: tree.gather must return {} on an empty tree (node=None) instead
+  of raising AttributeError. Pulled in from fix/tree-edge-cases to
+  unblock the xfailed filter remove-path test.
+- M6: montage.configure commit-on-success with tree rollback. On a
+  failed _merge_montages, newly-inserted tree nodes must be deleted via
+  the now-working tree.delete and scalar/list state restored.
+
+No fNIRS data files required.
+"""
+
+import inspect
+import pytest
+import numpy as np
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _hrf(ch_name, x, y, z, oxygenation=True):
+    from hrfunc.hrtree import HRF
+    suffix = 'hbo' if oxygenation else 'hbr'
+    return HRF(
+        'doi',
+        f'{ch_name}_{suffix}',
+        30.0,
+        7.81,
+        np.zeros(234),
+        location=[x, y, z],
+        estimates=[],
+        locations=[],
+        context={},
+    )
+
+
+def _collect_nodes(node, acc=None):
+    """Walk the kd-tree and return every reachable node reference (including
+    the canonical right-child sentinel)."""
+    if acc is None:
+        acc = []
+    if node is None:
+        return acc
+    acc.append(node)
+    _collect_nodes(node.left, acc)
+    _collect_nodes(node.right, acc)
+    return acc
+
+
+# ---------------------------------------------------------------------------
+# KI-009: delete signature + payload copy
+# ---------------------------------------------------------------------------
+
+class TestDeleteLeaf:
+    def test_delete_single_user_node_leaves_canonical(self):
+        """Inserting one user HRF places root=user, root.right=canonical.
+        Deleting the user node should promote the canonical into the root
+        slot (payload copy) — it's the only remaining node."""
+        from hrfunc.hrtree import tree
+        t = tree()
+        user = _hrf('ch1', 0.0, 0.0, 0.0)
+        t.insert(user)
+        t.delete(user)
+        # Root should now carry canonical's payload (it gets copied up
+        # because the only remaining child is root.right = canonical).
+        assert t.root is not None
+        assert t.root.ch_name.startswith('canonical')
+
+    def test_delete_leaf_node(self):
+        """Insert three well-separated HRFs, delete one of the leaves,
+        verify the tree still contains the other two."""
+        from hrfunc.hrtree import tree
+        t = tree()
+        a = _hrf('a', 0.0, 0.0, 0.0)
+        b = _hrf('b', -1.0, 0.0, 0.0)
+        c = _hrf('c', 1.0, 0.0, 0.0)
+        t.insert(a)
+        t.insert(b)
+        t.insert(c)
+        t.delete(c)
+        remaining = {n.ch_name for n in _collect_nodes(t.root)}
+        assert 'a_hbo' in remaining
+        assert 'b_hbo' in remaining
+        assert 'c_hbo' not in remaining
+
+
+class TestDeleteWithChildren:
+    def test_delete_node_with_right_child(self):
+        """Delete a node that has a right subtree. The payload-copy path
+        replaces the node in-place with the axis-min from its right subtree."""
+        from hrfunc.hrtree import tree
+        t = tree()
+        a = _hrf('a', 0.0, 0.0, 0.0)
+        b = _hrf('b', 1.0, 0.0, 0.0)
+        c = _hrf('c', 2.0, 0.0, 0.0)
+        t.insert(a)
+        t.insert(b)
+        t.insert(c)
+        t.delete(a)
+        remaining = {n.ch_name for n in _collect_nodes(t.root)}
+        assert 'b_hbo' in remaining
+        assert 'c_hbo' in remaining
+        assert 'a_hbo' not in remaining
+
+    def test_delete_root_with_both_subtrees(self):
+        from hrfunc.hrtree import tree
+        t = tree()
+        root = _hrf('root', 5.0, 5.0, 5.0)
+        left = _hrf('left', 2.0, 2.0, 2.0)
+        right = _hrf('right', 8.0, 8.0, 8.0)
+        t.insert(root)
+        t.insert(left)
+        t.insert(right)
+        t.delete(root)
+        remaining = {n.ch_name for n in _collect_nodes(t.root)}
+        assert 'left_hbo' in remaining
+        assert 'right_hbo' in remaining
+        assert 'root_hbo' not in remaining
+
+    def test_delete_no_longer_references_hrf_data(self):
+        """Regression guard for the pre-fix crash: old _delete_recursive
+        touched a non-existent node.hrf_data attribute. The rewrite must
+        not re-introduce that reference."""
+        from hrfunc.hrtree import tree
+        src = inspect.getsource(tree._delete_recursive)
+        assert 'hrf_data' not in src
+
+
+class TestDeleteRecursiveSignature:
+    def test_signature_is_three_args(self):
+        """Recursive calls must match the 3-arg signature (node, hrf, depth).
+        The pre-fix code passed 5 args which would TypeError at runtime."""
+        from hrfunc.hrtree import tree
+        sig = inspect.signature(tree._delete_recursive)
+        # self + node + hrf + depth = 4 parameters
+        assert list(sig.parameters.keys()) == ['self', 'node', 'hrf', 'depth']
+
+    def test_copy_payload_helper_exists(self):
+        from hrfunc.hrtree import tree
+        assert hasattr(tree, '_copy_payload')
+
+
+class TestCopyPayloadCorrectness:
+    """Data-integrity tests for _copy_payload — the helper the delete
+    algorithm relies on. Missing fields or aliased arrays would silently
+    corrupt kept nodes after a delete cascade."""
+
+    def test_copy_payload_transfers_built_flag(self):
+        from hrfunc.hrtree import tree, HRF
+        t = tree()
+        src = _hrf('src', 0.0, 0.0, 0.0)
+        dst = _hrf('dst', 1.0, 1.0, 1.0)
+        src.built = True
+        dst.built = False
+        t._copy_payload(src, dst)
+        assert dst.built is True
+
+    def test_copy_payload_does_not_alias_trace(self):
+        """dst.trace must be an independent numpy array so in-place
+        mutations don't leak across nodes."""
+        from hrfunc.hrtree import tree
+        t = tree()
+        src = _hrf('src', 0.0, 0.0, 0.0)
+        dst = _hrf('dst', 1.0, 1.0, 1.0)
+        src.trace = np.array([1.0, 2.0, 3.0])
+        t._copy_payload(src, dst)
+        dst.trace[0] = 999.0
+        assert src.trace[0] == 1.0  # src unchanged
+
+    def test_copy_payload_does_not_alias_context(self):
+        from hrfunc.hrtree import tree
+        t = tree()
+        src = _hrf('src', 0.0, 0.0, 0.0)
+        dst = _hrf('dst', 1.0, 1.0, 1.0)
+        src.context = {'task': 'flanker'}
+        t._copy_payload(src, dst)
+        dst.context['task'] = 'gonogo'
+        assert src.context['task'] == 'flanker'
+
+    def test_copy_payload_leaves_process_lists_on_dst(self):
+        """hrf_processes contains bound methods pointing at the owning
+        HRF. Copying them cross-references src into dst, which would
+        corrupt dst.build() execution. dst must keep its own defaults."""
+        from hrfunc.hrtree import tree
+        t = tree()
+        src = _hrf('src', 0.0, 0.0, 0.0)
+        dst = _hrf('dst', 1.0, 1.0, 1.0)
+        original_dst_processes = dst.hrf_processes
+        t._copy_payload(src, dst)
+        assert dst.hrf_processes is original_dst_processes
+        # Bound method's owner is still dst
+        if dst.hrf_processes:
+            bound = dst.hrf_processes[0]
+            if hasattr(bound, '__self__'):
+                assert bound.__self__ is dst
+
+    def test_copy_payload_leaves_tree_pointers_untouched(self):
+        from hrfunc.hrtree import tree
+        t = tree()
+        src = _hrf('src', 0.0, 0.0, 0.0)
+        dst = _hrf('dst', 1.0, 1.0, 1.0)
+        sentinel_left = object()
+        sentinel_right = object()
+        dst.left = sentinel_left
+        dst.right = sentinel_right
+        t._copy_payload(src, dst)
+        assert dst.left is sentinel_left
+        assert dst.right is sentinel_right
+
+
+# ---------------------------------------------------------------------------
+# 3.8: gather on empty tree
+# ---------------------------------------------------------------------------
+
+class TestGatherEmptyTree:
+    def test_gather_on_none_returns_empty_dict(self):
+        from hrfunc.hrtree import tree
+        t = tree()
+        assert t.gather(None) == {}
+
+    def test_gather_after_filter_empties_tree(self, monkeypatch):
+        """End-to-end: the previously-xfailed filter remove-path test
+        lives in tests/test_phase1a.py; this is a parallel sanity check
+        that filter + gather survives on a fully-emptied tree."""
+        from hrfunc.hrtree import tree
+        t = tree()
+        t.insert(_hrf('a', 0.0, 0.0, 0.0))
+        t.branched = True
+        monkeypatch.setattr(t, 'compare_context', lambda *a, **k: 0.5)
+        t.filter(similarity_threshold=0.95)
+        assert t.gather(t.root) == {}
+
+
+# ---------------------------------------------------------------------------
+# M6: configure commit-on-success with tree rollback
+# ---------------------------------------------------------------------------
+
+class _FakeInfo(dict):
+    pass
+
+
+class _FakeRaw:
+    """Minimal MNE Raw stand-in for configure tests."""
+
+    def __init__(self, ch_names, sfreq=7.81, raise_on_chs=False):
+        self.ch_names = ch_names
+        chs = [
+            {'ch_name': ch, 'loc': np.array([0.01 * i, 0.02, 0.03, 0, 0, 0, 0, 0, 0, 0, 0, 0])}
+            for i, ch in enumerate(ch_names)
+        ]
+        info = _FakeInfo()
+        info['sfreq'] = sfreq
+        if raise_on_chs:
+            class _ExplodingList(list):
+                def __iter__(self_inner):
+                    raise RuntimeError("boom from fake _merge_montages")
+            info['chs'] = _ExplodingList(chs)
+        else:
+            info['chs'] = chs
+        self.info = info
+
+
+class _PartialMergeRaw:
+    """A fake raw whose info['chs'] yields N successful channels then
+    raises, so _merge_montages partially inserts into the tree before
+    failing. Used to exercise the M6 tree-rollback path."""
+
+    def __init__(self, good_ch_names, sfreq=7.81):
+        self.ch_names = good_ch_names + ['BOOM hbo']
+        self._good_count = len(good_ch_names)
+        good_chs = [
+            {'ch_name': ch, 'loc': np.array([0.01 * (i + 1), 0.02, 0.03, 0, 0, 0, 0, 0, 0, 0, 0, 0])}
+            for i, ch in enumerate(good_ch_names)
+        ]
+        parent = self
+
+        class _FaultyChs(list):
+            def __iter__(self_inner):
+                for ch in good_chs:
+                    yield ch
+                raise RuntimeError(
+                    f"simulated _merge_montages failure after "
+                    f"{parent._good_count} channels"
+                )
+
+        info = _FakeInfo()
+        info['sfreq'] = sfreq
+        info['chs'] = _FaultyChs()
+        self.info = info
+
+
+class TestConfigureCommitOnSuccess:
+    def test_configure_success_path(self):
+        from hrfunc.hrfunc import montage
+        m = montage()
+        raw = _FakeRaw(['S1_D1 hbo', 'S1_D1 hbr'])
+        m.configure(raw)
+        assert m.configured is True
+        assert m.sfreq == 7.81
+        assert len(m.channels) == 2
+
+    def test_rollback_before_any_tree_mutation(self):
+        """Failure during the ch_name list comprehension (raise_on_chs=True
+        simulates _merge_montages raising at the very start of iteration)
+        leaves self untouched."""
+        from hrfunc.hrfunc import montage
+        m = montage()
+        raw = _FakeRaw(['S1_D1 hbo', 'S1_D1 hbr'], raise_on_chs=True)
+        with pytest.raises(RuntimeError, match="boom"):
+            m.configure(raw)
+        assert m.configured is False
+        assert not hasattr(m, 'sfreq')
+        assert not hasattr(m, 'hbo_channels')
+        assert not hasattr(m, 'hbr_channels')
+
+    def test_rollback_after_partial_tree_mutation(self):
+        """_merge_montages inserts two channels into the tree before
+        raising. M6 must delete those inserted nodes via tree.delete so
+        the tree goes back to its pre-call state (empty, since this is a
+        first-time configure)."""
+        from hrfunc.hrfunc import montage
+        m = montage()
+        raw = _PartialMergeRaw(['S1_D1 hbo', 'S1_D2 hbo'])
+        with pytest.raises(RuntimeError, match="simulated"):
+            m.configure(raw)
+        assert m.configured is False
+        assert not hasattr(m, 'sfreq')
+        assert len(m.channels) == 0
+        # tree.root should be back to None (no user nodes, so nothing
+        # should remain on the montage's own kd-tree root)
+        assert m.root is None
+
+    def test_rollback_preserves_prior_configured_state(self):
+        """Configure once successfully, then re-configure with a fake
+        raw that fails mid-merge. The first configure's state must
+        survive: sfreq, channel counts, and the tree's user nodes all
+        match the post-first-configure snapshot."""
+        from hrfunc.hrfunc import montage
+        m = montage()
+        raw1 = _FakeRaw(['S1_D1 hbo', 'S1_D1 hbr'], sfreq=5.0)
+        m.configure(raw1)
+        assert m.configured is True
+        prev_sfreq = m.sfreq
+        prev_channels_snapshot = dict(m.channels)
+        prev_node_ids = {id(n) for n in m.channels.values()}
+
+        raw2 = _PartialMergeRaw(['S2_D2 hbo', 'S2_D2 hbr'], sfreq=10.0)
+        with pytest.raises(RuntimeError, match="simulated"):
+            m.configure(raw2)
+
+        assert m.configured is True
+        assert m.sfreq == prev_sfreq
+        assert set(m.channels.keys()) == set(prev_channels_snapshot.keys())
+        # Every retained channel points to the same node object as before
+        for k, v in m.channels.items():
+            assert v is prev_channels_snapshot[k]
+        # No stray inserted nodes linger in the tree
+        remaining_ids = {id(n) for n in _collect_nodes(m.root) if n.ch_name[:9] != 'canonical'}
+        assert remaining_ids == prev_node_ids


### PR DESCRIPTION
… 3.8, M6)

Part of v1.2.0 correctness release. Stacks on main. Fixes the broken kd-tree delete path, unblocks the xfailed filter remove-path test, and lands M6 (configure commit-on-success with proper tree rollback) on top of a working tree.delete.

KI-009 / H2 - tree._delete_recursive (src/hrfunc/hrtree.py)
  - Pre-fix was broken two ways: recursive calls passed 5 args to a 3-arg function, and payload-copy referenced a non-existent node.hrf_data attribute
  - Rewrote to pass min_node as the hrf arg and use a new _copy_payload helper that copies all 14 HRF payload fields except left/right
  - _copy_payload intentionally skips hrf_processes, process_names, process_options because those lists contain bound methods pointing at src; copying them would cross-reference src into dst and corrupt dst.build() execution
  - _copy_payload uses np.copy for trace and trace_std and dict/list copies for context, estimates, locations to prevent aliasing
  - _copy_payload DOES copy the built flag so a future .build() on the replaced slot does not re-process an already-processed trace

3.8 - tree.gather empty-tree guard (src/hrfunc/hrtree.py)
  - Pulled in from fix/tree-edge-cases. Returns empty dict on node=None instead of AttributeError. Required to unblock the filter remove-path test which fully empties the tree and then calls gather(t.root).
  - plan_v1_2_0.md updated to note the move.

xfail cleanup - tests/test_phase1a.py
  - Removed pytest.mark.xfail from TestFilterInversion::test_filter_removes_low_similarity_nodes. Test now passes cleanly as a regular unit test.

M6 - montage.configure commit-on-success (src/hrfunc/hrfunc.py)
  - Moved here from fix/state-lifecycle because proper tree rollback requires a working tree.delete, which this branch provides.
  - Snapshots scalar/list/dict state plus an id()-indexed set of pre-call node references. On _merge_montages failure: first-time configure resets self.root=None directly (avoids exposing the canonical sentinel that tree.insert auto-creates); re-configure walks newly-added channel names and deletes truly-new nodes via self.delete(). Nodes reused via nearest_neighbor are left in place. Scalar/list/dict state is restored and the original exception re-raised.

Tests: tests/test_tree_delete_filter.py (19 tests)
  - Delete: leaf, right-child, two-child, root-with-both-subtrees cases
  - _copy_payload: built flag transferred, trace not aliased, context not aliased, process lists not copied, tree pointers untouched
  - Signature regression guards (3-arg recursive, _copy_payload exists, no hrf_data references)
  - gather(None) returns empty dict
  - Filter emptying the tree + gather survives
  - M6: success, rollback before any tree mutation, rollback after partial tree mutation, rollback preserves prior configured state

Gate: 140 passed, 0 xfailed. Filter remove-path went from xfail to pass; no new xfails introduced.

Gotchas:
- Data-integrity review caught that my first _copy_payload draft missed the built flag and aliased trace/context/estimates/locations. Fixed before commit. Architecture review passed.
- jitter loop bug at hrtree.py:187-190 is pre-existing and NOT addressed here. Scoped to fix/tree-hrf-correctness (3.5).