### PR TITLE
fix: observer.lens + typos + calc_snr sweep fixes (3.9, L1-L3, lint b…

### DIFF
--- a/src/hrfunc/hrfunc.py
+++ b/src/hrfunc/hrfunc.py
@@ -370,7 +370,7 @@ class montage(tree):
         for ind in range(events.shape[0]): # Iterate through all events
             if events[ind] != 0: # if we found an event
                 if (ind - timeshift) < 0: # Check if we can expand the event
-                    print("WARNING: An event has been ommited due to edge expansion falling outside of the scan timeframe")
+                    print("WARNING: An event has been omitted due to edge expansion falling outside of the scan timeframe")
                     continue
                 new_events[ind - timeshift] = 1
         
@@ -714,6 +714,15 @@ class montage(tree):
         Returns:
             None
         """
+        # Guard against unconfigured / empty montage: self.root is None
+        # until _merge_montages runs, and was previously dereferenced
+        # directly below. Caught by the mypy sweep.
+        if self.root is None or not self.channels:
+            raise ValueError(
+                "correlate_canonical requires a configured montage with "
+                "at least one channel; call configure() or estimate_hrf() "
+                "first so self.channels is populated."
+            )
         # Generate canonical HRF
         time_stamps = np.arange(0, len(self.root.trace), 1)
 
@@ -735,9 +744,9 @@ class montage(tree):
         plt.figure(figsize=(10, 8))
         plt.imshow(corr_matrix[:, 0][np.newaxis, :], cmap='viridis', aspect='auto')
         plt.colorbar(label='Correlation Coefficient')
-        plt.title('Correlation Matrix of HRF Estimates with Cannonical HRF')
+        plt.title('Correlation Matrix of HRF Estimates with Canonical HRF')
         plt.xlabel('Montage Channels')
-        plt.ylabel('Cannonical HRF')
+        plt.ylabel('Canonical HRF')
         plt.xticks(range(len(self.hbo_channels) + len(self.hbr_channels)), self.hbo_channels + self.hbr_channels, rotation=90)
         plt.yticks(range(1), ['Canonical'])
         plt.tight_layout()
@@ -749,9 +758,9 @@ class montage(tree):
         plt.figure(figsize=(10, 8))
         plt.imshow(corr_matrix[:, 1][np.newaxis, :], cmap='viridis', aspect='auto')
         plt.colorbar(label='P-value')
-        plt.title('P-values of Correlation with Cannonical HRF')
+        plt.title('P-values of Correlation with Canonical HRF')
         plt.xlabel('Montage Channels')
-        plt.ylabel('Cannonical HRF')
+        plt.ylabel('Canonical HRF')
         plt.xticks(range(len(self.hbo_channels) + len(self.hbr_channels)), self.hbo_channels + self.hbr_channels, rotation=90)
         plt.yticks(range(1), ['Canonical'])
         plt.tight_layout()

--- a/src/hrfunc/hrtree.py
+++ b/src/hrfunc/hrtree.py
@@ -98,7 +98,7 @@ class tree:
             self.load_hrfs(self.hrf_filename)
             print(f"Tree initialized with HRFs from {hrf_filename}")
         else:
-            print(f"Tree intiialized without HRFs loaded...")
+            print(f"Tree initialized without HRFs loaded...")
 
     def get_canonical_hrf(self, oxygenation, sfreq, duration):
         """

--- a/src/hrfunc/observer.py
+++ b/src/hrfunc/observer.py
@@ -12,10 +12,27 @@ class lens:
     This object is primarily used to calculate summary statistics of the passed in and
     preprocessed NIRX objects. This can be used to compare your output to published results
     """
-    def __init__(self, working_directory = None):
-        
+    def __init__(self, working_directory = None, sfreq = 7.81):
+        """
+        Arguments:
+            working_directory (str) - Directory to save plots / CSVs to.
+                Defaults to the current working directory.
+            sfreq (float) - Sampling frequency used by calc_snr when no
+                subject has been compared yet. Once compare_subject has
+                been called, self.sfreq is overwritten with the actual
+                preproc_nirx.info['sfreq'] so the fallback is only used
+                for the rare direct-calc-snr case.
+        """
         # Set working directory is not passed in
         self.working_directory = working_directory or os.getcwd()
+
+        # 3.9: self.sfreq was previously read by calc_snr without ever
+        # being initialized anywhere in the class, raising AttributeError
+        # on any direct SNR call before compare_subject. Initialize with
+        # a sensible default (~7.81 Hz is the HRFunc library default used
+        # for bundled HRFs) and allow override via the constructor.
+        self.sfreq = sfreq
+        self.channels = []
 
         self.metrics = {
             'Preprocessed': {
@@ -26,9 +43,9 @@ class lens:
             'Deconvolved': {
                 'kurtosis': {},
                 'skewness': {},
-                'snr': {}                
+                'snr': {}
                 },
-            'SCI': []  
+            'SCI': []
         }
 
 
@@ -37,8 +54,11 @@ class lens:
         if preproc_nirx is None:
             print(f"No data passed in...")
             return
-        
+
         self.channels = preproc_nirx.ch_names
+        # Track the scan's actual sample rate so calc_snr uses it
+        # instead of the constructor default.
+        self.sfreq = preproc_nirx.info['sfreq']
 
         # Plot the preprocessed nirx with the deconvolved with event overlays
         self.plot_nirx(subject_id, preproc_nirx, deconv_nirx, events, channel, length)
@@ -190,14 +210,29 @@ class lens:
         plt.close()
         return sci
 
-    def calc_snr(self, subject_id, nirx, state, 
-                 signal_band = (0.03, 0.1), 
-                 noise_bands = [(0.0, 0.01), (0.1, 0.5)]):
-        
+    def calc_snr(self, subject_id, nirx, state,
+                 signal_band = (0.03, 0.1),
+                 noise_bands = None):
+        """
+        Compute SNR as signal_band power / average(out-of-band power).
+
+        Bug fixes found in the lint sweep:
+        - noise_bands was a mutable default list — replaced with None
+          sentinel and materialized inside the function.
+        - The PSD calls used the wrong filtered signal: preproc_noise_fast
+          paired with noise_bands[0] (slow band), and preproc_noise_slow
+          paired with noise_bands[1] (fast band). The filters had zeroed
+          out all power in the "wrong" band, so psd_noise_slow and
+          psd_noise_fast were both near zero, making the computed SNR
+          effectively infinite. Re-wired so each band reads power from
+          the signal filtered to that band.
+        """
+        if noise_bands is None:
+            noise_bands = [(0.0, 0.01), (0.1, 0.5)]
+
         # Load data
         nirx.load_data()
-        data = nirx.get_data()
-    
+
         # Extract the signal in the desired band
         preproc_signal = nirx.copy().filter(signal_band[0], signal_band[1], fir_design='firwin')
 
@@ -208,8 +243,8 @@ class lens:
 
         # Calculate the Power Spectral Density (PSD) for signal and noise using compute_psd()
         psd_signal = preproc_signal.compute_psd(fmin = signal_band[0], fmax = signal_band[1])
-        psd_noise_slow = preproc_noise_fast.compute_psd(fmin = noise_bands[0][0], fmax = noise_bands[0][1])
-        psd_noise_fast = preproc_noise_slow.compute_psd(fmin = noise_bands[1][0], fmax = noise_bands[1][1])
+        psd_noise_slow = preproc_noise_slow.compute_psd(fmin = noise_bands[0][0], fmax = noise_bands[0][1])
+        psd_noise_fast = preproc_noise_fast.compute_psd(fmin = noise_bands[1][0], fmax = noise_bands[1][1])
 
         # Extract the power for each component
         signal_power = psd_signal.get_data().mean(axis = -1)  # Average power across frequencies for signal

--- a/tests/test_observer_and_typos.py
+++ b/tests/test_observer_and_typos.py
@@ -1,0 +1,119 @@
+"""
+Targeted unit tests for fix/observer-and-typos.
+
+Scope:
+- **3.9**: lens.__init__ initializes self.sfreq (and self.channels) so
+  calc_snr can be called directly without first running compare_subject.
+- **L1**: "Cannonical" → "Canonical" in hrfunc.py plot titles/labels.
+- **L2**: "intiialized" → "initialized" in the tree init warning.
+- **L3**: "ommited" → "omitted" in the estimate_hrf edge-expansion warning.
+
+Sweep-adjacent bug fixes (found during lint/type pass, in-scope):
+- calc_snr noise_bands mutable default replaced with None sentinel.
+- calc_snr psd_noise_slow / psd_noise_fast variable swap: pre-fix read
+  PSD from the wrong filtered signal for each band, producing near-zero
+  noise power and effectively infinite SNR.
+- montage.correlate_canonical now raises a clean ValueError on an
+  unconfigured montage instead of AttributeError on self.root.trace.
+
+Fast, no fNIRS data files.
+"""
+
+import inspect
+import pytest
+import numpy as np
+
+
+# ---------------------------------------------------------------------------
+# 3.9: lens.__init__ initializes sfreq
+# ---------------------------------------------------------------------------
+
+class TestLensSfreqInit:
+    def test_lens_has_sfreq_after_construction(self):
+        from hrfunc.observer import lens
+        observer = lens()
+        assert hasattr(observer, 'sfreq')
+        assert isinstance(observer.sfreq, (int, float))
+
+    def test_lens_accepts_sfreq_kwarg(self):
+        from hrfunc.observer import lens
+        observer = lens(sfreq=5.0)
+        assert observer.sfreq == 5.0
+
+    def test_lens_has_channels_list(self):
+        from hrfunc.observer import lens
+        observer = lens()
+        assert hasattr(observer, 'channels')
+        assert observer.channels == []
+
+
+# ---------------------------------------------------------------------------
+# L1/L2/L3: typos
+# ---------------------------------------------------------------------------
+
+class TestTyposFixed:
+    def test_cannonical_removed_from_hrfunc(self):
+        import hrfunc.hrfunc as mod
+        src = inspect.getsource(mod)
+        assert 'Cannonical' not in src
+        assert 'cannonical' not in src
+
+    def test_intiialized_removed_from_hrtree(self):
+        import hrfunc.hrtree as mod
+        src = inspect.getsource(mod)
+        assert 'intiialized' not in src
+
+    def test_ommited_removed_from_hrfunc(self):
+        import hrfunc.hrfunc as mod
+        src = inspect.getsource(mod)
+        assert 'ommited' not in src
+        # Positive: correct spelling is present
+        assert 'omitted' in src
+
+
+# ---------------------------------------------------------------------------
+# Sweep bonus: calc_snr mutable default + variable swap
+# ---------------------------------------------------------------------------
+
+class TestCalcSnrSweepFixes:
+    def test_noise_bands_default_is_none_sentinel(self):
+        from hrfunc.observer import lens
+        sig = inspect.signature(lens.calc_snr)
+        # Pre-fix was a mutable list literal default; post-fix is None
+        assert sig.parameters['noise_bands'].default is None
+
+    def test_calc_snr_wires_psd_to_correct_filtered_signal(self):
+        """Regression guard for the variable swap bug caught in the
+        lint sweep. Source inspection: psd_noise_slow must read from
+        preproc_noise_slow, and psd_noise_fast from preproc_noise_fast."""
+        from hrfunc.observer import lens
+        src = inspect.getsource(lens.calc_snr)
+        # Both correct pairings must be present
+        assert 'psd_noise_slow = preproc_noise_slow.compute_psd' in src
+        assert 'psd_noise_fast = preproc_noise_fast.compute_psd' in src
+        # The swapped pre-fix pairings must be gone
+        assert 'psd_noise_slow = preproc_noise_fast' not in src
+        assert 'psd_noise_fast = preproc_noise_slow' not in src
+
+
+# ---------------------------------------------------------------------------
+# Sweep bonus: correlate_canonical None guard
+# ---------------------------------------------------------------------------
+
+class TestCorrelateCanonicalGuard:
+    def test_correlate_canonical_raises_on_unconfigured(self):
+        from hrfunc.hrfunc import montage
+        m = montage()
+        with pytest.raises(ValueError, match="configured montage"):
+            m.correlate_canonical()
+
+    def test_guard_is_before_root_trace_access(self):
+        """The guard must fire before `len(self.root.trace)` which would
+        AttributeError on a None self.root."""
+        from hrfunc.hrfunc import montage
+        src = inspect.getsource(montage.correlate_canonical)
+        guard_idx = src.find('self.root is None')
+        access_idx = src.find('len(self.root.trace)')
+        assert guard_idx != -1
+        assert access_idx != -1
+        assert guard_idx < access_idx


### PR DESCRIPTION
…onus)

Part of v1.2.0 correctness release. Stacks on fix/tree-edge-cases. Small cleanup branch that also folds in three real bugs found by a targeted ruff + mypy sweep of src/hrfunc/. Type annotations were NOT added (v2.0.0 scope); the sweep was run as investigation only with findings triaged into correctness fixes (landed here) vs cleanup (deferred to v2.0.0).

3.9 - lens.__init__ sfreq initialization (src/hrfunc/observer.py)
  - Pre-fix: calc_snr read self.sfreq at line 262, but self.sfreq was never initialized anywhere in the class. compare_subject implicitly set self.channels but not self.sfreq, so any direct calc_snr call (or any path that reached it before compare_subject populated it) raised AttributeError.
  - Fix: __init__ now takes an sfreq kwarg (default 7.81, matching the HRFunc library's typical bundled-HRF sample rate) and initializes self.sfreq and self.channels up front. compare_subject overwrites self.sfreq with the actual scan's info['sfreq'] when invoked.

L1 - "Cannonical" -> "Canonical" (src/hrfunc/hrfunc.py)
  - Four occurrences in plot titles and axis labels for correlate_canonical. User-visible typos.

L2 - "intiialized" -> "initialized" (src/hrfunc/hrtree.py)
  - One occurrence in the tree "initialized without HRFs loaded" warning.

L3 - "ommited" -> "omitted" (src/hrfunc/hrfunc.py)
  - One occurrence in the estimate_hrf edge-expansion warning.

Sweep bonus fixes (real bugs caught by ruff/mypy, in v1.2.0 scope):

observer.calc_snr mutable default + variable swap (src/hrfunc/observer.py)
  - noise_bands default was a mutable list literal (3.7-class bug — different instances would share the same list across calls). Replaced with None sentinel and materialized inside the function.
  - More critically: the PSD computation reads from the WRONG filtered signal for each band. Pre-fix: psd_noise_slow = preproc_noise_FAST.compute_psd(slow_band) psd_noise_fast = preproc_noise_SLOW.compute_psd(fast_band) The variable names were correct but the filtered sources were swapped. preproc_noise_fast was filtered to remove everything below 0.1 Hz, so asking it for power in (0.0, 0.01) returns approximately zero. Same for the other direction. Result: both noise_power_slow and noise_power_fast near zero, noise_power near zero, SNR effectively infinite for every call. Silent scientifically wrong result.
  - Fix: re-wire so each band reads power from the signal filtered to that band. Dropped the unused `data = nirx.get_data()` line at the same time (ruff F841).

montage.correlate_canonical None-root guard (src/hrfunc/hrfunc.py)
  - Pre-fix line `time_stamps = np.arange(0, len(self.root.trace), 1)` AttributeErrored on a montage where _merge_montages had never been called (self.root = None from __init__). Caught by mypy.
  - Fix: raise a clean ValueError naming the preconditions ("requires a configured montage with at least one channel") instead of the cryptic AttributeError.

Lint/type sweep methodology:
  - Ran `ruff check src/hrfunc/ --select=E,F,B,UP,SIM,PL` (291 findings) and narrowed to real-bug rule classes (F841 unused-var, B006 mutable-default, B904 raise-without-from, PLW2901 loop-name-redef, B007 unused-loop-control). Triaged each: fixed the calc_snr findings above, dismissed the rest as either intentional (compare_context scalar wrap is a deliberate in-place shadow) or v2.0.0 cleanup (unused imports, f-string placeholders, line length).
  - Ran `mypy src/hrfunc/ --ignore-missing-imports --check-untyped-defs` (33 errors across 4 files). Most are missing annotations that v2.0.0's feat/type-hints will resolve. The only real-bug finding was the correlate_canonical None-root dereference fixed above.
  - Annotations were NOT added in this branch — type-hint work is v2.0.0 scope per the release strategy.

Tests: tests/test_observer_and_typos.py (10 tests)
  - lens.sfreq initialized, accepts kwarg, channels list present
  - Cannonical/intiialized/ommited absent from source, correct spellings present
  - calc_snr noise_bands default is None sentinel, PSD wiring reads from the correct filtered signal per band (source-level check)
  - correlate_canonical raises ValueError on unconfigured, guard fires before self.root.trace access

Gate: pytest tests/test_phase1a.py tests/test_phase1bc.py tests/test_phase2.py tests/test_threading.py tests/test_input_validation.py tests/test_state_lifecycle.py tests/test_oxygenation_guard.py tests/test_tree_delete_filter.py tests/test_hasher_branch.py tests/test_tree_hrf.py tests/test_canonical_hrf.py tests/test_tree_edge_cases.py tests/test_observer_and_typos.py -> 213 passed, 0 xfailed