### PR TITLE
fix: hasher populate/search by values + tree.branch AND semantics (NE…

### DIFF
--- a/src/hrfunc/hrfunc.py
+++ b/src/hrfunc/hrfunc.py
@@ -1,7 +1,7 @@
 import scipy.linalg, scipy.stats, json, mne, random, re, os, nilearn, time
 import numpy as np
 import matplotlib.pyplot as plt
-from .hrtree import tree, HRF
+from .hrtree import tree, HRF, _flatten_context_value
 from ._utils import standardize_name, _is_oxygenated, _LIB_DIR
 from concurrent.futures import ThreadPoolExecutor, TimeoutError
 from itertools import compress
@@ -128,18 +128,26 @@ def load_montage(json_filename, rich = False, **kwargs):
                 channel['locations']
             )
 
-            # Insert hrf into tree and attach pointer to channel
+            # Insert hrf into tree and attach pointer to channel. Populate
+            # the tree's hasher keyed by the channel's own context VALUES
+            # (NE-002 fix — pre-fix populated by context dict KEYS, which
+            # tree.branch never searches for).
             oxygenation = _is_oxygenated(ch_name)
             if oxygenation:
                 _montage.channels[ch_name] = _montage.hbo_tree.insert(estimated_hrf)
-                # Add context to tree
-                for context in _montage.context:
-                    _montage.hbo_tree.hasher.add(context, _montage.channels[ch_name])
+                target_tree = _montage.hbo_tree
             elif oxygenation == False:
                 _montage.channels[ch_name] = _montage.hbr_tree.insert(estimated_hrf)
-                # Add context to tree
-                for context in _montage.context:
-                    _montage.hbr_tree.hasher.add(context, _montage.channels[ch_name])
+                target_tree = _montage.hbr_tree
+            else:
+                target_tree = None
+
+            if target_tree is not None:
+                channel_context = channel.get('context', {})
+                if isinstance(channel_context, dict):
+                    for ctx_value in channel_context.values():
+                        for hashable in _flatten_context_value(ctx_value):
+                            target_tree.hasher.add(hashable, _montage.channels[ch_name])
         except Exception as exc:
             raise ValueError(
                 f"load_montage: failed to load entry {key!r}: {exc}"

--- a/src/hrfunc/hrhash.py
+++ b/src/hrfunc/hrhash.py
@@ -159,35 +159,12 @@ class hasher:
 
 	# ------------- Core Hash Table Functions ------------- #
 
-	def fill(self, data = None, replace = True, empty = False):
-		"""
-		Fill the hash table with data, replacing any existing data if replace is True
-		
-		Arguments:
-			data (list) - List of keys to add to the hash table
-			replace (bool) - If True, replace existing data in the hash table
-			empty (bool) - If True, initialize an empty hash table without adding data
-		"""
-		if self.size != 0 and replace == True: # If data has already been added to the table, reset param/variables
-			self.size = 0
-			self.capacity = 2
-			self.collision_count = 0
-
-			self.table = [None]*self.capacity
-			self.contexts = [[] for _ in range(self.capacity)]
-
-		self.data = data
-		if self.data != None:
-			for datum in self.data:
-				self.add(datum)
-			self.__repr__()
-		else:
-			print('Empty universal hash table initialized')
-
 	def add(self, key, pointer):
 		"""
-		Add a new key to the hash table with associated pointer
-		
+		Add a pointer under the given key. Multiple pointers may share a
+		key — subsequent adds append to the slot's pointer list. Duplicate
+		(key, pointer) pairs are deduplicated by identity.
+
 		Arguments:
 			key (str) - Key to add to the hash table
 			pointer (any) - Pointer to associate with the key
@@ -200,39 +177,46 @@ class hasher:
 			self.resize()
 		hashkey = self.hasher(key)
 		while self.table[hashkey] is not None:
-			if self.table[hashkey] == key: # If the key already exists in the table
-				return# Return
+			if self.table[hashkey] == key: # Key already present — append if new
+				if not any(existing is pointer for existing in self.contexts[hashkey]):
+					self.contexts[hashkey].append(pointer)
+				self.probe_count = 0
+				return
 			if self.table[hashkey] == '!tombstone!': # If a tombstone was found
 				break # Replace tombstone
 			hashkey = self.prober(key, hashkey)
 
 		self.table[hashkey] = key # insert the new key into the found hash
-		self.contexts[hashkey] = pointer # Add node pointer
+		self.contexts[hashkey] = [pointer] # Start a fresh pointer list for this key
 
 		self.size += 1 # Increment size
 		self.probe_count = 0 # Reset
 
 	def search(self, key):
 		"""
-		Search for a key in the hash table and return its associated pointer
+		Search for a key in the hash table and return the list of pointers
+		associated with it.
+
 		Arguments:
 			key (str) - Key to search for in the hash table
 
 		Returns:
-			pointer (any) - Pointer associated with the key, or False if not found
+			list - Pointers associated with the key. Empty list on miss.
+			A shallow copy is returned so callers can safely iterate and
+			mutate their own copy without affecting the hasher's state.
 		"""
 		hashkey = self.hasher(key)
 		steps = 0
 		while self.table[hashkey] is not None:
 			if self.table[hashkey] == key:
 				self.probe_count = 0
-				return self.contexts[hashkey]
+				return list(self.contexts[hashkey])
 			hashkey = self.prober(key, hashkey)
 			steps += 1
 			if steps >= self.capacity:  # Full cycle — key not present
 				break
 		self.probe_count = 0 # Reset the quadratic multiplier probe for the next call
-		return False
+		return []
 
 	def remove(self, key):
 		hashkey = self.hasher(key)
@@ -268,9 +252,3 @@ class hasher:
 		self.table = new_table
 		self.contexts = new_hrf_filenames
 
-	def double_check(self):
-		found = 0
-		for datum in self.data:
-			if self.search(datum) == True:
-				found += 1
-		print(f"Double check found {(found/self.size)*100}% of data added")

--- a/src/hrfunc/hrtree.py
+++ b/src/hrfunc/hrtree.py
@@ -7,6 +7,28 @@ from scipy.interpolate import interp1d
 from collections import deque
 from nilearn.glm.first_level import spm_hrf
 
+
+def _flatten_context_value(value):
+    """
+    Yield hashable hasher keys from a context dict value. Lists and tuples
+    are flattened one level; None and empty containers are skipped; dicts
+    are passed through as-is (caller is responsible for not indexing them).
+
+    This exists to bridge the HRF context schema (where values may be
+    scalars like 'flanker' or lists like [20, 30] for age_range) and the
+    hasher's key requirement (any hashable). Used by both load_hrfs and
+    load_montage when populating the hasher under NE-002.
+    """
+    if value is None:
+        return
+    if isinstance(value, (list, tuple)):
+        for item in value:
+            if item is None:
+                continue
+            yield item
+        return
+    yield value
+
 class tree:
 
     def __init__(self, hrf_filename = None, **kwargs):
@@ -133,9 +155,16 @@ class tree:
             # Insert hrf node into tree
             node = self.insert(new_hrf)
 
-            # Add newly added node into HRHash table
-            for context in self.context:
-                self.hasher.add(context, node)
+            # Add newly added node into HRHash table, keyed by the VALUES
+            # in the channel's own context dict — not by the tree's context
+            # dict KEYS, which was the NE-002 bug. After the fix,
+            # `hasher.search('flanker')` returns every node whose
+            # context dict contained 'flanker' anywhere.
+            channel_context = channel.get('context', {})
+            if isinstance(channel_context, dict):
+                for ctx_value in channel_context.values():
+                    for hashable in _flatten_context_value(ctx_value):
+                        self.hasher.add(hashable, node)
 
     def insert(self, hrf, depth = 0, node = None):
         """Insert a new node into the 3D k-d tree based on spatial position.
@@ -220,13 +249,18 @@ class tree:
         if node is None: # Set up filtering
             if self.root is None: # If nothing loaded yet
                 raise ValueError("No HRFs loaded yet, nothing to filter")
-            
-            node = self.root # Set root at node
-            self.context = {**self.context, **kwargs} 
 
-            if self.branched == False: # Branch to reduce number of hard comparison
-                print("Branching tree on context before filtering")
-                self.branch()
+            node = self.root # Set root at node
+            self.context = {**self.context, **kwargs}
+
+            # Historical no-op: the pre-fix code here called self.branch()
+            # and discarded the result — the intent was to pre-filter to
+            # a smaller sub-tree before compare_context, but filter()
+            # always ran against self.root regardless, so the "branch"
+            # was just a flag flip. Preserved as a direct assignment
+            # after the hasher-branch-correctness fix made branch() with
+            # no kwargs return an empty tree by design.
+            self.branched = True
 
         if node.left: # If there's a left node
             self.filter(similarity_threshold, node.left)
@@ -241,7 +275,13 @@ class tree:
 
     def compare_context(self, first_context, second_context, context_weights=None):
         """
-        Compare two contexts to see how similar they are
+        Compare two contexts to see how similar they are.
+
+        3.1: Context values may be scalars ('flanker'), lists ([20, 30]),
+        or None. Scalars are auto-wrapped to single-element lists before
+        comparison so the inner `for value in values:` loop behaves the
+        same way regardless of the raw type. A key missing from
+        second_context (or set to None there) counts as zero matches.
 
         Arguments:
             first_context (dict) - Context to compare against
@@ -254,27 +294,55 @@ class tree:
         weights = context_weights if context_weights is not None else self.context_weights
         context_similarity = []
         for key, values in first_context.items():
-            # If context not mentioned in first context
-            if values is None: # Exclude context in similarity comparison
+            if values is None: # Exclude from similarity comparison
                 continue
+
+            # Auto-wrap scalars so the inner loop doesn't iterate over
+            # characters of a string or crash on a non-iterable.
+            if not isinstance(values, (list, tuple)):
+                values = [values]
+            if len(values) == 0:
+                continue
+
+            other = second_context.get(key) if isinstance(second_context, dict) else None
+            if other is None:
+                other_values = []
+            elif not isinstance(other, (list, tuple)):
+                other_values = [other]
+            else:
+                other_values = list(other)
 
             same = 0 # Create a context specific similarity value
             for value in values:
-                if value in second_context[key]:
+                if value in other_values:
                     if weights: # If a context weight provided
-                        same += 1 * weights[key] # Weight similarity score
+                        same += 1 * weights.get(key, 1.0) # Weight similarity score
                     else:
                         same += 1
 
             # Calculate context-specific similarity and append (ND-002: use len(values) not len(first_context))
-            context_similarity.append(same / len(values) if len(values) > 0 else 0.0)
+            context_similarity.append(same / len(values))
 
         return sum(context_similarity) / len(context_similarity) if len(context_similarity) > 0 else 0.0
 
     def branch(self, **kwargs):
         """
-        Accepts context keyword inputs via kwargs, updates the trees context
-        and then builds a new tree filtering for just the context
+        Build a new tree filtered to nodes whose context dict contains
+        every user-specified kwarg value.
+
+        Semantics:
+        - kwargs are ANDed together: a node must match all user-specified
+          keys to be included.
+        - Values within a single kwarg are ORed: `branch(task=['a','b'])`
+          returns nodes whose task is 'a' or 'b'.
+        - Only the kwargs passed to this call act as filters. The tree's
+          own `self.context` defaults (e.g. `method='toeplitz'`) are not
+          treated as implicit filters — that pre-fix behavior made
+          `branch(task='nothing_matches')` return every node whose method
+          happened to equal 'toeplitz', because the loop iterated every
+          context-dict entry including defaults.
+        - Matching uses the hasher populated by `load_hrfs` / `load_montage`
+          keyed by the channel context VALUES (NE-002 fix).
 
         Arguments:
             **kwargs - Any context keyword value pair to branch on (i.e. doi, age, etc)
@@ -283,24 +351,55 @@ class tree:
             branch (tree object) - A new tree object filtered on the requested context
         """
         if kwargs:
-            self.context = {**self.context, **kwargs} # Update context
+            self.context = {**self.context, **kwargs} # Update context for downstream readers
 
         branch = tree()
+        self.branched = True
 
-        for key, values in self.context.items(): # Iterate through all context items
+        if not kwargs:
+            # No filter specified — return an empty branch rather than the
+            # whole tree. Callers wanting a full copy should use the
+            # montage.branch() API or a dedicated clone method.
+            return branch
+
+        # For each kwarg, gather the set of candidate nodes (ORed across
+        # that kwarg's values). Then intersect across kwargs to get the
+        # final ANDed set.
+        candidate_lists = []
+        for key, values in kwargs.items():
             if values is None:
                 continue
-            for value in values: # Iterate through each item in a context area
-                # Hash on the value and iterate through the tree pointers
-                context_references = self.hasher.search(value)
-                for node in context_references:
-                    # Create a deep copy of the HRF node to preserve all data
-                    node_copy = node.copy()
-                    branch.insert(node_copy)
-                    # Add context to hasher
-                    for context in branch.context:
-                        branch.hasher.add(context, node_copy)
-        self.branched = True
+            if not isinstance(values, (list, tuple)):
+                values = [values]
+            matches = []
+            seen_ids = set()
+            for value in values:
+                if value is None:
+                    continue
+                for node in self.hasher.search(value):
+                    if id(node) not in seen_ids:
+                        seen_ids.add(id(node))
+                        matches.append(node)
+            candidate_lists.append(matches)
+
+        if not candidate_lists:
+            return branch
+
+        final_nodes = candidate_lists[0]
+        for cl in candidate_lists[1:]:
+            cl_ids = {id(n) for n in cl}
+            final_nodes = [n for n in final_nodes if id(n) in cl_ids]
+
+        for node in final_nodes:
+            node_copy = node.copy()
+            branch.insert(node_copy)
+            # Populate the sub-tree's hasher keyed by the copied node's
+            # context VALUES — mirrors load_hrfs (NE-002 semantics).
+            if isinstance(node_copy.context, dict):
+                for ctx_value in node_copy.context.values():
+                    for hashable in _flatten_context_value(ctx_value):
+                        branch.hasher.add(hashable, node_copy)
+
         return branch
 
     def nearest_neighbor(self, optode, max_distance, node = 'root', depth = 0, best = None, verbose = False):

--- a/tests/test_hasher_branch.py
+++ b/tests/test_hasher_branch.py
@@ -1,0 +1,335 @@
+"""
+Targeted unit tests for fix/hasher-branch-correctness.
+
+Scope:
+- **3.3**: hasher.add supports multiple pointers per key (appends to slot's
+  pointer list); hasher.search returns the full list.
+- **H4**: hasher.search returns [] on miss instead of False. All callers
+  updated to the list contract.
+- **3.4**: hasher.fill and hasher.double_check were dead/broken code and
+  have been removed.
+- **NE-002**: load_hrfs and load_montage now populate the hasher keyed by
+  channel context VALUES (e.g. 'flanker', 'checkerboard'), not by the
+  tree's context-dict KEYS. This matches what tree.branch searches for.
+- **3.1**: compare_context auto-wraps scalar context values so it can
+  handle both `'flanker'` and `['flanker']` consistently.
+- **3.2**: tree.branch auto-wraps scalar values, dedupes matched nodes
+  across multiple hasher hits, and populates the sub-tree's hasher from
+  each copied node's context values (not dict keys).
+
+Fast, no fNIRS data files.
+"""
+
+import json
+import pytest
+import numpy as np
+
+
+# ---------------------------------------------------------------------------
+# 3.3 + H4: hasher structural and return-type contract
+# ---------------------------------------------------------------------------
+
+class TestHasherAddAppend:
+    def test_add_first_pointer_creates_list(self):
+        from hrfunc.hrhash import hasher
+        h = hasher({})
+        h.add('task', 'ptr_a')
+        assert h.search('task') == ['ptr_a']
+
+    def test_add_second_pointer_appends(self):
+        from hrfunc.hrhash import hasher
+        h = hasher({})
+        h.add('task', 'ptr_a')
+        h.add('task', 'ptr_b')
+        result = h.search('task')
+        assert 'ptr_a' in result
+        assert 'ptr_b' in result
+        assert len(result) == 2
+
+    def test_add_duplicate_pointer_deduplicates(self):
+        """Adding the same (key, pointer) pair twice should not produce
+        two entries. Dedup is by identity."""
+        from hrfunc.hrhash import hasher
+        h = hasher({})
+        pointer = object()
+        h.add('task', pointer)
+        h.add('task', pointer)
+        assert h.search('task') == [pointer]
+
+    def test_add_different_keys_independent(self):
+        from hrfunc.hrhash import hasher
+        h = hasher({})
+        h.add('task', 'flanker')
+        h.add('stimulus', 'checkerboard')
+        assert h.search('task') == ['flanker']
+        assert h.search('stimulus') == ['checkerboard']
+
+    def test_many_adds_trigger_resize(self):
+        """Inserting enough entries to trigger the resize path should not
+        corrupt the pointer lists."""
+        from hrfunc.hrhash import hasher
+        h = hasher({})
+        for i in range(20):
+            h.add(f'key_{i}', f'ptr_{i}')
+        for i in range(20):
+            assert h.search(f'key_{i}') == [f'ptr_{i}']
+
+
+class TestHasherSearchContract:
+    def test_search_miss_returns_empty_list(self):
+        from hrfunc.hrhash import hasher
+        h = hasher({})
+        assert h.search('nonexistent') == []
+
+    def test_search_miss_is_iterable(self):
+        """The whole point of H4: `for node in hasher.search(x):` must
+        not TypeError on a miss."""
+        from hrfunc.hrhash import hasher
+        h = hasher({})
+        count = 0
+        for node in h.search('nothing'):
+            count += 1
+        assert count == 0
+
+    def test_search_returns_copy_not_live_list(self):
+        """Callers must be able to mutate the returned list without
+        affecting the hasher's internal state."""
+        from hrfunc.hrhash import hasher
+        h = hasher({})
+        h.add('task', 'ptr_a')
+        result = h.search('task')
+        result.append('garbage')
+        # Subsequent search should not see the appended garbage
+        assert h.search('task') == ['ptr_a']
+
+
+class TestHasherDeadCodeRemoved:
+    def test_fill_removed(self):
+        from hrfunc.hrhash import hasher
+        assert not hasattr(hasher, 'fill') or True  # Allow either
+        # Hard assertion: the method should not exist
+        assert not hasattr(hasher, 'fill')
+
+    def test_double_check_removed(self):
+        from hrfunc.hrhash import hasher
+        assert not hasattr(hasher, 'double_check')
+
+
+# ---------------------------------------------------------------------------
+# NE-002: load_hrfs populates hasher by context VALUES
+# ---------------------------------------------------------------------------
+
+def _entry(doi='doi', task='flanker', stimulus='checkerboard', location=(0.01, 0.02, 0.03)):
+    return {
+        "hrf_mean": [0.0, 0.1, 0.2, 0.1, 0.0],
+        "hrf_std": [0.0, 0.0, 0.0, 0.0, 0.0],
+        "sfreq": 7.81,
+        "location": list(location),
+        "context": {
+            "task": task,
+            "stimulus": stimulus,
+            "doi": doi,
+            "duration": 30.0,
+        },
+        "estimates": [],
+        "locations": [],
+    }
+
+
+class TestLoadHrfsPopulatesByValue:
+    def test_task_value_becomes_hasher_key(self, tmp_path):
+        from hrfunc.hrtree import tree
+        path = tmp_path / "hrfs.json"
+        path.write_text(json.dumps({
+            "S1_D1 hbo-doi1": _entry(task='flanker'),
+        }))
+        t = tree(str(path))
+        # The hasher should contain 'flanker' as a key, NOT 'task'
+        result = t.hasher.search('flanker')
+        assert len(result) == 1
+        assert result[0].ch_name.startswith('s1_d1')
+
+    def test_old_keys_not_present(self, tmp_path):
+        """Regression guard: the pre-fix populated the hasher with dict
+        KEYS like 'task' / 'stimulus'. After the fix, those should be
+        empty (searching for 'task' as a value returns nothing)."""
+        from hrfunc.hrtree import tree
+        path = tmp_path / "hrfs.json"
+        path.write_text(json.dumps({
+            "S1_D1 hbo-doi1": _entry(task='flanker'),
+        }))
+        t = tree(str(path))
+        # 'task' is the KEY in context dict, not a value any HRF carries
+        assert t.hasher.search('task') == []
+        assert t.hasher.search('stimulus') == []
+
+    def test_multiple_hrfs_same_task_share_hasher_slot(self, tmp_path):
+        from hrfunc.hrtree import tree
+        path = tmp_path / "hrfs.json"
+        path.write_text(json.dumps({
+            "S1_D1 hbo-doi1": _entry(task='flanker', location=(0.01, 0.01, 0.01)),
+            "S1_D2 hbo-doi1": _entry(task='flanker', location=(0.02, 0.02, 0.02)),
+            "S1_D3 hbo-doi1": _entry(task='gonogo', location=(0.03, 0.03, 0.03)),
+        }))
+        t = tree(str(path))
+        flanker_nodes = t.hasher.search('flanker')
+        gonogo_nodes = t.hasher.search('gonogo')
+        assert len(flanker_nodes) == 2
+        assert len(gonogo_nodes) == 1
+
+
+# ---------------------------------------------------------------------------
+# NE-002: load_montage populates hasher by context VALUES
+# ---------------------------------------------------------------------------
+
+def _montage_entry_payload(task='flanker'):
+    return {
+        "S1_D1 hbo-10.0/doi": _entry(task=task, location=(0.01, 0.02, 0.03)),
+        "S1_D1 hbr-10.0/doi": {
+            **_entry(task=task, location=(0.01, 0.02, 0.03)),
+        },
+    }
+
+
+class TestLoadMontagePopulatesByValue:
+    def test_task_value_reaches_hbo_tree_hasher(self, tmp_path):
+        from hrfunc.hrfunc import load_montage
+        path = tmp_path / "montage.json"
+        path.write_text(json.dumps(_montage_entry_payload(task='flanker')))
+        m = load_montage(str(path))
+        # The montage's library trees are loaded from the bundled HRFs at
+        # montage.__init__ time. load_montage then inserts the user's
+        # channels into those same trees. Searching 'flanker' on the HbO
+        # tree should return the user's channel node.
+        flanker_hits = m.hbo_tree.hasher.search('flanker')
+        # At least one of the hits should be the user's channel
+        user_ch_name = 's1_d1_hbo'
+        assert any(
+            getattr(node, 'ch_name', '').startswith(user_ch_name[:5])
+            for node in flanker_hits
+        )
+
+
+# ---------------------------------------------------------------------------
+# 3.1: compare_context scalar auto-wrap
+# ---------------------------------------------------------------------------
+
+class TestCompareContextScalar:
+    def test_scalar_task_values_match(self):
+        from hrfunc.hrtree import tree
+        t = tree()
+        a = {'task': 'flanker'}
+        b = {'task': 'flanker'}
+        # Pre-fix: `for value in 'flanker'` iterated chars and crashed
+        # on `second_context['task']` char lookup.
+        score = t.compare_context(a, b, context_weights={'task': 1.0})
+        assert score == 1.0
+
+    def test_scalar_vs_list_match(self):
+        from hrfunc.hrtree import tree
+        t = tree()
+        a = {'task': 'flanker'}
+        b = {'task': ['flanker', 'gonogo']}
+        score = t.compare_context(a, b, context_weights={'task': 1.0})
+        assert score == 1.0
+
+    def test_scalar_mismatch(self):
+        from hrfunc.hrtree import tree
+        t = tree()
+        a = {'task': 'flanker'}
+        b = {'task': 'gonogo'}
+        score = t.compare_context(a, b, context_weights={'task': 1.0})
+        assert score == 0.0
+
+    def test_missing_key_in_second_context(self):
+        from hrfunc.hrtree import tree
+        t = tree()
+        a = {'task': 'flanker'}
+        b = {}  # Missing 'task' entirely — no crash
+        score = t.compare_context(a, b, context_weights={'task': 1.0})
+        assert score == 0.0
+
+    def test_none_value_skipped(self):
+        from hrfunc.hrtree import tree
+        t = tree()
+        a = {'task': None, 'stimulus': 'checkerboard'}
+        b = {'stimulus': 'checkerboard'}
+        score = t.compare_context(a, b, context_weights={'task': 1.0, 'stimulus': 1.0})
+        # Only 'stimulus' counted; 'task' None skipped
+        assert score == 1.0
+
+
+# ---------------------------------------------------------------------------
+# 3.2: tree.branch end-to-end
+# ---------------------------------------------------------------------------
+
+class TestTreeBranchEndToEnd:
+    def test_branch_on_scalar_value(self, tmp_path):
+        from hrfunc.hrtree import tree
+        path = tmp_path / "hrfs.json"
+        path.write_text(json.dumps({
+            "S1_D1 hbo-doi1": _entry(task='flanker', location=(0.01, 0.01, 0.01)),
+            "S1_D2 hbo-doi1": _entry(task='gonogo', location=(0.02, 0.02, 0.02)),
+        }))
+        t = tree(str(path))
+        branched = t.branch(task='flanker')
+        # The branched tree should contain only the flanker node
+        assert branched.root is not None
+        names = {n.ch_name for n in _collect_all_user_nodes(branched.root)}
+        assert any('s1_d1' in n for n in names)
+        assert not any('s1_d2' in n for n in names)
+
+    def test_branch_dedupes_nodes_matched_under_multiple_values(self, tmp_path):
+        """If a single node's context happens to contain values matching
+        multiple search terms, the sub-tree must contain it only once."""
+        from hrfunc.hrtree import tree
+        path = tmp_path / "hrfs.json"
+        path.write_text(json.dumps({
+            "S1_D1 hbo-doi1": _entry(task='flanker', stimulus='checkerboard',
+                                     location=(0.01, 0.01, 0.01)),
+        }))
+        t = tree(str(path))
+        # Branch on both task and stimulus — the single HRF matches both
+        branched = t.branch(task='flanker', stimulus='checkerboard')
+        user_nodes = [n for n in _collect_all_user_nodes(branched.root)]
+        assert len(user_nodes) == 1
+
+    def test_branch_empty_when_no_match(self, tmp_path):
+        from hrfunc.hrtree import tree
+        path = tmp_path / "hrfs.json"
+        path.write_text(json.dumps({
+            "S1_D1 hbo-doi1": _entry(task='flanker', location=(0.01, 0.01, 0.01)),
+        }))
+        t = tree(str(path))
+        branched = t.branch(task='nothing_matches_this')
+        # No user nodes should be in the branched tree (the canonical
+        # sentinel may or may not be present depending on insert path)
+        user_nodes = [n for n in _collect_all_user_nodes(branched.root)]
+        assert user_nodes == []
+
+    def test_branch_populates_sub_tree_hasher_by_values(self, tmp_path):
+        """The sub-tree's hasher should be populated by the copied
+        nodes' context VALUES — same contract as load_hrfs."""
+        from hrfunc.hrtree import tree
+        path = tmp_path / "hrfs.json"
+        path.write_text(json.dumps({
+            "S1_D1 hbo-doi1": _entry(task='flanker', location=(0.01, 0.01, 0.01)),
+        }))
+        t = tree(str(path))
+        branched = t.branch(task='flanker')
+        # The sub-tree's hasher should have 'flanker' as a key
+        assert len(branched.hasher.search('flanker')) >= 1
+        # And NOT the dict keys
+        assert branched.hasher.search('task') == []
+
+
+def _collect_all_user_nodes(node, acc=None):
+    if acc is None:
+        acc = []
+    if node is None:
+        return acc
+    if not node.ch_name.startswith('canonical'):
+        acc.append(node)
+    _collect_all_user_nodes(node.left, acc)
+    _collect_all_user_nodes(node.right, acc)
+    return acc

--- a/tests/test_phase1bc.py
+++ b/tests/test_phase1bc.py
@@ -197,12 +197,18 @@ class TestHasherReprEmpty:
 # ---------------------------------------------------------------------------
 
 class TestHasherSearchNoCycle:
-    def test_search_missing_key_returns_false(self):
-        """search() must return False for a key that was never added — not loop forever."""
+    # Note: the return-type contract for hasher.search was changed in
+    # fix/hasher-branch-correctness (H4 + 3.3). Before that branch, search
+    # returned False on miss and a scalar pointer on hit. After, it returns
+    # [] on miss and a list of pointers on hit. These tests were updated
+    # to the list-based contract but still exercise the no-cycle invariant
+    # this class was originally written for.
+    def test_search_missing_key_returns_empty_list(self):
+        """search() must return an empty list for a key that was never added — not loop forever."""
         from hrfunc.hrhash import hasher
         h = hasher({})
         result = h.search('nonexistent_key')
-        assert result is False
+        assert result == []
 
     def test_search_exits_within_capacity_steps(self):
         """Probe loop must terminate in at most capacity iterations."""
@@ -213,15 +219,15 @@ class TestHasherSearchNoCycle:
             h.add(f'key_{i}', f'ptr_{i}')
         # Search for something that definitely isn't there
         result = h.search('definitely_not_a_key_xyz_999')
-        assert result is False
+        assert result == []
 
     def test_search_finds_existing_key(self):
-        """search() still returns the correct pointer for an inserted key."""
+        """search() returns the list of pointers for an inserted key."""
         from hrfunc.hrhash import hasher
         h = hasher({})
         h.add('mykey', 'mypointer')
         result = h.search('mykey')
-        assert result == 'mypointer'
+        assert result == ['mypointer']
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
…-002, H4, 3.1-3.4)

Part of v1.2.0 correctness release. Stacks on main. Makes tree.branch() and the hasher work correctly end-to-end, from population through search. Pre-implementation call-site audit confirmed tree.branch() was unreachable from production code paths (montage.branch reimplements inline), so the blast radius is limited despite touching a return-type contract.

3.3 + H4 - hrhash.hasher (src/hrfunc/hrhash.py)
  - hasher.add now appends pointers to the slot's pointer list instead of overwriting with a scalar. Dedup by identity via `any(existing is pointer for existing in slot)` so the same node only appears once per key.
  - hasher.search now returns list[pointer] instead of scalar | False. Empty list on miss so `for node in search(x):` never TypeErrors. Returns a shallow copy so callers can safely mutate.
  - hasher.fill and hasher.double_check deleted. fill() had a broken signature (called add with one arg) and no reachable callers; double_check() was only called from fill().

NE-002 - load_hrfs and load_montage (src/hrfunc/hrtree.py, src/hrfunc/hrfunc.py)
  - Pre-fix: iterated self.context.keys() and added dict KEYS (like 'task') to the hasher. tree.branch then searched by VALUES (like 'flanker'), which were never stored. Fundamental mismatch.
  - Fix: iterate the CHANNEL's own context dict values and add each as a hasher key. A new module-level _flatten_context_value helper in hrtree.py flattens list values (for fields like age_range) and skips None cleanly. Exported and reused by both load paths.

3.1 - compare_context (src/hrfunc/hrtree.py)
  - Auto-wrap scalar context values into single-element lists so the inner `for value in values:` loop doesn't iterate string characters.
  - Handle missing keys in second_context cleanly (return 0 for that key instead of KeyError).
  - Handle second_context being None or non-dict.
  - Use weights.get(key, 1.0) with a sensible default.

3.2 - tree.branch (src/hrfunc/hrtree.py)
  - Rewrote with AND-on-kwargs / OR-within-kwarg semantics. Matches the plan's exit criterion that branch returns an empty tree when no nodes match the requested filter. Pre-fix iterated self.context (including defaults like method='toeplitz') which OR-unioned every matching node regardless of user kwargs.
  - Empty kwargs returns an empty branch (explicit sentinel value).
  - Scalar kwarg values auto-wrapped; None kwargs skipped.
  - id()-based dedup so a node matched under multiple kwarg values only appears once in the sub-tree.
  - Sub-tree's hasher populated from each copied node's context VALUES, mirroring load_hrfs semantics.

Cleanup - tree.filter (src/hrfunc/hrtree.py)
  - Pre-fix code called self.branch() with no kwargs as a purported optimization, then discarded the return value. filter() always ran compare_context + delete against self.root regardless, so the branch call was just a flag flip. Replaced with a direct self.branched = True assignment plus an inline comment explaining the historical no-op. Caught by the parallel architecture review.

Test contract updates - tests/test_phase1bc.py
  - Three tests in TestHasherSearchNoCycle updated from the old False/scalar return contract to the new [] / [pointers] contract. Comment added explaining the contract change and where it happened.

Tests: tests/test_hasher_branch.py (23 tests)
  - 3.3/H4: add appends, dedupes, empty-list miss, iterable miss, copy not live list, resize survives
  - 3.4: hasher.fill and hasher.double_check removed
  - NE-002: load_hrfs populates by value, old keys absent, multiple HRFs sharing a task share a hasher slot
  - NE-002: load_montage populates hbo_tree hasher by value
  - 3.1: compare_context scalar-vs-scalar, scalar-vs-list, mismatch, missing key, None skipped
  - 3.2: branch on scalar value, dedup across multiple kwargs, empty result on no match, sub-tree hasher populated by values

Gate: 163 passed, 0 xfailed across the full targeted suite.

Gotchas:
- Pre-implementation call-site audit ran before any code changes, so the implementation order (hasher structure -> callers -> populate logic) matched the audit's recommended sequence. No silent regressions from the search() return-type change because the only production caller of tree.branch (which is internal plumbing — montage.branch reimplements inline) was also rewritten in the same branch.
- tree.branch() with no kwargs now returns an empty tree instead of mirroring self.context. This is a semantic change, but tree.branch() is internal-only and the new semantics match the plan's exit criterion.
- The 'weights' fallback in compare_context was changed from weights[key] to weights.get(key, 1.0) to handle partial weights dicts cleanly. Unweighted paths still use same += 1.