### PR TITLE
fix: tree.merge deep copy + nearest_neighbor empty-tree guard + load_…

### DIFF
--- a/src/hrfunc/hrfunc.py
+++ b/src/hrfunc/hrfunc.py
@@ -115,7 +115,15 @@ def load_montage(json_filename, rich = False, **kwargs):
                             f"{field!r} (rich=True)"
                         )
 
-            # create an empty HRF object
+            # Create an HRF node from the saved channel. We must pass
+            # channel['context'] through — pre-fix this was omitted, so
+            # every loaded HRF fell back to the default template context
+            # inside HRF.__init__. After NE-002 the hasher was populated
+            # correctly with channel context VALUES, but the node itself
+            # carried no task/stimulus/demographics metadata, so
+            # compare_context / filter / branch comparisons downstream
+            # silently failed to match on the real values. Caught by the
+            # cross-branch audit on fix/tree-edge-cases.
             estimated_hrf = HRF(
                 doi,
                 ch_name,
@@ -125,7 +133,8 @@ def load_montage(json_filename, rich = False, **kwargs):
                 np.asarray(channel['hrf_std'], dtype=np.float64),
                 channel['location'],
                 channel['estimates'],
-                channel['locations']
+                channel['locations'],
+                channel['context'],
             )
 
             # Insert hrf into tree and attach pointer to channel. Populate

--- a/src/hrfunc/hrtree.py
+++ b/src/hrfunc/hrtree.py
@@ -488,16 +488,24 @@ class tree:
         """
         # If first call, attach root to node
         if node == 'root':
-            if verbose: print(f"Attaching root ({(self.root.ch_name if self.root else self.root)}) to search node for {optode.ch_name} search")
+            # NE-007: explicit empty-tree early return. If the caller
+            # invokes nearest_neighbor on a tree that has never had a
+            # node inserted, self.root is None and we short-circuit
+            # before the recursive base case. Keeps the control flow
+            # obvious for future readers.
+            if self.root is None:
+                if verbose: print(f"nearest_neighbor called on empty tree — no match")
+                return None, float("inf")
+            if verbose: print(f"Attaching root ({self.root.ch_name}) to search node for {optode.ch_name} search")
             node = self.root
 
         # Handle base cases
-        if node == None: 
-            if best:
-                if verbose: print(f"No node found, returning {best[0].ch_name}")
+        if node is None:
+            if best is not None:
+                if verbose: print(f"No further branch, returning running best {best[0].ch_name}")
                 return best
             else:
-                if verbose: print("No node found, returning canonical HRF")
+                if verbose: print("No further branch and no best yet")
                 return None, float("inf")
         
         k = 3 
@@ -673,20 +681,31 @@ class tree:
 
     def merge(self, tree, node = None):
         """
-        Merge another tree into this one
-        
+        Merge another tree into this one.
+
+        NE-006: pre-fix called `self.insert(node)` with the source tree's
+        node reference, so the inserted node in `self` still carried the
+        source's left/right pointers. Subsequent kd-tree operations on
+        either tree could corrupt the other. Fix: insert a fresh copy
+        (HRF.copy returns a node with left=right=None and deep-copied
+        payload), and recurse on the SOURCE's children so we traverse
+        the full source tree rather than the (empty-children) copy.
+
         Arguments:
             tree (tree object) - Tree to merge into this one
-            node (HRF object) - Node to start merging from 
+            node (HRF object) - Node to start merging from
         """
         if node is None:
             node = tree.root
+        # Empty source tree — nothing to merge
+        if node is None:
+            return
 
-        self.insert(node)
+        self.insert(node.copy())
 
         if node.left:
             self.merge(tree, node.left)
-        
+
         if node.right:
             self.merge(tree, node.right)
 

--- a/tests/test_tree_edge_cases.py
+++ b/tests/test_tree_edge_cases.py
@@ -1,0 +1,245 @@
+"""
+Targeted unit tests for fix/tree-edge-cases.
+
+Scope:
+- **NE-006**: tree.merge now inserts node.copy() so the merged tree's
+  node structure is fully independent of the source tree. Recursion
+  still walks the SOURCE's children so the full subtree is transplanted.
+  Includes an empty-source early return.
+- **NE-007**: tree.nearest_neighbor has an explicit early return when
+  self.root is None, in addition to the recursive base case handling
+  that already existed. Keeps the control flow obvious and avoids any
+  reliance on falling through to the recursive terminal.
+
+Note: 3.8 (gather None guard) was pulled into fix/tree-delete-filter.
+
+Fast, no fNIRS data files.
+"""
+
+import pytest
+import numpy as np
+
+
+def _hrf(ch_name, x, y, z, oxygenation=True):
+    from hrfunc.hrtree import HRF
+    suffix = 'hbo' if oxygenation else 'hbr'
+    return HRF(
+        'doi',
+        f'{ch_name}_{suffix}',
+        30.0,
+        7.81,
+        np.ones(10),
+        location=[x, y, z],
+        estimates=[],
+        locations=[],
+    )
+
+
+def _collect_nodes(node, acc=None):
+    if acc is None:
+        acc = []
+    if node is None:
+        return acc
+    acc.append(node)
+    _collect_nodes(node.left, acc)
+    _collect_nodes(node.right, acc)
+    return acc
+
+
+# ---------------------------------------------------------------------------
+# NE-006: tree.merge
+# ---------------------------------------------------------------------------
+
+class TestMergeIndependence:
+    def test_merge_copies_nodes_so_source_and_dest_are_independent(self):
+        from hrfunc.hrtree import tree
+        source = tree()
+        dest = tree()
+        a = _hrf('a', 0.0, 0.0, 0.0)
+        b = _hrf('b', 1.0, 0.0, 0.0)
+        c = _hrf('c', -1.0, 0.0, 0.0)
+        source.insert(a)
+        source.insert(b)
+        source.insert(c)
+
+        dest.merge(source)
+
+        # Dest should have three nodes with the same ch_names
+        dest_names = {n.ch_name for n in _collect_nodes(dest.root)}
+        assert 'a_hbo' in dest_names
+        assert 'b_hbo' in dest_names
+        assert 'c_hbo' in dest_names
+
+        # Mutating the source must NOT affect the dest
+        a.trace = np.zeros(10)
+        a.trace[5] = 999.0
+        # Find the 'a_hbo' node in dest
+        dest_nodes = [n for n in _collect_nodes(dest.root) if n.ch_name == 'a_hbo']
+        assert len(dest_nodes) == 1
+        assert dest_nodes[0].trace[5] != 999.0  # independent copy
+
+    def test_merge_dest_nodes_are_different_objects(self):
+        from hrfunc.hrtree import tree
+        source = tree()
+        dest = tree()
+        a = _hrf('a', 0.5, 0.5, 0.5)
+        source.insert(a)
+
+        dest.merge(source)
+
+        dest_a = [n for n in _collect_nodes(dest.root) if n.ch_name == 'a_hbo']
+        assert len(dest_a) == 1
+        assert dest_a[0] is not a  # different Python object
+
+    def test_merge_empty_source_is_noop(self):
+        from hrfunc.hrtree import tree
+        source = tree()
+        dest = tree()
+        dest.insert(_hrf('existing', 0.0, 0.0, 0.0))
+        assert dest.root is not None
+
+        dest.merge(source)  # source is empty
+
+        # Dest unchanged
+        dest_names = {n.ch_name for n in _collect_nodes(dest.root)}
+        assert 'existing_hbo' in dest_names
+        assert len(dest_names) == 1
+
+    def test_merge_walks_full_source_subtree(self):
+        """Ensures the recursion happens on the source's children, not
+        the empty-children copy. Five-node tree must transplant all
+        five nodes into dest."""
+        from hrfunc.hrtree import tree
+        source = tree()
+        positions = [
+            ('a', 0.0, 0.0, 0.0),
+            ('b', 1.0, 0.0, 0.0),
+            ('c', -1.0, 0.0, 0.0),
+            ('d', 0.5, 0.5, 0.5),
+            ('e', -0.5, -0.5, -0.5),
+        ]
+        for name, x, y, z in positions:
+            source.insert(_hrf(name, x, y, z))
+
+        dest = tree()
+        dest.merge(source)
+
+        dest_names = {n.ch_name for n in _collect_nodes(dest.root)}
+        for name, _, _, _ in positions:
+            assert f'{name}_hbo' in dest_names
+
+
+# ---------------------------------------------------------------------------
+# Cross-branch audit fix: load_montage must pass channel['context'] through
+# to the HRF constructor so compare_context / filter can match on real values
+# ---------------------------------------------------------------------------
+
+class TestLoadMontageContextRoundTrip:
+    def test_loaded_hrf_carries_channel_context(self, tmp_path):
+        """Pre-fix: load_montage constructed HRFs without passing
+        channel['context'], so every loaded node fell back to the
+        default template context. The hasher was populated correctly
+        but the node itself carried no task/stimulus metadata, so
+        downstream compare_context / branch / filter would silently
+        fail to match on real values."""
+        import json
+        from hrfunc.hrfunc import load_montage
+        entry = {
+            "hrf_mean": [0.0, 0.1, 0.2, 0.1, 0.0],
+            "hrf_std": [0.0, 0.0, 0.0, 0.0, 0.0],
+            "sfreq": 7.81,
+            "location": [0.01, 0.02, 0.03],
+            "context": {
+                "task": "flanker",
+                "stimulus": "checkerboard",
+                "doi": "10.1000/test",
+                "duration": 30.0,
+                "study": "my_study",
+            },
+            "estimates": [],
+            "locations": [],
+        }
+        path = tmp_path / "m.json"
+        path.write_text(json.dumps({"S1_D1 hbo-10.1000/test": entry}))
+        m = load_montage(str(path))
+
+        # The inserted HRF must carry the channel's real context, not
+        # the default template. Grab the loaded node via self.channels.
+        assert len(m.channels) == 1
+        node = next(iter(m.channels.values()))
+        assert node.context.get('task') == 'flanker'
+        assert node.context.get('stimulus') == 'checkerboard'
+        assert node.context.get('study') == 'my_study'
+
+    def test_branch_matches_loaded_context(self, tmp_path):
+        """End-to-end: after load_montage, calling tree.branch on the
+        tree should find the loaded node by its real context value."""
+        import json
+        from hrfunc.hrfunc import load_montage
+        entry = {
+            "hrf_mean": [0.0, 0.1, 0.2, 0.1, 0.0],
+            "hrf_std": [0.0, 0.0, 0.0, 0.0, 0.0],
+            "sfreq": 7.81,
+            "location": [0.01, 0.02, 0.03],
+            "context": {
+                "task": "flanker",
+                "duration": 30.0,
+            },
+            "estimates": [],
+            "locations": [],
+        }
+        path = tmp_path / "m.json"
+        path.write_text(json.dumps({"S1_D1 hbo-10.1000/test": entry}))
+        m = load_montage(str(path))
+
+        # Branching the HbO tree on task='flanker' should match the
+        # loaded node (hasher populated by NE-002 + context now carried
+        # on the node itself).
+        branched = m.hbo_tree.branch(task='flanker')
+        user_nodes = [
+            n for n in _collect_nodes(branched.root)
+            if not n.ch_name.startswith('canonical')
+        ]
+        assert len(user_nodes) >= 1
+
+
+# ---------------------------------------------------------------------------
+# NE-007: tree.nearest_neighbor empty tree
+# ---------------------------------------------------------------------------
+
+class TestNearestNeighborEmptyTree:
+    def test_empty_tree_returns_none_inf(self):
+        from hrfunc.hrtree import tree
+        t = tree()
+        probe = _hrf('probe', 0.0, 0.0, 0.0)
+        result, distance = t.nearest_neighbor(probe, max_distance=0.01)
+        assert result is None
+        assert distance == float('inf')
+
+    def test_empty_tree_early_return_does_not_touch_self_root(self):
+        """Regression: the empty-tree path must not try to dereference
+        self.root (which is None). The early-return guard makes this
+        explicit."""
+        from hrfunc.hrtree import tree
+        t = tree()
+        probe = _hrf('probe', 0.0, 0.0, 0.0)
+        # Just confirm it doesn't raise
+        t.nearest_neighbor(probe, max_distance=0.01)
+
+    def test_single_node_tree_far_probe_returns_none(self):
+        from hrfunc.hrtree import tree
+        t = tree()
+        t.insert(_hrf('a', 0.0, 0.0, 0.0))
+        far_probe = _hrf('probe', 100.0, 100.0, 100.0)
+        result, distance = t.nearest_neighbor(far_probe, max_distance=0.01)
+        assert result is None
+
+    def test_single_node_tree_near_probe_returns_node(self):
+        from hrfunc.hrtree import tree
+        t = tree()
+        a = _hrf('a', 0.0, 0.0, 0.0)
+        t.insert(a)
+        near_probe = _hrf('probe', 1e-6, 1e-6, 1e-6)
+        result, distance = t.nearest_neighbor(near_probe, max_distance=0.01)
+        assert result is a
+        assert distance < 0.01


### PR DESCRIPTION
…montage context round-trip (NE-006, NE-007, cross-branch)

Part of v1.2.0 correctness release. Stacks on fix/canonical-hrf-sfreq. Final edge-case branch before release packaging. Also folds in one critical cross-branch regression caught by the pre-push architecture audit.

NE-006 - tree.merge shared pointer bug (src/hrfunc/hrtree.py)
  - Pre-fix: self.insert(node) re-used the source tree's node reference, so the merged tree's nodes still carried left/right pointers from the source. Subsequent kd-tree operations on either tree could corrupt the other.
  - Fix: self.insert(node.copy()) — HRF.copy returns a fresh node with left=right=None and deep-copied payload. Recursion still walks the SOURCE's children so the full subtree transplants rather than stopping at the copy's empty children.
  - Also: empty-source early return if the caller passes an empty tree.

NE-007 - nearest_neighbor empty-tree early return (src/hrfunc/hrtree.py)
  - Pre-fix: relied on the recursive base case to catch node=None after the root assignment. After S4 removed the canonical sentinel, an empty tree has self.root = None and the first recursive call would short-circuit — but the control flow was non-obvious.
  - Fix: explicit `if self.root is None: return None, float('inf')` at the top of the function, before any recursion. Keeps the empty-tree path obvious for future readers. Also tightened `== None` to `is None` and `if best:` to `if best is not None:` (best is a non-empty tuple so both were functionally identical, but `is None` is the correct style).

Cross-branch audit fix - load_montage context round-trip (src/hrfunc/hrfunc.py)
  - CAUGHT BY PRE-PUSH ARCHITECTURE REVIEW of the in-flight v1.2.0 stack.
  - The HRF constructor call at load_montage did not pass channel['context'] as the context argument (it passed estimates and locations but stopped there). Pre-NE-002 this was hidden because the hasher was populated by context dict KEYS (from _montage.context), so the node's empty-template context didn't matter — nothing searched it.
  - After fix/hasher-branch-correctness (NE-002), the hasher is now populated by channel context VALUES. But the HRF NODE still carried the default template context, so compare_context / branch / filter downstream silently failed to match on the real task, stimulus, demographics, etc. — the hasher would return the node on a value search, but copy-then-compare on the result would see empty context and fail the similarity check.
  - Fix: pass channel['context'] through to HRF.__init__ at the load_montage constructor call site. load_hrfs (hrtree.py) already did this correctly; load_montage was the outlier.

Tests: tests/test_tree_edge_cases.py (10 tests)
  - NE-006: merge copies are independent from source (trace mutation doesn't leak), merged nodes are distinct objects, empty source is a no-op, full source subtree transplants
  - NE-007: empty tree returns (None, inf), single-node-far-probe returns None, single-node-near-probe returns the node
  - Cross-branch: loaded HRFs carry their real context metadata, and tree.branch on a loaded montage finds the loaded node by its real context value

Gate: pytest tests/test_phase1a.py tests/test_phase1bc.py tests/test_phase2.py tests/test_threading.py tests/test_input_validation.py tests/test_state_lifecycle.py tests/test_oxygenation_guard.py tests/test_tree_delete_filter.py tests/test_hasher_branch.py tests/test_tree_hrf.py tests/test_canonical_hrf.py tests/test_tree_edge_cases.py -> 203 passed, 0 xfailed

Audit notes:
- Ran a comprehensive cross-branch audit of the full v1.2.0 in-flight stack (state-lifecycle, hasher-branch-correctness, tree-hrf-correctness, canonical-hrf-sfreq, tree-edge-cases) before pushing. Found one real regression (the load_montage context drop above) and otherwise the stack audited clean: no lingering self.root.right canonical references, HRF.copy round-trip still works with the 3.7 mutable- default fix, filter + delete-by-copy traversal is safe, M5 partial- load rollback still correct, sub-tree hasher population in tree.branch still mirrors load_hrfs semantics.