### PR TITLE
fix: tree.insert + HRF class correctness (NE-001, 3.5, NE-003, NE-004…

### DIFF
--- a/src/hrfunc/hrtree.py
+++ b/src/hrfunc/hrtree.py
@@ -4,6 +4,7 @@ from ._utils import standardize_name, _is_oxygenated, _LIB_DIR
 import matplotlib.pyplot as plt
 import numpy as np
 from scipy.interpolate import interp1d
+from scipy.ndimage import gaussian_filter1d
 from collections import deque
 from nilearn.glm.first_level import spm_hrf
 
@@ -200,7 +201,10 @@ class tree:
                 estimates = [canonical_hrf],
                 locations = [[359.0, 359.0, 390.0]]
             )
-            self.root.context['method'] = 'canonical'
+            # NE-001: label the canonical sentinel, NOT the user-inserted
+            # root. Pre-fix this line clobbered the first real HRF's
+            # context method with 'canonical'.
+            self.root.right.context['method'] = 'canonical'
             return self.root
 
         if node is None:
@@ -211,12 +215,20 @@ class tree:
         h_val = (hrf.x, hrf.y, hrf.z)[axis]
         n_val = (node.x, node.y, node.z)[axis]
 
-        # Handle duplicates by jittering location
+        # Handle duplicates by jittering location.
+        # 3.5: the pre-fix loop `for val in (hrf.x, hrf.y, hrf.z): val += 1e-10`
+        # mutated the loop variable, not the HRF's coordinates, so the
+        # jitter never took effect. Assign directly instead.
         if h_val == n_val and hrf.x == node.x and hrf.y == node.y and hrf.z == node.z:
-            for val in (hrf.x, hrf.y, hrf.z):
-                if node.oxygenation == hrf.oxygenation:
-                    print(f"WARNING: Jittering location for {hrf.ch_name}, same location as the following node.../n{node.ch_name}")
-                    val += 1e-10 # Jitter location while staying above 64-precision double threshold
+            if node.oxygenation == hrf.oxygenation:
+                print(f"WARNING: Jittering location for {hrf.ch_name}, same location as the following node...\n{node.ch_name}")
+                hrf.x += 1e-10
+                hrf.y += 1e-10
+                hrf.z += 1e-10
+                # Refresh the axis comparison value for this pass so the
+                # jittered coordinate actually informs the left/right
+                # decision below.
+                h_val = (hrf.x, hrf.y, hrf.z)[axis]
             
         # If the current node is less than the new node
         if h_val < n_val: 
@@ -735,7 +747,7 @@ class tree:
         return min([node, left_min, right_min], key=lambda n: getattr(n, ["x", "y", "z"][axis]) if n else float('inf'))
 
 class HRF:
-    def __init__(self, doi, ch_name, duration, sfreq, trace, trace_std = None, location = None, estimates = [], locations = [], context = [], **kwargs):
+    def __init__(self, doi, ch_name, duration, sfreq, trace, trace_std = None, location = None, estimates = None, locations = None, context = None, **kwargs):
         """
         Object for storing all information apart of an estimated HRF from an fNIRS optode
 
@@ -781,9 +793,14 @@ class HRF:
             self.y = -1 + random.random()
             self.z = -1 + random.random()
 
-        # Set HRF default context
+        # 3.7: mutable default args (estimates=[], locations=[], context=[])
+        # replaced with None sentinels and materialized inside the function
+        # so two HRF instances don't silently share the same list/dict.
         if context:
-            self.context = context
+            # NOTE: pre-fix accepted a list default `context=[]`. Keep
+            # truthiness check so an empty-but-non-None value still falls
+            # back to the default template.
+            self.context = dict(context) if isinstance(context, dict) else {}
         else:
             self.context = {
                 'method': 'toeplitz',
@@ -806,12 +823,16 @@ class HRF:
         self.left = None
         self.right = None
 
-        self.estimates = estimates
-        self.locations = locations
+        self.estimates = list(estimates) if estimates is not None else []
+        self.locations = list(locations) if locations is not None else []
 
+        # NE-003: process_options must be the same length as hrf_processes
+        # and process_names so the zip in build() produces one iteration
+        # per configured step. Pre-fix this was `[]`, making zip zero-
+        # iterate and build() silently do nothing.
         self.hrf_processes = [self.spline_interp]
         self.process_names = ['spline_interpolate']
-        self.process_options = []
+        self.process_options = [None]
 
         self.built = False
 
@@ -845,16 +866,19 @@ class HRF:
     def build(self, new_sfreq, plot = False, show = False):
         """ Run through the processes requested for generating an hrf """
         self.target_length = new_sfreq * float(self.context['duration'])
+        # 3.10: derive hrf_type from oxygenation instead of reading
+        # self.type, which was never set anywhere and would AttributeError.
+        hrf_type = "hbo" if self.oxygenation else "hbr"
         for process, process_name, process_option in zip(self.hrf_processes, self.process_names, self.process_options):
-            
+
             if process_option == None:
                 self.trace = process(self.trace)
             else:
                 self.trace = process(self.trace, process_option)
-            
+
             if plot: # Plot the processing step results
                 title = f"HRF - {process_name}"
-                filename = f"plots/{'-'.join(process_name.split(' ')).lower()}_{self.type}_hrf_results.png"
+                filename = f"plots/{'-'.join(process_name.split(' ')).lower()}_{hrf_type}_hrf_results.png"
                 self.plot(title, filename, show)
         self.built = True
 
@@ -871,21 +895,30 @@ class HRF:
         # Update class variables
         self.x, self.y, self.z = centroid[0], centroid[1], centroid[2]
 
-    def spline_interp(self):
+    def spline_interp(self, trace = None):
         """
-        Use spline interpolation to resample the HRF to a new size that fits the new target length
-        
+        Use spline interpolation to resample the HRF to a new size that fits
+        self.target_length. Accepts an optional trace argument so it can be
+        used as a pipeline step in build() (which calls
+        `self.trace = process(self.trace)` on each configured process).
+
+        Arguments:
+            trace (array-like) - Source trace to resample. Defaults to
+                self.trace if omitted.
+
         Returns:
-            trace (list of floats) - The resampled HRF trace
+            resampled_trace (np.ndarray) - Trace resampled to target_length
         """
+        if trace is None:
+            trace = self.trace
         # Original list
-        hrf_indices = np.linspace(0, len(self.trace) - 1, len(self.trace))
+        hrf_indices = np.linspace(0, len(trace) - 1, len(trace))
 
         # Create a spline interpolation function
-        spline = interp1d(hrf_indices, self.trace, kind='cubic')
-        new_indices = np.linspace(0, len(self.trace) - 1, int(self.target_length))
+        spline = interp1d(hrf_indices, trace, kind='cubic')
+        new_indices = np.linspace(0, len(trace) - 1, int(self.target_length))
 
-        # Compressed list
+        # Resampled list
         return spline(new_indices)
 
     def smooth(self, a):
@@ -896,7 +929,9 @@ class HRF:
             a (float) - Sigma value used in gaussian filter to dictate how much the HRF is smoothed
         """
         print(f'Smoothing HRF trace with Gaussian filter (sigma = {a})...')
-        self.trace = self.gaussian_filter1d(self.trace, a)
+        # NE-004: pre-fix called self.gaussian_filter1d which was never
+        # imported or defined. Use the module-level scipy import.
+        self.trace = gaussian_filter1d(self.trace, a)
 
         
     def normalize(self):

--- a/tests/test_tree_hrf.py
+++ b/tests/test_tree_hrf.py
@@ -1,0 +1,214 @@
+"""
+Targeted unit tests for fix/tree-hrf-correctness.
+
+Scope:
+- **NE-001**: tree.insert labels the CANONICAL SENTINEL node with
+  context['method']='canonical', not the first user-inserted root.
+- **3.5**: tree.insert jitter branch mutates the HRF's x/y/z directly
+  rather than a loop variable that was immediately discarded.
+- **NE-003**: HRF.__init__ initializes process_options to [None] so the
+  build() zip produces one iteration and spline_interp actually runs.
+  spline_interp now accepts an optional trace argument so build() can
+  call it through the `process(self.trace)` pipeline pattern.
+- **NE-004**: HRF.smooth uses scipy.ndimage.gaussian_filter1d (imported
+  at module level) instead of the non-existent self.gaussian_filter1d.
+- **3.7**: HRF.__init__ mutable default args (estimates=[], locations=[],
+  context=[]) replaced with None sentinels + per-instance materialization.
+- **3.10**: HRF.build derives hrf_type from self.oxygenation instead of
+  reading the never-set self.type.
+
+Fast, no fNIRS data files.
+"""
+
+import pytest
+import numpy as np
+
+
+def _hrf(ch_name, x, y, z, oxygenation=True, trace_len=30, **kwargs):
+    from hrfunc.hrtree import HRF
+    suffix = 'hbo' if oxygenation else 'hbr'
+    return HRF(
+        'doi',
+        f'{ch_name}_{suffix}',
+        30.0,
+        7.81,
+        np.ones(trace_len),
+        location=[x, y, z],
+        **kwargs,
+    )
+
+
+# ---------------------------------------------------------------------------
+# NE-001: canonical context does not clobber the first real node
+# ---------------------------------------------------------------------------
+
+class TestCanonicalContextAssignment:
+    def test_first_real_node_context_method_preserved(self):
+        from hrfunc.hrtree import tree
+        t = tree()
+        hrf = _hrf('s1_d1', 0.0, 0.0, 0.0)
+        # The HRF arrives with method='toeplitz' from its default context
+        assert hrf.context.get('method') == 'toeplitz'
+        t.insert(hrf)
+        # After insert, the USER's method should still be 'toeplitz'
+        # (pre-fix this was clobbered to 'canonical')
+        assert t.root.context['method'] == 'toeplitz'
+
+    def test_canonical_sentinel_labeled_canonical(self):
+        from hrfunc.hrtree import tree
+        t = tree()
+        hrf = _hrf('s1_d1', 0.0, 0.0, 0.0)
+        t.insert(hrf)
+        # root.right is the canonical sentinel inserted by tree.insert
+        assert t.root.right is not None
+        assert t.root.right.ch_name.startswith('canonical')
+        assert t.root.right.context['method'] == 'canonical'
+
+
+# ---------------------------------------------------------------------------
+# 3.5: jitter actually moves the HRF's coordinates
+# ---------------------------------------------------------------------------
+
+class TestJitterCoordinates:
+    def test_duplicate_insert_jitters_coordinates(self, capsys):
+        from hrfunc.hrtree import tree
+        t = tree()
+        a = _hrf('a', 0.5, 0.5, 0.5)
+        b = _hrf('b', 0.5, 0.5, 0.5)
+        t.insert(a)
+        t.insert(b)
+        # Post-fix: b's coordinates should have been jittered by 1e-10
+        assert b.x != 0.5 or b.y != 0.5 or b.z != 0.5
+        captured = capsys.readouterr()
+        assert 'Jittering location' in captured.out
+
+    def test_jitter_preserves_first_node_coordinates(self):
+        from hrfunc.hrtree import tree
+        t = tree()
+        a = _hrf('a', 0.5, 0.5, 0.5)
+        b = _hrf('b', 0.5, 0.5, 0.5)
+        t.insert(a)
+        orig_a_x, orig_a_y, orig_a_z = a.x, a.y, a.z
+        t.insert(b)
+        # The first-inserted node should NOT be jittered
+        assert a.x == orig_a_x
+        assert a.y == orig_a_y
+        assert a.z == orig_a_z
+
+
+# ---------------------------------------------------------------------------
+# NE-003: HRF.build actually runs spline_interp and resamples
+# ---------------------------------------------------------------------------
+
+class TestBuildResamples:
+    def test_build_resamples_trace_to_target_length(self):
+        from hrfunc.hrtree import HRF
+        h = HRF(
+            'doi',
+            's1_d1_hbo',
+            duration=10.0,
+            sfreq=5.0,
+            trace=np.linspace(0.0, 1.0, 50),
+            location=[0, 0, 0],
+        )
+        # Target: new_sfreq=10 × duration=10 = 100 samples
+        h.build(new_sfreq=10.0)
+        assert len(h.trace) == 100
+        assert h.built is True
+
+    def test_build_resamples_downward(self):
+        from hrfunc.hrtree import HRF
+        h = HRF(
+            'doi',
+            's1_d1_hbo',
+            duration=10.0,
+            sfreq=20.0,
+            trace=np.linspace(0.0, 1.0, 200),
+            location=[0, 0, 0],
+        )
+        # Target: 5 × 10 = 50 samples
+        h.build(new_sfreq=5.0)
+        assert len(h.trace) == 50
+
+    def test_process_options_matches_hrf_processes_length(self):
+        from hrfunc.hrtree import HRF
+        h = HRF('doi', 's1_d1_hbo', 30.0, 7.81, np.zeros(10), location=[0, 0, 0])
+        assert len(h.process_options) == len(h.hrf_processes)
+        assert len(h.process_options) == len(h.process_names)
+
+
+# ---------------------------------------------------------------------------
+# NE-004: HRF.smooth actually runs without AttributeError
+# ---------------------------------------------------------------------------
+
+class TestSmooth:
+    def test_smooth_runs_without_attributeerror(self):
+        from hrfunc.hrtree import HRF
+        h = HRF('doi', 's1_d1_hbo', 30.0, 7.81, np.ones(100), location=[0, 0, 0])
+        # Pre-fix: called self.gaussian_filter1d which was never imported
+        h.smooth(2.0)
+        assert len(h.trace) == 100
+
+    def test_smooth_actually_smooths(self):
+        from hrfunc.hrtree import HRF
+        # Sharp step function
+        trace = np.concatenate([np.zeros(50), np.ones(50)])
+        h = HRF('doi', 's1_d1_hbo', 30.0, 7.81, trace, location=[0, 0, 0])
+        h.smooth(5.0)
+        # After smoothing, the midpoint should be less extreme than raw
+        mid = h.trace[49:51]
+        assert 0.0 < mid[0] < 1.0
+        assert 0.0 < mid[1] < 1.0
+
+
+# ---------------------------------------------------------------------------
+# 3.7: mutable default args are not shared across instances
+# ---------------------------------------------------------------------------
+
+class TestMutableDefaults:
+    def test_two_hrfs_have_independent_estimates(self):
+        from hrfunc.hrtree import HRF
+        a = HRF('doi_a', 'a_hbo', 30.0, 7.81, np.zeros(10), location=[0, 0, 0])
+        b = HRF('doi_b', 'b_hbo', 30.0, 7.81, np.zeros(10), location=[1, 1, 1])
+        a.estimates.append('from_a')
+        assert 'from_a' not in b.estimates
+
+    def test_two_hrfs_have_independent_locations(self):
+        from hrfunc.hrtree import HRF
+        a = HRF('doi_a', 'a_hbo', 30.0, 7.81, np.zeros(10), location=[0, 0, 0])
+        b = HRF('doi_b', 'b_hbo', 30.0, 7.81, np.zeros(10), location=[1, 1, 1])
+        a.locations.append([99, 99, 99])
+        assert [99, 99, 99] not in b.locations
+
+    def test_two_hrfs_have_independent_contexts(self):
+        from hrfunc.hrtree import HRF
+        a = HRF('doi_a', 'a_hbo', 30.0, 7.81, np.zeros(10), location=[0, 0, 0])
+        b = HRF('doi_b', 'b_hbo', 30.0, 7.81, np.zeros(10), location=[1, 1, 1])
+        a.context['task'] = 'flanker'
+        assert b.context.get('task') is None
+
+
+# ---------------------------------------------------------------------------
+# 3.10: build's plot path uses oxygenation-derived hrf_type
+# ---------------------------------------------------------------------------
+
+class TestBuildTypeField:
+    def test_build_no_longer_references_self_type(self):
+        """The build method must not read self.type (which was never set).
+        Only allowed occurrence is inside a comment explaining the fix."""
+        import inspect
+        from hrfunc.hrtree import HRF
+        src = inspect.getsource(HRF.build)
+        # Strip comment lines before searching for the attribute access
+        code_lines = [
+            line for line in src.splitlines()
+            if not line.lstrip().startswith('#')
+        ]
+        code_only = '\n'.join(code_lines)
+        assert 'self.type' not in code_only
+
+    def test_build_uses_hrf_type_helper(self):
+        import inspect
+        from hrfunc.hrtree import HRF
+        src = inspect.getsource(HRF.build)
+        assert 'hrf_type' in src


### PR DESCRIPTION
…, 3.7, 3.10)

Part of v1.2.0 correctness release. Stacks on fix/hasher-branch-correctness. Six correctness fixes to hrtree.py covering the kd-tree insert path and the HRF node class. All fixes stay inside hrtree.py; no callers needed updating.

NE-001 - tree.insert canonical label (src/hrfunc/hrtree.py)
  - Pre-fix: `self.root.context['method'] = 'canonical'` ran immediately after setting root to the first user HRF, clobbering that user's method (typically 'toeplitz') with 'canonical'. All subsequent HRFs loaded from a user file carried the wrong method.
  - Fix: label the canonical SENTINEL (self.root.right) instead. The first user HRF keeps its real method.

3.5 - tree.insert jitter (src/hrfunc/hrtree.py)
  - Pre-fix: `for val in (hrf.x, hrf.y, hrf.z): val += 1e-10` mutated a loop variable that was immediately discarded. Jitter never took effect, so duplicate-location inserts would either collide or infinite-loop depending on the later comparison.
  - Fix: assign hrf.x/y/z directly, then refresh h_val for the current axis so the jittered coordinate informs the left/right routing on the same pass.
  - Known limitation: the absolute 1e-10 offset is effective at the MNE NIRX coordinate scale (meters, ~0.1 range in float64) but loses relative precision at much larger scales. Sufficient for current users; a magnitude-relative jitter is scoped for v2.0.0.

NE-003 - HRF.__init__ process_options + spline_interp signature
  - Pre-fix: `process_options = []` made the zip in build() zero- iterate, so spline_interp was never actually called.
  - Also pre-fix: `def spline_interp(self):` had no trace parameter, so even with process_options=[None] build()'s `self.trace = process(self.trace)` pipeline would TypeError.
  - Fix: process_options = [None], and spline_interp now accepts an optional trace argument (defaulting to self.trace for backward compatibility with any direct callers). Both changes needed to satisfy the plan's exit criterion that build() actually resamples.

NE-004 - HRF.smooth gaussian filter import
  - Pre-fix: `self.trace = self.gaussian_filter1d(self.trace, a)` referenced a method that was neither imported nor defined. Any call to HRF.smooth AttributeErrored immediately.
  - Fix: `from scipy.ndimage import gaussian_filter1d` at module level, call as a free function.

3.7 - HRF.__init__ mutable default args
  - Pre-fix: `estimates=[], locations=[], context=[]` — shared mutable defaults across all HRF instances. Appending to one HRF's estimates leaked into every other HRF created from the same call site. The `context=[]` default was also the wrong TYPE — HRF uses a dict everywhere else.
  - Fix: None sentinels + per-instance materialization. context accepts either dict or None; list fallback handled for legacy.

3.10 - HRF.build self.type undefined
  - Pre-fix: `f"plots/..._{self.type}_hrf_results.png"` — self.type was never set anywhere in the class. Any build() call with plot=True AttributeErrored before emitting a file.
  - Fix: derive `hrf_type = "hbo" if self.oxygenation else "hbr"` locally inside build().

Tests: tests/test_tree_hrf.py (14 tests)
  - NE-001: first real node method preserved, canonical sentinel labeled
  - 3.5: duplicate insert actually jitters, first node coords preserved
  - NE-003: build resamples upward and downward, process_options length matches hrf_processes/process_names
  - NE-004: smooth runs without AttributeError, actually smooths a step function
  - 3.7: independent estimates/locations/context across instances
  - 3.10: build source references hrf_type, not self.type (comment-aware)

Gate: pytest tests/test_phase1a.py tests/test_phase1bc.py tests/test_phase2.py tests/test_threading.py tests/test_input_validation.py tests/test_state_lifecycle.py tests/test_oxygenation_guard.py tests/test_tree_delete_filter.py tests/test_hasher_branch.py tests/test_tree_hrf.py -> 177 passed, 0 xfailed