### PR TITLE
docs: comprehensive refresh for v1.2.0 stack state

### DIFF
--- a/docs/external/api_reference.md
+++ b/docs/external/api_reference.md
@@ -1,0 +1,439 @@
+# HRFunc API Reference
+
+**Version:** 1.2.0 (correctness release, in flight)
+**Python:** ≥ 3.8
+**Depends on:** MNE-Python, NumPy, SciPy, nilearn, matplotlib
+
+For installation and quickstart, see the [README](../../README.md).
+For in-depth guides, visit [hrfunc.org](https://www.hrfunc.org).
+
+---
+
+## Quick Import
+
+```python
+import hrfunc as hrf
+import mne
+
+# Load your scan via MNE
+scan = mne.io.read_raw_snirf("subject_1.snirf")
+
+# Core objects
+montage = hrf.montage(scan)                 # Main estimation object
+montage = hrf.load_montage("hrfs.json")     # Load saved HRFs
+
+# Standalone functions
+montage = hrf.localize_hrfs(scan)           # Attach pre-trained HRFs
+scan = hrf.preprocess_fnirs(scan)           # Preprocess fNIRS data
+```
+
+---
+
+## Return-value capture pattern
+
+Several MNE NIRS preprocessing steps internally call `.copy().load_data()` and return a new object rather than mutating in place. HRFunc follows the same convention:
+
+```python
+# WRONG — scan is still unpreprocessed
+hrf.preprocess_fnirs(scan)
+
+# RIGHT — capture the return value
+scan = hrf.preprocess_fnirs(scan)
+if scan is None:
+    # preprocess_fnirs returns None when every channel was flagged bad
+    return
+```
+
+`montage.estimate_activity()` also returns an MNE Raw object (or `None` if all channels were bad), and must be captured the same way when you need the deconvolved data.
+
+---
+
+## `montage`
+
+The central object for HRF estimation and neural activity deconvolution.
+
+### `montage(nirx_obj=None, **kwargs)`
+
+Create a new montage, optionally configured to a specific fNIRS scan.
+
+**Parameters:**
+- `nirx_obj` (`mne.io.Raw`, optional) — fNIRS scan loaded through MNE. Accepted formats: NIRX, sNIRF, FIF. If provided, the montage is immediately configured to the scan's channels and sampling frequency.
+- `**kwargs` — Context metadata as keyword arguments. See [Context System](#context-system) below for the full list of supported keys.
+
+**Attributes after construction:**
+- `channels` (`dict`) — Maps standardized channel name → HRF node
+- `hbo_channels` / `hbr_channels` (`list`) — Channel names by oxygenation
+- `sfreq` (`float`) — Sampling frequency in Hz (only set after `configure()`)
+- `context` (`dict`) — Active context metadata
+- `configured` (`bool`) — Whether the montage has been configured to a scan
+- `hbo_tree` / `hbr_tree` (`tree`) — Bundled HRF libraries
+
+**Unconfigured instances are safe to print and introspect** — `__repr__` handles missing `sfreq` / channel lists gracefully.
+
+**Example:**
+```python
+import mne
+import hrfunc as hrf
+
+scan = mne.io.read_raw_snirf("subject_1.snirf")
+montage = hrf.montage(scan, doi="10.1000/xyz", task="flanker")
+```
+
+---
+
+### `montage.configure(nirx_obj, **kwargs)`
+
+Configure the montage against an MNE Raw object. Called automatically by `__init__` if `nirx_obj` is provided.
+
+**Failure behavior:** configure is transactional. If anything fails partway through (channel-name error, `_merge_montages` exception), the montage is rolled back to its pre-call state via the spatial tree. A re-configure attempt that fails leaves the previous configuration intact.
+
+**Parameters:**
+- `nirx_obj` (`mne.io.Raw`) — fNIRS scan
+- `**kwargs` — Additional context overrides
+
+---
+
+### `montage.estimate_hrf(nirx_obj, events, duration=30.0, lmbda=1e-3, edge_expansion=0.15, preprocess=True)`
+
+Estimate channel-wise HRFs from a single subject's fNIRS scan and event series using Toeplitz deconvolution with Tikhonov regularization.
+
+Call this once per subject. Multiple calls accumulate estimates in `montage.channels[ch_name].estimates`; call `generate_distribution()` after all subjects have been processed to compute means and standard deviations.
+
+**Parameters:**
+- `nirx_obj` (`mne.io.Raw`) — fNIRS scan
+- `events` (`list[int]`) — Binary event impulse series (0 or 1 per sample), same length as scan
+- `duration` (`float`) — HRF duration to estimate in seconds, default `30.0`. Must be `> 0`.
+- `lmbda` (`float`) — Tikhonov regularization strength, default `1e-3`. Must be `> 0`. Increase to smooth the HRF estimate; decrease for sharper (potentially noisier) estimates.
+- `edge_expansion` (`float`) — Fraction of `duration` used to pad edges to remove Toeplitz artifacts, default `0.15` (15%)
+- `preprocess` (`bool`) — If `True`, run `preprocess_fnirs()` before estimation
+
+**Raises:**
+- `ValueError` — `duration` not numeric or `<= 0`
+- `ValueError` — `events` not a list, empty, or length mismatch with scan
+- `ValueError` — `lmbda <= 0`
+
+**Returns:** `None` (HRF estimates accumulated in `montage.channels[ch_name].estimates`)
+
+**Example:**
+```python
+with open("events.txt") as f:
+    events = [int(line.strip()) for line in f]
+
+for scan in scans:
+    montage.estimate_hrf(scan, events, duration=30.0)
+
+montage.generate_distribution()
+```
+
+---
+
+### `montage.generate_distribution(plot_dir=None)`
+
+Compute the channel-wise mean HRF and standard deviation across all accumulated subject estimates. Call this after `estimate_hrf()` has been run for every subject.
+
+**Parameters:**
+- `plot_dir` (`str`, optional) — Directory path to save per-channel HRF plots. Directory must exist.
+
+**Returns:** `None` (updates `montage.channels[ch_name].trace` and `.trace_std`)
+
+---
+
+### `montage.estimate_activity(nirx_obj, lmbda=1e-4, hrf_model='toeplitz', preprocess=True, cond_thresh=None, timeout=30)`
+
+Deconvolve neural activity from a fNIRS scan using the estimated HRFs stored in the montage. Returns a new MNE Raw object with deconvolved channel data — **capture the return value**.
+
+**Parameters:**
+- `nirx_obj` (`mne.io.Raw`) — fNIRS scan to deconvolve
+- `lmbda` (`float`) — Tikhonov regularization strength, default `1e-4`. Must be `> 0`.
+- `hrf_model` (`str`) — `'toeplitz'` to use localized HRFs, or `'canonical'` to use the Glover canonical HRF for all channels (generated at the scan's actual sample rate).
+- `preprocess` (`bool`) — If `True`, run `preprocess_fnirs()` before deconvolution
+- `cond_thresh` (`float`, optional) — Condition number threshold; if exceeded, uses pseudoinverse instead of lstsq
+- `timeout` (`int`) — Maximum seconds to wait for lstsq convergence per channel, default `30`. Realistic fNIRS inputs solve in tens of milliseconds; this fires only on pathological matrices.
+
+**Behavior on failure:** If a channel's solve times out or raises any exception, the channel is dropped from both the output `nirx_obj` and the montage's `channels` / `hbo_channels` / `hbr_channels` lists, so downstream calls like `correlate_hrf()` and `generate_distribution()` don't iterate orphan entries.
+
+**Zero-trace fallback:** If a channel's HRF has an empty, `None`, or all-zero trace, `estimate_activity` transparently falls back to the canonical HRF and emits a warning. This avoids silent `NaN` propagation from dividing by `max(abs(zeros))`.
+
+**Canonical HRF matches scan sample rate:** When `hrf_model='canonical'` (or zero-trace fallback is triggered), the canonical is generated at the scan's actual `sfreq`, not a hardcoded 7.81 Hz. Each `(sfreq, duration)` pair is generated once and cached.
+
+**Raises:**
+- `ValueError` — `lmbda <= 0`
+
+**Returns:** `mne.io.Raw` — the deconvolved scan, or `None` if all channels were bad.
+
+**Example:**
+```python
+for scan in scans:
+    deconvolved = montage.estimate_activity(scan)
+    if deconvolved is not None:
+        deconvolved.save(f"neural_{scan.filenames[0]}")
+```
+
+---
+
+### `montage.localize_hrfs(max_distance=0.01, verbose=False)`
+
+Attach pre-trained HRFs from the bundled library to each channel using spatial nearest-neighbor search. Channels without a match within `max_distance` fall back to the Glover canonical HRF generated at the montage's own `sfreq`.
+
+**Parameters:**
+- `max_distance` (`float`) — Maximum Euclidean distance (in MNE coordinate units, meters) for a library HRF to be attached to an optode
+- `verbose` (`bool`) — Print search details for each channel
+
+**Returns:** `None`
+
+---
+
+### `montage.branch(**kwargs)`
+
+Return a new montage containing only channels whose HRF context matches **all** of the requested keyword filters. Values within a single kwarg are ORed.
+
+```python
+# Match any channel whose HRF was tagged task='flanker'
+flanker_montage = montage.branch(task='flanker')
+
+# Match channels tagged both task='flanker' AND stimulus='checkerboard'
+filtered = montage.branch(task='flanker', stimulus='checkerboard')
+```
+
+**Parameters:**
+- `**kwargs` — Context key/value pairs to match against each channel's HRF `context` dict
+
+**Returns:** A new `montage` with deep-copied HRF nodes for each matching channel.
+
+---
+
+### `montage.save(filename='montage_hrfs.json')`
+
+Save the montage's HRF estimates to a JSON file for later loading via `load_montage()`.
+
+**Parameters:**
+- `filename` (`str`) — Output file path, default `'montage_hrfs.json'`
+
+---
+
+### `montage.correlate_hrf(plot_filename='montage_correlation.png')`
+
+Compute Spearman rank correlations between all HbO and HbR channel HRF estimates, saving a correlation matrix plot (PNG) and the raw matrix as `correlation_matrix.json` in the current working directory.
+
+**Returns:** `np.ndarray` — correlation matrix, shape `(n_hbo, n_hbr, 2)` where `[:,:,0]` is the correlation coefficient and `[:,:,1]` is the p-value
+
+---
+
+### `montage.correlate_canonical(plot_filename='canonical_correlation.png', duration=30.0)`
+
+Correlate each channel's HRF with a double-gamma canonical HRF to assess fit quality. Requires a configured montage with at least one channel.
+
+**Raises:**
+- `ValueError` — montage has no configured channels (call `configure()` or `estimate_hrf()` first)
+
+---
+
+## `localize_hrfs(nirx_obj, max_distance=0.01, verbose=False, **kwargs)`
+
+Convenience function that creates a `montage`, attaches context kwargs, and immediately runs spatial HRF localization. Use this when you have no subject-specific HRF estimates and want to rely on the community library.
+
+**Parameters:**
+- `nirx_obj` (`mne.io.Raw`) — fNIRS scan
+- `max_distance` (`float`) — Maximum search radius for library HRF attachment
+- `verbose` (`bool`) — Print localization details
+- `**kwargs` — Context metadata (same keys as `montage.__init__`)
+
+**Returns:** Configured `montage` with library HRFs attached
+
+**Example:**
+```python
+montage = hrf.localize_hrfs(scan, max_distance=0.01, task="flanker", age_range=[5, 10])
+```
+
+---
+
+## `load_montage(json_filename, rich=False, **kwargs)`
+
+Load a previously saved montage from a JSON file. Per-entry schema validation runs on load; if any entry is malformed the whole load aborts and raises a `ValueError` naming the offending entry key and field. The caller never receives a half-populated montage.
+
+**Parameters:**
+- `json_filename` (`str`) — Path to JSON file created by `montage.save()`
+- `rich` (`bool`) — If `True`, load full per-subject estimates and locations. If `False` (default), load only mean and std.
+- `**kwargs` — Context metadata to apply to the loaded montage
+
+**Raises:**
+- `ValueError` — JSON is empty, not a dict, or first entry missing `sfreq`
+- `ValueError` — A per-entry field (`hrf_mean`, `hrf_std`, `sfreq`, `location`, `context`, `context.duration`, and with `rich=True` also `estimates`, `locations`) is missing. The wrapped exception preserves the original cause via `__cause__`.
+
+**Returns:** Configured `montage`
+
+**Example:**
+```python
+try:
+    montage = hrf.load_montage("flanker_study_hrfs.json", rich=False)
+except ValueError as e:
+    print(f"Failed to load: {e}")
+    print(f"Underlying cause: {e.__cause__}")
+```
+
+---
+
+## `preprocess_fnirs(scan, deconvolution=False)`
+
+Preprocess a raw fNIRS scan using the standard HRFunc pipeline. Returns a **new** MNE Raw object — capture the return value.
+
+**Pipeline steps:**
+1. Convert to optical density
+2. Scalp coupling index → mark bad channels (threshold < 0.5)
+3. Interpolate bad channels
+4. TDDR motion correction
+5. *(deconvolution=True only)* Polynomial detrend, order 3
+6. Beer-Lambert Law → hemoglobin concentrations
+7. Baseline correction
+8. *(deconvolution=False only)* Bandpass filter 0.01–0.2 Hz
+
+**Parameters:**
+- `scan` (`mne.io.Raw`) — Raw fNIRS scan in optical density or raw intensity format
+- `deconvolution` (`bool`) — If `True`, apply detrending instead of bandpass filtering (appropriate for deconvolution pipelines)
+
+**Returns:** Preprocessed `mne.io.Raw` (new object), or `None` if all channels were marked bad
+
+**Example:**
+```python
+preprocessed = hrf.preprocess_fnirs(scan, deconvolution=True)
+if preprocessed is None:
+    print("All channels bad — skipping subject")
+```
+
+---
+
+## `tree`
+
+The underlying k-d tree spatial data structure indexed by optode (x, y, z) coordinates. Most users interact with it indirectly through `montage`. Use directly when building custom HRF libraries.
+
+### `tree(hrf_filename=None, **kwargs)`
+
+**Parameters:**
+- `hrf_filename` (`str`, optional) — JSON file to load HRFs from on initialization
+- `**kwargs` — Context metadata for filtering
+
+**Key methods:**
+
+| Method | Description |
+|--------|-------------|
+| `insert(hrf)` | Insert an HRF node into the tree. No canonical sentinel is created; the tree is a pure kd-tree of user HRFs. |
+| `get_canonical_hrf(oxygenation, sfreq, duration)` | Lazily generate and cache a Glover canonical HRF at the requested sample rate and duration. Sentinel location `[359, 359, 359]`. |
+| `nearest_neighbor(optode, max_distance, verbose=False)` | Find the spatially nearest HRF. Returns `(HRF, distance)` on match, `(None, float("inf"))` on miss. Callers wanting a canonical fallback should call `get_canonical_hrf()`. |
+| `radius_search(optode, radius)` | Find all HRFs within Euclidean radius |
+| `filter(similarity_threshold=0.95, **kwargs)` | Remove HRFs below context similarity threshold |
+| `branch(**kwargs)` | Return a new sub-tree containing only nodes matching all supplied context kwargs (AND semantics, values-within-kwarg ORed). Empty kwargs returns an empty sub-tree. |
+| `gather(node, oxygenation=None)` | Collect all nodes as a JSON-serializable dict. Returns `{}` on `node=None`. |
+| `save(filename)` | Save tree to JSON |
+| `split_save(hbo_filename, hbr_filename)` | Save HbO and HbR HRFs to separate files |
+| `merge(other_tree)` | Merge another tree into this one. Nodes are deep-copied so the source and destination remain independent after the merge. |
+| `delete(hrf)` | Delete a node by spatial position using the standard kd-tree delete-by-copy algorithm |
+| `compare_context(first, second, context_weights=None)` | Similarity score `0.0–1.0` between two context dicts. Scalar values are auto-wrapped; missing keys in the second context count as zero matches. |
+
+---
+
+## `hasher`
+
+Open-addressed hash table used internally by `tree.branch()` to look up nodes by their context values (not keys).
+
+**Contract:**
+- `hasher.add(key, pointer)` — append pointer to the key's slot list. Duplicate `(key, pointer)` pairs are deduplicated by identity.
+- `hasher.search(key)` — returns a `list` of pointers. Empty list on miss. The returned list is a shallow copy so callers can mutate without affecting the hasher.
+
+Populated by `load_hrfs` and `load_montage` with the VALUES from each channel's context dict (e.g., `'flanker'`, `'checkerboard'`, a DOI string). Not by context dict KEYS.
+
+---
+
+## `lens`
+
+Signal quality observer. Use to compare preprocessed and deconvolved fNIRS data.
+
+### `lens(working_directory=None, sfreq=7.81)`
+
+**Parameters:**
+- `working_directory` (`str`, optional) — Directory for saving plots and CSV output. Defaults to CWD.
+- `sfreq` (`float`) — Fallback sampling frequency used if `compare_subject` has not been called. Overwritten with the actual scan's `info['sfreq']` on first compare.
+
+**Key methods:**
+
+| Method | Description |
+|--------|-------------|
+| `compare_subject(subject_id, raw_nirx, preproc_nirx, deconv_nirx, events)` | Run all QC metrics for one subject |
+| `compare_subjects()` | Aggregate metrics across subjects and generate group plots |
+| `calc_snr(subject_id, nirx, state, signal_band=(0.03, 0.1), noise_bands=None)` | Compute signal-to-noise ratio via Welch PSD. `noise_bands` defaults to `[(0.0, 0.01), (0.1, 0.5)]`. |
+| `calc_skewness_and_kurtosis(subject_id, nirx, state)` | Compute skewness and kurtosis per channel |
+| `calc_sci(subject_id, data, state)` | Compute Scalp Coupling Index |
+| `save(output_dir)` | Save all metrics to CSV files |
+
+---
+
+## Context System
+
+All context keys filter which pre-trained HRFs are retrieved from the community library. Internally the hasher keys on **values** (task name, DOI, etc.) so `tree.branch(task='flanker')` returns every HRF whose context dict contained `'flanker'`.
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `doi` | `str` | Study DOI |
+| `study` | `str` | Study name/identifier |
+| `task` | `str` | Task name (e.g., `'flanker'`, `'stroop'`, `'rest'`) |
+| `conditions` | `list` | Experimental conditions |
+| `stimulus` | `str` | Stimulus modality |
+| `intensity` | `float` | Stimulus intensity |
+| `duration` | `float` | HRF duration (seconds) |
+| `protocol` | `str` | Protocol description |
+| `age_range` | `list` | `[min_age, max_age]` |
+| `demographics` | `str` | Demographic descriptor |
+
+Context keys with `None` values are excluded from similarity comparisons. Pass context as kwargs to `montage()`, `localize_hrfs()`, or `load_montage()`.
+
+---
+
+## Units Convention
+
+**HRFunc outputs estimated HRFs and deconvolved neural activity in arbitrary units (a.u.)**, matching the fMRI BOLD analysis convention. Specifically:
+
+- `estimate_hrf` z-scores the signal before the least-squares solve and does **not** denormalize back to absolute hemoglobin concentrations. Returned HRF traces are in z-score space.
+- `estimate_activity` peak-normalizes the HRF kernel before using it as a deconvolution template. Returned neural activity is a relative deviation from baseline, not an absolute metric.
+
+This is intentional. Treat HRF shapes and neural activity traces as relative templates for comparison across conditions and subjects, not as absolute magnitudes.
+
+---
+
+## Error Handling
+
+| Exception | When raised |
+|-----------|-------------|
+| `ValueError` | Invalid duration (must be > 0), empty events, lmbda <= 0, malformed JSON schema, unconfigured montage on `correlate_canonical` |
+| `TypeError` | Non-string passed to `standardize_name` or `_is_oxygenated` |
+| `FileNotFoundError` | JSON file not found |
+| `LookupError` | Cannot determine channel oxygenation from name/wavelength |
+
+`preprocess_fnirs()` and `montage.estimate_activity()` both return `None` when all channels are bad — **always check the return value**.
+
+---
+
+## Supported fNIRS Formats
+
+HRFunc accepts any `mne.io.Raw` object. Load your data through MNE:
+
+```python
+import mne
+
+# sNIRF
+scan = mne.io.read_raw_snirf("subject.snirf")
+
+# NIRX
+scan = mne.io.read_raw_nirx("path/to/nirx_directory")
+
+# FIF
+scan = mne.io.read_raw_fif("subject.fif")
+```
+
+---
+
+## Channel Naming
+
+Channel names are standardized internally to the format `{source}_{detector}_{hbo|hbr}` (e.g., `s1_d1_hbo`). Any separator (`-`, `_`, space) and any case is accepted on input. Inputs shorter than 3 characters raise `ValueError`.
+
+Oxygenation is inferred from:
+- The `hbo`/`hbr` suffix in the channel name, OR
+- The wavelength suffix (760–780 nm → HbR, 830–850 nm → HbO)

--- a/docs/external/workflow_examples.md
+++ b/docs/external/workflow_examples.md
@@ -1,0 +1,233 @@
+# HRFunc Workflow Examples
+
+Practical end-to-end examples for the most common HRFunc workflows. Assumes you've already installed HRFunc and have a working MNE-Python environment.
+
+For reference-level documentation of each function, see [api_reference.md](api_reference.md).
+
+---
+
+## Prerequisites
+
+```bash
+pip install hrfunc mne mne-nirs
+```
+
+```python
+import mne
+import hrfunc as hrf
+import numpy as np
+```
+
+---
+
+## Workflow 1 — Localize pre-trained HRFs to a new scan
+
+Use this when you don't have subject-specific HRF estimates and want to rely on HRFunc's bundled community library. The library is spatially indexed by optode location, so each channel gets the nearest match.
+
+```python
+# Load a scan
+scan = mne.io.read_raw_snirf("subject_01.snirf")
+
+# Attach nearest-neighbor HRFs from the bundled library.
+# Context kwargs narrow the match (e.g., only flanker-task HRFs for
+# subjects aged 18-35).
+montage = hrf.localize_hrfs(
+    scan,
+    max_distance=0.01,         # meters, in MNE coordinates
+    task="flanker",
+    age_range=[18, 35],
+)
+
+# Channels without a library match within max_distance fall back to a
+# Glover canonical HRF generated at the scan's own sample rate.
+for ch_name, optode in montage.channels.items():
+    print(f"{ch_name}: method={optode.context['method']}, "
+          f"trace_length={len(optode.trace)}")
+```
+
+---
+
+## Workflow 2 — Estimate per-subject HRFs, then deconvolve neural activity
+
+Use this when you have event-aligned fNIRS scans and want to recover the HRFs first, then use them to deconvolve neural activity from the same (or different) scans.
+
+```python
+# --- Phase 1: estimate HRFs ---
+montage = hrf.montage(doi="10.1000/my-study", task="flanker")
+
+# Per subject: load scan + events, call estimate_hrf
+for subject_path, events_path in zip(subjects, events_files):
+    scan = mne.io.read_raw_snirf(subject_path)
+
+    # Events must be a binary list (0 or 1 per sample, same length as scan)
+    with open(events_path) as f:
+        events = [int(line.strip()) for line in f]
+
+    montage.estimate_hrf(
+        scan, events,
+        duration=30.0,
+        lmbda=1e-3,
+    )
+
+# Compute per-channel means and std dev across all subjects
+montage.generate_distribution(plot_dir="plots/hrfs")
+
+# Save the estimated HRFs for future reuse
+montage.save("flanker_study_hrfs.json")
+
+
+# --- Phase 2: deconvolve neural activity ---
+for subject_path in subjects:
+    scan = mne.io.read_raw_snirf(subject_path)
+
+    # estimate_activity returns a NEW MNE Raw with deconvolved channels.
+    # Capture the return value — the original scan is not mutated.
+    deconvolved = montage.estimate_activity(scan, lmbda=1e-4)
+    if deconvolved is None:
+        print(f"{subject_path}: all channels bad, skipping")
+        continue
+
+    deconvolved.save(f"neural_{subject_path.replace('.snirf', '.fif')}")
+```
+
+**Important gotchas:**
+- `estimate_hrf` and `estimate_activity` both return a new MNE Raw object (or `None`). Always capture the return value.
+- If `estimate_activity` drops a channel (timeout, solve failure, zero-trace HRF), that channel is removed from both the output scan AND the montage's `channels` / `hbo_channels` / `hbr_channels` lists. Subsequent calls to `correlate_hrf()` or `generate_distribution()` will only see the remaining channels.
+- `estimate_activity` silently falls back to the canonical HRF for any channel whose stored HRF has an empty, `None`, or all-zero trace (with a warning printed). This avoids silent `NaN` propagation.
+
+---
+
+## Workflow 3 — Load a saved montage and apply it to a new scan
+
+```python
+# Load previously saved HRFs
+montage = hrf.load_montage("flanker_study_hrfs.json")
+
+# Apply to a new scan from the same study
+new_scan = mne.io.read_raw_snirf("new_subject.snirf")
+deconvolved = montage.estimate_activity(new_scan)
+```
+
+**If the JSON is malformed:**
+```python
+try:
+    montage = hrf.load_montage("maybe_broken.json")
+except ValueError as e:
+    print(f"Failed to load: {e}")
+    # The per-entry error message names the offending entry key and field
+    print(f"Underlying cause: {e.__cause__}")
+```
+
+`load_montage` is transactional: if any entry fails schema validation, the whole load aborts and nothing is returned. You'll never get a half-populated montage.
+
+---
+
+## Workflow 4 — Filter HRFs by experimental context
+
+Use `montage.branch()` (or `tree.branch()`) to get a filtered sub-montage containing only channels whose stored HRFs match the requested context.
+
+```python
+# Load a large multi-task montage
+all_hrfs = hrf.load_montage("multi_task_library.json")
+
+# Get a sub-montage with only flanker HRFs
+flanker_only = all_hrfs.branch(task="flanker")
+
+# AND multiple kwargs
+filtered = all_hrfs.branch(task="flanker", age_range=[18, 35])
+
+# Values within a single kwarg are ORed
+flanker_or_gonogo = all_hrfs.branch(task=["flanker", "gonogo"])
+```
+
+The sub-montage is a deep copy — mutations on the branch don't affect the parent.
+
+---
+
+## Workflow 5 — QC metrics with `lens`
+
+Compare preprocessed and deconvolved data for a subject:
+
+```python
+observer = hrf.lens(working_directory="qc_outputs/")
+
+for subject_id, raw_path in subjects.items():
+    raw = mne.io.read_raw_snirf(raw_path)
+    preproc = hrf.preprocess_fnirs(raw.copy(), deconvolution=False)
+    montage = hrf.load_montage("hrfs.json")
+    deconv = montage.estimate_activity(preproc.copy())
+
+    events = load_events_for_subject(subject_id)
+    observer.compare_subject(
+        subject_id,
+        raw_nirx=raw,
+        preproc_nirx=preproc,
+        deconv_nirx=deconv,
+        events=events,
+    )
+
+observer.compare_subjects()  # Generate group-level plots
+```
+
+---
+
+## Workflow 6 — Minimal sanity check (no real data)
+
+Useful for verifying your installation works end-to-end without needing an actual fNIRS scan.
+
+```python
+import hrfunc as hrf
+
+# A bare montage loads the bundled library into hbo_tree and hbr_tree
+m = hrf.montage()
+print(m)  # Reports "unconfigured" state cleanly
+
+# Fetch a canonical HRF directly from the tree (doesn't need a scan)
+canonical = m.hbo_tree.get_canonical_hrf(
+    oxygenation=True,
+    sfreq=10.0,
+    duration=30.0,
+)
+print(f"Canonical HbO at 10 Hz, 30 s: {len(canonical.trace)} samples")
+```
+
+---
+
+## Error-handling cheat sheet
+
+| You see | What's going on |
+|---------|-----------------|
+| `ValueError: duration must be > 0` | Passed `duration=0` or negative to `estimate_hrf`. Pass a positive float. |
+| `ValueError: events list must not be empty` | Passed `events=[]`. Your event series has no events. |
+| `ValueError: lmbda must be > 0` | Regularization strength must be positive. Use `1e-3` to `1e-4` for typical fNIRS. |
+| `ValueError: load_montage: entry 'X' is missing required field 'Y'` | Your saved JSON is missing a field. Check the entry named in the error. |
+| `TypeError: standardize_name expected a str` | Passed `None` or a non-string as a channel name. Check your MNE `ch_names`. |
+| `ValueError: Channel name '...' is too short` | Channel name is under 3 characters. MNE channel names should carry at least an `hbo`/`hbr` suffix or wavelength digits. |
+| `ValueError: correlate_canonical requires a configured montage` | You called `correlate_canonical()` before any channels were added. Call `configure()` or `estimate_hrf()` first. |
+| `WARNING: HRF trace for channel X is empty or all-zero` | `estimate_activity` detected a degenerate HRF and fell back to the canonical. Not an error — the deconvolution proceeds. |
+| `lstsq exceeded 30s timeout, dropping channel` | A single channel's solve timed out. The channel is dropped from the output scan and the montage. |
+| `preprocess_fnirs()` returns `None` | All channels were flagged bad by the scalp coupling index check. Check your data quality. |
+| `estimate_activity()` returns `None` | `preprocess_fnirs` inside `estimate_activity` returned `None`. Same cause as above. |
+
+---
+
+## Units reminder
+
+HRFunc intentionally outputs HRF traces and deconvolved neural activity in **arbitrary units (a.u.)**, matching the fMRI BOLD analysis convention. Traces are z-score-normalized inputs and peak-normalized kernels; the absolute magnitude is not meaningful. Treat HRF shapes and activity traces as relative templates for comparison across conditions and subjects. See [api_reference.md](api_reference.md#units-convention) for the full rationale.
+
+---
+
+## Supported scan formats
+
+```python
+# sNIRF
+scan = mne.io.read_raw_snirf("subject.snirf")
+
+# NIRX
+scan = mne.io.read_raw_nirx("path/to/nirx_directory")
+
+# FIF (already-loaded or previously saved)
+scan = mne.io.read_raw_fif("subject.fif")
+```
+
+HRFunc accepts any `mne.io.Raw` object.

--- a/docs/internal/architecture.md
+++ b/docs/internal/architecture.md
@@ -1,0 +1,401 @@
+# HRFunc Internal Architecture
+
+**Version:** 1.2.0 (correctness release in flight)
+**Last reviewed:** 2026-04-14
+**Audience:** Contributors and maintainers
+
+---
+
+## Overview
+
+HRFunc estimates hemodynamic response functions (HRFs) and neural activity from fNIRS (functional near-infrared spectroscopy) brain imaging data. It wraps MNE-Python's Raw fNIRS objects and applies Toeplitz deconvolution with Tikhonov regularization to recover HRF shapes and neural activity timeseries.
+
+The library is used by neuroscientists to:
+1. Estimate channel-wise HRFs from event-related fNIRS scans
+2. Store and retrieve those HRFs from a community-sourced spatial library (the HRtree)
+3. Use those HRFs to deconvolve neural activity from new fNIRS scans
+
+---
+
+## Module Structure
+
+```
+src/hrfunc/
+├── __init__.py      — public exports
+├── hrfunc.py        — montage (main API), standalone functions
+├── hrtree.py        — tree (k-d tree), HRF (node/data container)
+├── hrhash.py        — hasher (open-addressed hash table)
+├── observer.py      — lens (signal quality metrics)
+├── _utils.py        — standardize_name, _is_oxygenated, _LIB_DIR
+└── hrfs/
+    ├── hbo_hrfs.json — bundled HbO HRF library
+    └── hbr_hrfs.json — bundled HbR HRF library
+```
+
+---
+
+## Module Dependency Graph
+
+```
+__init__.py
+├── hrfunc.py  ──→  hrtree.py  ──→  hrhash.py
+│                 ─→  _utils.py (standardize_name, _is_oxygenated, _LIB_DIR)
+└── observer.py  (standalone, no internal imports)
+
+hrtree.py
+├── from . import hrhash
+├── from ._utils import standardize_name, _is_oxygenated, _LIB_DIR
+└── _flatten_context_value  (module-level helper exported to hrfunc.py)
+
+hrfunc.py
+├── from .hrtree import tree, HRF, _flatten_context_value
+└── from ._utils import standardize_name, _is_oxygenated, _LIB_DIR
+```
+
+The old circular import between `hrfunc.py` and `hrtree.py` was broken during the `refactor/circular-imports-phase2` branch by extracting shared helpers into `_utils.py`. Neither `hrtree.py` nor `_utils.py` imports from `hrfunc.py` anymore.
+
+---
+
+## Class Responsibilities
+
+### `montage` (hrfunc.py)
+
+The primary user-facing object. Currently **inherits from `tree`** while also **owning two separate `tree` instances** (`self.hbo_tree`, `self.hbr_tree`). This inheritance/composition clash is the central architectural problem addressed by `refactor/composition` in v2.0.0.
+
+| Attribute | Type | Purpose |
+|-----------|------|---------|
+| `channels` | `dict[str, HRF]` | ch_name → HRF node pointer |
+| `hbo_tree` | `tree` | Spatial library of HbO HRFs (from hbo_hrfs.json) |
+| `hbr_tree` | `tree` | Spatial library of HbR HRFs (from hbr_hrfs.json) |
+| `hbo_channels` | `list[str]` | HbO channel names from nirx_obj |
+| `hbr_channels` | `list[str]` | HbR channel names from nirx_obj |
+| `sfreq` | `float` | Sampling frequency extracted from nirx_obj |
+| `context` | `dict` | Metadata applied during HRF tree filtering |
+| `context_weights` | `dict` | Per-key weights for context similarity scoring |
+| `configured` | `bool` | Whether configure() has been called with a nirx_obj |
+| `lib_dir` | `str` | Path to hrfunc package directory (for bundled JSON) |
+
+**Key methods:**
+- `configure(nirx_obj)` — transactional: commits sfreq/channel lists only on successful `_merge_montages()`; rolls back scalar/list state AND undoes tree inserts on failure (via `tree.delete`)
+- `_merge_montages(nirx_obj)` — create empty HRF nodes for each channel, link to channels dict
+- `estimate_hrf(nirx_obj, events, duration, lmbda, edge_expansion, preprocess)` — Toeplitz HRF estimation with M2a/M2b input validation at the top (duration > 0, events non-empty, lmbda > 0)
+- `estimate_activity(nirx_obj, lmbda, hrf_model, preprocess, cond_thresh, timeout)` — neural activity deconvolution. Snapshot-iterates self.channels so orphaned entries can be popped on drop. Catches generic `Exception` from the solve (not just `TimeoutError`) so every failure routes through the drop-and-cleanup path
+- `localize_hrfs(max_distance, verbose)` — k-d tree nearest-neighbor search for each channel; falls back to `tree.get_canonical_hrf` at the scan's own sfreq on miss
+- `generate_distribution()` — compute mean/std across subject estimates per channel
+- `save(filename)` — serialize montage HRFs to JSON
+- `correlate_hrf(plot_filename)` — Spearman correlation matrix across channels
+- `correlate_canonical(plot_filename, duration)` — correlation vs. double-gamma canonical HRF (raises `ValueError` on unconfigured montage)
+- `branch(**kwargs)` — reimplements sub-tree construction by iterating `self.channels` and deep-copying matching nodes. The user-facing branch API.
+
+---
+
+### `tree` (hrtree.py)
+
+A 3D k-d tree that indexes HRF estimates by optode spatial position (x, y, z in MNE's coordinate space). The splitting axis cycles through x → y → z by depth.
+
+| Attribute | Type | Purpose |
+|-----------|------|---------|
+| `root` | `HRF\|None` | Root node of the tree |
+| `hasher` | `hasher` | Context-based fast lookup table, keyed by context VALUES |
+| `context` | `dict` | Default context for filtering/branching |
+| `context_weights` | `dict` | Per-key similarity weights |
+| `branched` | `bool` | Whether branch() has been called |
+| `hrf_filename` | `str\|None` | Source JSON path if loaded from file |
+| `_canonical_cache` | `dict` | Lazy Glover HRF cache keyed on `(oxygenation, sfreq, duration)` |
+
+**Canonical HRFs are lazy (S4):** `tree.insert` does NOT create a sentinel node. The tree is a pure kd-tree of user HRFs. When a canonical is needed, callers invoke `tree.get_canonical_hrf(oxygenation, sfreq, duration)` which generates a Glover HRF at the requested sample rate, caches it, and returns an HRF node at sentinel location `[359, 359, 359]`. `nearest_neighbor` returns `(None, float("inf"))` on miss; callers handle `None` explicitly and fetch the canonical via the helper.
+
+**Key methods:**
+- `insert(hrf, depth, node)` — recursive k-d insertion; jitter branch directly mutates `hrf.x/y/z` (3.5 fix) and refreshes `h_val` for the axis routing
+- `get_canonical_hrf(oxygenation, sfreq, duration)` — lazy canonical generator with cache
+- `nearest_neighbor(optode, max_distance, ...)` — recursive k-d search; explicit early return on empty tree; returns `(HRF, distance)` or `(None, inf)` on miss
+- `radius_search(optode, radius, ...)` — collect all nodes within Euclidean radius
+- `filter(similarity_threshold, node, **kwargs)` — delete nodes below context similarity threshold. Iterates post-order so child mutations don't affect parent traversal
+- `branch(**kwargs)` — AND-on-kwargs / OR-within-kwarg semantics. Empty kwargs returns an empty sub-tree. Populates the sub-tree's hasher keyed by copied node context VALUES
+- `compare_context(first_context, second_context, context_weights)` — returns 0.0–1.0 similarity. Auto-wraps scalar values, handles missing keys in second_context, uses `weights.get(key, 1.0)` for partial weights dicts
+- `gather(node, oxygenation)` — collect all nodes into JSON-serializable dict. Returns `{}` on `node=None`
+- `delete(hrf)` / `_delete_recursive(node, hrf, depth)` — standard kd-tree delete-by-copy using `_copy_payload` helper
+- `_copy_payload(src, dst)` — copies all HRF payload fields except `left`/`right`. Uses `np.copy` for trace/trace_std and dict/list copies for context/estimates/locations to avoid aliasing. Copies the `built` flag but NOT `hrf_processes`/`process_names`/`process_options` (bound methods point to `src`)
+- `merge(tree, node)` — walks the SOURCE tree but inserts fresh `node.copy()` so merged tree is independent
+
+### Module-level helper
+
+- `_flatten_context_value(value)` — generator that yields hashable keys from a context dict value. Flattens one-level lists/tuples, skips None. Used by `load_hrfs`, `load_montage`, and `tree.branch` to bridge HRF context values (scalars or lists like `age_range=[20, 30]`) to the hasher's single-key requirement.
+
+---
+
+### `HRF` (hrtree.py)
+
+Tree node AND data container. Serves dual roles: spatial tree node (has `left`, `right` pointers and `x`, `y`, `z` coordinates) and HRF data record.
+
+| Attribute | Type | Purpose |
+|-----------|------|---------|
+| `doi` | `str` | Publication DOI for provenance tracking |
+| `ch_name` | `str` | Standardized channel name (e.g., `s1_d1_hbo`) |
+| `sfreq` | `float` | Sampling frequency of source scan |
+| `length` | `int` | Expected trace length (sfreq × duration) |
+| `oxygenation` | `bool` | True=HbO, False=HbR |
+| `trace` | `np.ndarray` | Mean HRF timeseries |
+| `trace_std` | `np.ndarray\|None` | Standard deviation over time |
+| `x, y, z` | `float` | 3D optode coordinates |
+| `estimates` | `list` | Per-subject HRF estimates (list of lists) — per-instance, not shared |
+| `locations` | `list` | Per-subject optode locations — per-instance, not shared |
+| `context` | `dict` | Experimental metadata — per-instance, not shared |
+| `left`, `right` | `HRF\|None` | k-d tree child pointers |
+| `hrf_processes` | `list` | Pipeline step bound methods (currently `[self.spline_interp]`) |
+| `process_names` | `list` | Human-readable names for each step |
+| `process_options` | `list` | Per-step options (one entry per process; `[None]` default triggers the zero-arg path) |
+| `built` | `bool` | Whether `build()` has already run |
+
+Mutable default args (`estimates=[]`, `locations=[]`, `context=[]`) were replaced with None sentinels + per-instance materialization in `fix/tree-hrf-correctness` (3.7).
+
+**Key methods:**
+- `build(new_sfreq, plot, show)` — apply the pipeline in `hrf_processes` to resample `trace` to `new_sfreq × duration` samples. Derives `hrf_type` from `self.oxygenation` locally instead of reading the never-set `self.type` (3.10).
+- `spline_interp(trace=None)` — resample `trace` (defaults to `self.trace`) via cubic spline to `self.target_length`. Accepts a trace argument so `build()` can call it through the pipeline pattern (NE-003 fix)
+- `smooth(a)` — Gaussian smoothing via the module-level `scipy.ndimage.gaussian_filter1d` (NE-004 fix — was previously calling a non-existent `self.gaussian_filter1d`)
+- `update_centroid()` — set x,y,z to mean of all locations[]
+- `copy()` — deep copy of HRF. `context`/`estimates`/`locations` are fresh, `trace`/`trace_std` are `np.copy`'d. Left/right are None.
+- `plot(plot_path, show_legend, show)` — save HRF plot PNG
+
+---
+
+### `hasher` (hrhash.py)
+
+Open-addressed hash table mapping **context values** (not keys) to lists of HRF node pointers. Used by `tree.branch()` to avoid full tree traversal when filtering by context.
+
+- Hash function: SHA3-512 (via `hashlib`)
+- Collision resolution: linear probe `(5*hashkey + 1) % capacity`
+- Resize triggers: shrink at <1/3 fill, grow at >2/3 fill
+- Tombstone deletion: removed slots marked `'!tombstone!'`
+- Storage: each slot holds a **list** of pointers (multiple HRFs can share a context value)
+
+**Contract (post-fix/hasher-branch-correctness):**
+- `add(key, pointer)` — appends pointer to the slot's list, deduplicated by identity
+- `search(key)` — returns `list[pointer]`. Empty list on miss (not `False`). Returns a shallow copy so callers can iterate safely.
+- `remove(key)` — removes the key's slot and replaces with an empty list
+
+`fill` and `double_check` methods were dead code with broken signatures; deleted in `fix/hasher-branch-correctness`.
+
+---
+
+### `lens` (observer.py)
+
+Signal quality observer for comparing preprocessed vs. deconvolved data. Standalone from the core pipeline — used for QA/QC.
+
+- Tracks: kurtosis, skewness, SNR (Welch PSD) per channel per subject
+- Outputs: CSV files (SNR, kurtosis, skewness), PNG plots
+- `__init__` initializes `self.sfreq` (default 7.81) and `self.channels = []` so direct `calc_snr` calls don't AttributeError (3.9 fix)
+- `calc_snr` takes `noise_bands=None` sentinel and materializes the default list inside the function (3.7-class fix for observer). The pre-fix variable swap between `psd_noise_slow` / `preproc_noise_fast` is fixed.
+
+---
+
+## Execution Paths
+
+### Path 1: Localize pre-trained HRFs to optodes
+```
+localize_hrfs(nirx_obj, max_distance=0.01, **kwargs)
+  → montage.__init__(nirx_obj, **kwargs)
+      → self.hbo_tree = tree("hbo_hrfs.json")   # loads pre-trained library
+      → self.hbr_tree = tree("hbr_hrfs.json")
+      → self.configure(nirx_obj)
+          → extract sfreq, hbo_channels, hbr_channels
+          → _merge_montages(nirx_obj): for each channel, nearest_neighbor(empty_hrf, 1e-9)
+          → commit on success; roll back on failure (including tree.delete of newly-inserted nodes)
+  → montage.localize_hrfs(max_distance)
+      → for ch_name in self.channels:
+          hrf, dist = hbo_tree.nearest_neighbor(optode, max_distance)  # or hbr_tree
+          if hrf is not None: attach hrf.trace, hrf.trace_std to optode
+          else: attach canonical trace from hbo_tree.get_canonical_hrf(True, self.sfreq, duration)
+→ return montage
+```
+
+### Path 2: Estimate HRFs from events
+```
+montage.estimate_hrf(nirx_obj, events, duration=30.0, lmbda=1e-3, edge_expansion=0.15)
+  → M2a/M2b validation: duration > 0, events non-empty list, lmbda > 0
+  → configure(nirx_obj) if not configured
+  → if preprocess: nirx_obj = preprocess_fnirs(nirx_obj, deconvolution=True)
+      (if preprocess_fnirs returns None → early return)
+  → nirx_obj.load_data()  (AFTER preprocessing — 1.8 pipeline ordering fix)
+  → data = nirx_obj.get_data()
+  → Expand events by edge_expansion to account for Toeplitz edge artifacts
+  → X = scipy.linalg.toeplitz(events, zeros(hrf_len))
+  → for each channel:
+      Y = (signal - mean) / std                           # z-score normalize
+      lhs = X.T @ X + lmbda * I
+      rhs = X.T @ Y
+      hrf_estimate = solve_lstsq(lhs, rhs)
+      hrf_estimate = hrf_estimate[timeshift:-timeshift]   # remove edge artifacts
+      optode.estimates.append(hrf_estimate)
+      optode.locations.append(channel_loc)
+```
+
+### Path 3: Deconvolve neural activity
+```
+montage.estimate_activity(nirx_obj, lmbda=1e-4, hrf_model='toeplitz', timeout=30)
+  → M2b validation: lmbda > 0
+  → configure(nirx_obj) if not configured
+  → nirx_obj = preprocess_fnirs(nirx_obj, deconvolution=True)   # captures return
+      (return None early if all channels bad)
+  → success = None  (outer-scope declaration for nonlocal closure write)
+  → dropped_channels = []
+  → for ch_name in list(self.channels.keys()):  (snapshot iteration)
+      hrf = self.channels[ch_name]
+      success = None
+      if 'global' in ch_name: continue
+
+      # H1: zero-trace guard
+      trace_invalid = (hrf.trace is None or len(hrf.trace) == 0
+                       or np.max(np.abs(hrf.trace)) == 0)
+      if trace_invalid and hrf_model != 'canonical':
+          print warning; fall through to canonical branch
+
+      if hrf_model == 'canonical' or trace_invalid:
+          # S4: canonical generated at the scan's own sfreq
+          hrf = self.hbo_tree.get_canonical_hrf(True, self.sfreq, duration)  # or hbr
+
+      Closure deconvolution(nirx):         # captures hrf, lmbda, cond_thresh, timeout
+        Y = (nirx - mean) / std
+        hrf_kernel = hrf.trace / np.max(np.abs(hrf.trace))
+        A = scipy.linalg.toeplitz(hrf_kernel, ...)
+        lhs = A.T @ A + lmbda * I
+        rhs = A.T @ Y
+        with ThreadPoolExecutor(max_workers=1):
+          try: deconvolved = solve_lstsq(lhs, rhs, cond_thresh); success = True
+          except TimeoutError: deconvolved = nirx; success = False
+          except Exception: deconvolved = nirx; success = False   # M4: catch-all
+        return deconvolved
+      nirx_obj.apply_function(deconvolution, picks=[ch_name])
+
+      if success is False:
+          nirx_obj.drop_channels([ch_name])
+          dropped_channels.append(ch_name)
+
+  # M4 post-loop cleanup: pop dropped channels from self.channels and lists
+  for ch_name in dropped_channels:
+      self.channels.pop(ch_name, None)
+      if ch_name in self.hbo_channels: self.hbo_channels.remove(ch_name)
+      if ch_name in self.hbr_channels: self.hbr_channels.remove(ch_name)
+  return nirx_obj
+```
+
+**Why the closure pattern**: `mne.Raw.apply_function()` requires a single-argument callable `f(channel_data) → channel_data`. Extra parameters (hrf kernel, lambda, etc.) must be captured via closure. This constraint prevents clean abstraction of deconvolution logic between `estimate_hrf` and `estimate_activity`. (See `project_deconvolution_quirk.md` memory for the full explanation.)
+
+### Path 4: Load montage from JSON
+```
+load_montage(json_filename, rich=False, **kwargs)
+  → parse JSON
+  → M3 validation: json_contents must be non-empty dict; first entry must contain sfreq
+  → montage(**kwargs)   # fresh montage with library hbo_tree/hbr_tree
+  → for each JSON entry (M5 per-entry try/except):
+      → M3 per-entry schema validation (hrf_mean, hrf_std, sfreq, location, context, context.duration)
+      → create HRF with channel['context']  (cross-branch fix: pre-fix omitted this argument)
+      → insert into hbo_tree or hbr_tree
+      → populate target tree's hasher keyed by channel context VALUES (NE-002)
+  → on any exception: raise ValueError naming the entry key; local _montage dropped
+  → return _montage
+```
+
+---
+
+## Data Preprocessing Pipeline (preprocess_fnirs)
+
+```
+mne.Raw (optical density)
+  1. mne.preprocessing.nirs.optical_density()
+  2. mne.preprocessing.nirs.scalp_coupling_index() → mark bad channels (threshold < 0.5)
+  3. mne.interpolate_bads()
+  4. mne.preprocessing.nirs.tddr()                  # motion correction
+  5. [deconvolution=True] polynomial detrend (order 3)
+  6. mne.preprocessing.nirs.beer_lambert_law(ppf=0.1)  # experimental ppf value — see plan
+  7. raw.apply_baseline((None, 0))
+  8. [deconvolution=False] raw.filter(0.01, 0.2)     # hemodynamic bandpass
+→ mne.Raw (hemoglobin concentrations) — NEW OBJECT, caller must capture
+```
+
+Note: the `ppf=0.1` value is under experimental validation in `experiment/ppf-validation`. MNE's default is `6.0`. The resolution of this question is pending Denny's experimental test on real data.
+
+---
+
+## File I/O Schema
+
+### HRF JSON format
+```json
+{
+  "{ch_name}-{doi}": {
+    "hrf_mean": [float, ...],
+    "hrf_std": [float, ...],
+    "location": [x, y, z],
+    "oxygenation": bool,
+    "sfreq": float,
+    "context": {
+      "method": "toeplitz",
+      "doi": "...",
+      "study": "...",
+      "task": "...",
+      "conditions": [...],
+      "stimulus": "...",
+      "intensity": 1.0,
+      "duration": 30.0,
+      "protocol": "...",
+      "age_range": [...],
+      "demographics": "..."
+    },
+    "estimates": [[float, ...], ...],
+    "locations": [[x, y, z], ...]
+  }
+}
+```
+
+### Channel name standardization
+Channel names are standardized via `_utils.standardize_name()` before any dict lookup:
+1. Short-name and type guards (raises `TypeError`/`ValueError` on bad input)
+2. Replace separators `[-_\s]+` → `_`
+3. Lowercase
+4. Normalize suffix: `hbo` or `hbr`
+
+`_utils._is_oxygenated` has its own matching guards so direct callers (in configure, load_montage, etc.) also get clean errors on degenerate input.
+
+---
+
+## Hasher Data Model
+
+Each slot in the `hasher.contexts` array holds a `list` of HRF node pointers. `add` appends, `search` returns the full list (shallow copy). `load_hrfs` and `load_montage` populate the hasher with each channel's context VALUES (e.g., `'flanker'`, `'checkerboard'`, a DOI string, or each element of `age_range`). `tree.branch(task='flanker')` then searches for `'flanker'` as a hasher key and gets back every node whose context dict contained it anywhere.
+
+The `_flatten_context_value` helper bridges the gap between HRF context values (scalars, lists, or None) and the hasher's single-hashable-key requirement.
+
+---
+
+## Units Convention (intentional)
+
+HRFunc intentionally outputs HRF traces and deconvolved neural activity in **arbitrary units (a.u.)**, matching the fMRI BOLD analysis convention:
+
+- `estimate_hrf` z-scores the input signal before the least-squares solve and does not denormalize back to absolute hemoglobin concentrations. Returned HRF traces are in z-score space.
+- `estimate_activity` peak-normalizes the HRF kernel (`hrf.trace / np.max(np.abs(hrf.trace))`) before using it as a deconvolution template. Returned activity is relative deviation from baseline.
+
+This is NOT a bug — past code reviews have flagged it as one. Do not "fix" it. See the `project_unit_conventions.md` memory for the full rationale.
+
+---
+
+## Known Architectural Problems (scope: v2.0.0)
+
+The v1.2.0 correctness release fixed all the crash-class, silent-wrong-result, and input-validation issues. Remaining architectural problems are all scoped to v2.0.0:
+
+1. **`class montage(tree)` inheritance clash** — montage both inherits from tree (has its own root, insert, etc.) AND owns hbo_tree/hbr_tree. Fixed by `refactor/composition`.
+2. **No structured logging** — `print()` everywhere. Fixed by `feat/logging`.
+3. **No type hints** — mypy can't give us much structure. Fixed by `feat/type-hints`.
+4. **Magic numbers scattered through the code** — Fixed by `feat/constants`.
+5. **Integration tests crash pytest on collection (KI-033)** — module-level code in `test_estimation.py` and `test_localization.py`. Fixed by `feat/test-suite-restructure`.
+6. **Sequential channel solves in `estimate_activity`** — one ThreadPoolExecutor per channel. Fixed by `perf/estimate-activity-parallel` after `refactor/shared-helpers`.
+7. **Sequential batch solves in `estimate_hrf`** — one lstsq per channel. Fixed by `perf/estimate-hrf-batch`.
+8. **Absolute 1e-10 jitter in `insert`** — effective at MNE NIRX meter scale but loses relative precision at much larger coordinate scales. Flagged for v2.0.0 magnitude-relative jitter.
+
+---
+
+## References
+
+- Plan roadmap: [docs/plans/phase_breakdown.md](../plans/phase_breakdown.md)
+- v1.2.0 detailed plan: [docs/plans/plan_v1_2_0.md](../plans/plan_v1_2_0.md)
+- v2.0.0 detailed plan: [docs/plans/plan_v2_0_0.md](../plans/plan_v2_0_0.md)
+- Known issues (open + resolved catalog): [known_issues.md](known_issues.md)
+- v1.2.0 change summary: [v1_2_0_changelog_summary.md](v1_2_0_changelog_summary.md)

--- a/docs/internal/known_issues.md
+++ b/docs/internal/known_issues.md
@@ -1,0 +1,159 @@
+# HRFunc Known Issues
+
+**Status as of:** 2026-04-14
+**Active work:** v1.2.0 correctness release (10 branches in flight, 6 merged to main, 4 pushed pending merge)
+**Audience:** Contributors — see [plan_v1_2_0.md](../plans/plan_v1_2_0.md) and [plan_v2_0_0.md](../plans/plan_v2_0_0.md) for where each open issue is scoped.
+
+Issues are grouped by status. File:line references are to the codebase as of this revision.
+
+---
+
+## RESOLVED in v1.2.0 (in flight)
+
+The following issues have been fixed on feature branches in the v1.2.0 correctness chain. Some are merged to main, others are pushed but pending merge. See [v1_2_0_changelog_summary.md](v1_2_0_changelog_summary.md) for per-branch attribution.
+
+### Critical — silent data corruption, wrong scientific results
+
+| ID | Summary | Fixed in |
+|----|---------|----------|
+| KI-001 | `tree.filter()` condition inverted — deleted matching nodes instead of non-matching | `fix/critical-bugs-phase1a` |
+| KI-002 | Mutable default args in `HRF.__init__` (`estimates=[], locations=[], context=[]`) | `fix/tree-hrf-correctness` (3.7) |
+| KI-003 | `hasher.contexts = [[]] * capacity` shared list references in three locations | `fix/critical-bugs-phase1bc` |
+| KI-004 | `ValueError` returned instead of raised in multiple validators | `fix/critical-bugs-phase1a` |
+| KI-005 | `estimate_hrf` loaded data before preprocessing | `fix/critical-bugs-phase1bc` |
+| KI-006 | `estimate_activity` preprocess return value not captured | `fix/critical-bugs-phase1bc` |
+| KI-007 | `load_montage` discarded inserted HRF nodes via duplicate tree re-init | `fix/critical-bugs-phase1bc` |
+| NE-001 | `tree.insert` stamped `context['method']='canonical'` on first user HRF (clobbered user data) | `fix/tree-hrf-correctness` |
+| NE-002 | `load_hrfs`/`load_montage` populated hasher by dict KEYS; `tree.branch` searched by VALUES | `fix/hasher-branch-correctness` |
+| S4 | Hardcoded canonical HRF at `t_r=0.128` regardless of scan sfreq | `fix/canonical-hrf-sfreq` |
+| H1 | Zero-trace HRFs produced silent NaN in `estimate_activity` (division by `max(abs(zeros))`) | `fix/input-validation` |
+| — | `calc_snr` PSD variable swap — each band read from the signal filtered to the WRONG band, noise power ≈ 0, SNR effectively infinite | `fix/observer-and-typos` (lint-sweep bonus) |
+| — | `load_montage` dropped `channel['context']` when constructing HRF nodes — post-NE-002 this broke `compare_context` / branch / filter on loaded montages | `fix/tree-edge-cases` (cross-branch audit) |
+
+### High — crashes or wrong algorithm behavior
+
+| ID | Summary | Fixed in |
+|----|---------|----------|
+| KI-008 | `hasher.probe_count` never initialized in `__init__` | `fix/critical-bugs-phase1bc` |
+| KI-009 | `tree._delete_recursive` 5-arg-to-3-arg signature mismatch + non-existent `node.hrf_data` | `fix/tree-delete-filter` |
+| KI-010 | `compare_context` signature mismatch with callers | `fix/critical-bugs-phase1bc` |
+| KI-011 | `compare_context` wrong denominator (`len(first_context)` vs `len(values)`) | `fix/critical-bugs-phase1bc` |
+| KI-012 | Divide-by-zero guards in `hasher.__repr__` and `compare_context` | `fix/critical-bugs-phase1bc`, `fix/hasher-branch-correctness` |
+| KI-013 / 3.5 | Jitter loop variable bug — pre-fix mutated a temp var, not `hrf.x/y/z` | `fix/tree-hrf-correctness` |
+| KI-014 | `hasher.search` could infinite-loop on full table | `fix/critical-bugs-phase1bc` |
+| KI-015 / 3.8 | `tree.gather(None)` crashed on `.left` access | `fix/tree-delete-filter` |
+| KI-016 | `double_probe(key, hashkey, False)` passed `False` as the linear coefficient | `fix/critical-bugs-phase1a` |
+| KI-017 / 3.9 | `lens.__init__` didn't initialize `self.sfreq`; `calc_snr` AttributeError'd | `fix/observer-and-typos` |
+| KI-018 / 3.10 | `HRF.build` referenced the never-set `self.type` | `fix/tree-hrf-correctness` |
+| NE-003 | `HRF.process_options=[]` made `build()` zip zero-iterate; `spline_interp` took no trace arg | `fix/tree-hrf-correctness` |
+| NE-004 | `HRF.smooth` called `self.gaussian_filter1d` which was never imported | `fix/tree-hrf-correctness` |
+| NE-006 | `tree.merge` inserted source node references, sharing mutable child pointers | `fix/tree-edge-cases` |
+| NE-007 | `tree.nearest_neighbor` fallback returned `self.root.right` which crashed on empty tree | `fix/canonical-hrf-sfreq` + explicit guard in `fix/tree-edge-cases` |
+| H2 | Same as KI-009 (delete path) | `fix/tree-delete-filter` |
+| H3 | `montage.__repr__` crashed on unconfigured montage | `fix/state-lifecycle` |
+| H4 | `hasher.search` returned `False` on miss; `tree.branch` TypeError'd on `for node in False:` | `fix/hasher-branch-correctness` |
+
+### Medium — behavioral issues
+
+| ID | Summary | Fixed in |
+|----|---------|----------|
+| KI-019 / ND-003 | `success` variable scope broken in `estimate_activity` closure (non-local write) | `fix/estimate-activity-threading` |
+| KI-020 / ND-004 | `timeout=1500` was seconds (25 minutes), not the intended ~seconds | `fix/estimate-activity-threading` (now default 30) |
+| KI-025 | `preprocess_fnirs` crashed on missing `subject_info` | `fix/critical-bugs-phase1bc` |
+| KI-026 | f-string nested-quote syntax error in `montage.__repr__` | `fix/critical-bugs-phase1a` |
+| KI-027 | Missing `scipy.stats` import | `fix/critical-bugs-phase1a` |
+| KI-028 | `hasher.fill()` broken signature (dead code) | `fix/hasher-branch-correctness` (deleted) |
+| M1 | `standardize_name` / `_is_oxygenated` crashed on short/non-str inputs | `fix/input-validation` + `fix/oxygenation-guard` |
+| M2 | Missing `lmbda≤0`, `duration≤0`, empty-events validation | `fix/input-validation` |
+| M3 | `load_montage` cryptic `KeyError` on malformed JSON | `fix/input-validation` |
+| M4 | `estimate_activity` left orphaned channel entries after drop | `fix/state-lifecycle` |
+| M5 | `load_montage` partial-failure could return half-populated montage | `fix/state-lifecycle` |
+| M6 | `configure()` committed state before `_merge_montages` could fail | `fix/tree-delete-filter` (moved from `fix/state-lifecycle` because it needed working `tree.delete`) |
+| L1 | "Cannonical" → "Canonical" (4 occurrences) | `fix/observer-and-typos` |
+| L2 | "intiialized" → "initialized" | `fix/observer-and-typos` |
+| L3 | "ommited" → "omitted" | `fix/observer-and-typos` |
+
+### Newly discovered, also resolved
+
+| ID | Summary | Fixed in |
+|----|---------|----------|
+| ND-001 | `filter()` threshold comparison inverted (`>` → `<`) | `fix/critical-bugs-phase1a` |
+| ND-002 | `compare_context` denominator (same as KI-011) | `fix/critical-bugs-phase1bc` |
+
+---
+
+## OPEN — scheduled for v1.2.0
+
+### `experiment/ppf-validation` (S1)
+
+| File:Line | Issue |
+|-----------|-------|
+| `hrfunc.py` `preprocess_fnirs` | `ppf=0.1` vs MNE default `ppf=6.0`. Likely a bug from early exploration, but Denny will validate experimentally on a real dataset before deciding. Blocks `release/1.2.0`. |
+
+### `release/1.2.0`
+
+Packaging and release mechanics:
+- `pyproject.toml` dependency lower-bound pins
+- `pyproject.toml` `[tool.setuptools.package-data]` for `hrfs/*.json`
+- `MANIFEST.in` sdist inclusion
+- Version bump to `1.2.0`
+- CHANGELOG.md entry
+- Tag + PyPI upload
+
+---
+
+## OPEN — scheduled for v2.0.0
+
+### Architectural refactors
+
+| ID | File | Issue | v2.0.0 branch |
+|----|------|-------|----------------|
+| KI-024 | `hrfunc.py` | `class montage(tree)` inheritance clash with `hbo_tree`/`hbr_tree` composition | `refactor/composition` |
+| KI-031 | All modules | No logging infrastructure — `print()` everywhere | `feat/logging` |
+| — | All modules | No type hints; mypy cannot verify much structure | `feat/type-hints` |
+| — | All modules | Magic numbers throughout (`0.01`, `0.128`, `7.81`, `30.0`, `0.1`, `0.2`, `1e-3`, `1e-4`) | `feat/constants` |
+| KI-032 | All modules | Class names don't follow PascalCase (`montage`, `tree`, `lens`, `hasher`) | `refactor/composition` (pick up naming while we're in there) |
+| KI-033 | `tests/test_estimation.py`, `tests/test_localization.py` | Module-level code crashes pytest on collection | `feat/test-suite-restructure` |
+| KI-034 | `tests/test_hashing.py` | Empty test file | `feat/test-suite-restructure` |
+| KI-022 | `hrfunc.py` `correlate_hrf` | Hardcoded `correlation_matrix.json` write to CWD regardless of working directory | `refactor/shared-helpers` |
+| — | `hrtree.py` `tree.insert` | Absolute `1e-10` jitter loses relative precision at large coordinate scales (flagged in `fix/tree-hrf-correctness` data-integrity review) | v2.0.0 magnitude-relative jitter |
+| KI-021 | `hrtree.py` `HRF.copy()` | `dict(self.context)` shallow copy — nested lists/dicts in context still shared across branched trees | `refactor/shared-helpers` |
+
+### Performance
+
+| ID | Issue | v2.0.0 branch |
+|----|-------|----------------|
+| — | `estimate_hrf` solves one channel at a time; batch solve via `np.linalg.solve` gives ~20–40× speedup | `perf/estimate-hrf-batch` |
+| — | `estimate_activity` solves one channel at a time; parallel solve with `ThreadPoolExecutor(max_workers=N)` gives ~N× speedup | `perf/estimate-activity-parallel` |
+
+### Nice-to-haves
+
+| ID | Issue | v2.0.0 branch |
+|----|-------|----------------|
+| — | `estimate_hrf` silently drops events that fall outside the scan timeframe after edge expansion; should count and report | `feat/event-edge-warning` |
+| — | Nicer error messages for JSON load/save edge cases | `feat/robustness-io` |
+| — | Adaptive `lmbda` scaling with matrix norm | `feat/adaptive-regularization` (needs design work) |
+| KI-029 | No dependency version pins in `pyproject.toml` | `release/1.2.0` (moved from v2.0.0 — needed for PyPI release) |
+| KI-030 | Bundled HRF JSON not declared in `[tool.setuptools.package-data]` | `release/1.2.0` |
+
+### Documentation
+
+| ID | Issue | v2.0.0 branch |
+|----|-------|----------------|
+| KI-023 | README code examples had syntax errors and typos | Fixed directly in a README PR (or bundle into release/1.2.0) |
+
+---
+
+## Issue ID key
+
+| Prefix | Source |
+|--------|--------|
+| `KI-NNN` | Original "known issues" catalog from the first code review (2026-04-13) |
+| `NE-NNN` | "Newly discovered" during the 2026-04-13 code review |
+| `ND-NNN` | Non-deterministic / threading issues discovered during `fix/estimate-activity-threading` scoping |
+| `S1–S4` | Scientific correctness issues from the 2026-04-14 parallel review |
+| `H1–H4` | High-priority issues from the same review |
+| `M1–M6` | Medium issues from the same review |
+| `L1–L3` | Low-priority typos from the same review |
+
+All issue IDs are stable once assigned. Fixed issues are preserved in this file for traceability; do not delete them.

--- a/docs/internal/v1_2_0_changelog_summary.md
+++ b/docs/internal/v1_2_0_changelog_summary.md
@@ -1,0 +1,190 @@
+# HRFunc v1.2.0 — Change Summary
+
+**Release type:** Correctness release (minor version bump 1.1.2 → 1.2.0)
+**Strategy:** Fix every crash, silent-wrong-result, and input-validation hole without changing architecture. See [../plans/plan_v1_2_0.md](../plans/plan_v1_2_0.md) for the detailed plan.
+
+This document is the authoritative per-branch change summary for use when writing the CHANGELOG.md entry, PyPI release notes, and GitHub release.
+
+---
+
+## Branch chain (in dependency order)
+
+1. `fix/critical-bugs-phase1a`
+2. `fix/critical-bugs-phase1bc`
+3. `refactor/circular-imports-phase2`
+4. `fix/estimate-activity-threading`
+5. `fix/input-validation`
+6. `fix/state-lifecycle`
+7. `fix/oxygenation-guard` (mini-branch)
+8. `fix/tree-delete-filter`
+9. `fix/hasher-branch-correctness`
+10. `fix/tree-hrf-correctness`
+11. `fix/canonical-hrf-sfreq`
+12. `fix/tree-edge-cases`
+13. `fix/observer-and-typos`
+14. `experiment/ppf-validation` *(pending Denny's experimental validation)*
+15. `release/1.2.0` *(pending)*
+
+---
+
+## What changed, grouped by theme
+
+### Bug fixes — pipeline correctness
+
+- **Pipeline ordering** in `estimate_hrf`: data loaded AFTER preprocessing instead of before, so deconvolution runs on HbO/HbR data instead of raw intensity (1.8)
+- **`preprocess_fnirs` return capture** in `estimate_activity`: the preprocessed haemo object is now assigned back, preventing deconvolution on unprocessed data (1.9)
+- **`load_montage` tree overwrite**: removed the duplicate `hbo_tree = tree(...)` / `hbr_tree = tree(...)` re-init at the end of load_montage that was discarding all just-inserted user HRFs (1.10)
+- **`preprocess_fnirs` subject_info guard**: no longer crashes on `raw_od.info['subject_info']['his_id']` when subject_info is None (1.11)
+- **`_is_oxygenated` fallthrough**: unrecognized channel names now raise a clean `ValueError` instead of falling through silently (1.12)
+- **`filter()` threshold comparison**: inverted `>` to `<` so nodes BELOW the similarity threshold are deleted instead of nodes ABOVE it (ND-001)
+- **`compare_context` denominator**: divides by `len(values)` (number of values for the current key) instead of `len(first_context)` (total keys) so multi-value contexts aren't underweighted (ND-002)
+- **`estimate_activity` threading scope**: `nonlocal success` declaration added inside the deconvolution closure so the outer drop-channel check actually sees the closure's write (ND-003)
+- **`estimate_activity` timeout default**: changed from `1500` (seconds = 25 minutes) to `30` seconds (ND-004)
+- **`estimate_activity` return value**: returns `nirx_obj` (or `None` when all channels were bad) instead of implicit `None` (1.16)
+- **`polynomial_detrend` order**: reverted from 1 back to 3 to match documentation (Q2 resolved)
+
+### Bug fixes — data structures
+
+- **`hasher.probe_count`** initialized in `__init__` — first probe call no longer AttributeErrors (KI-008, 1.3)
+- **`hasher.contexts`** now uses `[[] for _ in range(capacity)]` instead of `[[]] * capacity` in three locations (init, `fill`, `resize`) so slots don't share list references (KI-003, 1.14)
+- **`hasher.__repr__`** ZeroDivisionError guard when `size == 0` (KI-012, 1.15)
+- **`hasher.search`** cycle detection stops the probe loop at capacity steps instead of infinite-looping on a full table (KI-014, 1.17)
+- **`hasher.add`** now appends pointers to a per-slot list with identity deduplication (3.3)
+- **`hasher.search`** returns `list[pointer]` (empty on miss) instead of scalar-or-False (H4)
+- **`hasher.fill` / `hasher.double_check`** deleted as broken / dead code (3.4)
+- **`tree._delete_recursive`** rewritten with a new `_copy_payload` helper. Pre-fix had a 5-arg-to-3-arg recursive call mismatch and referenced the non-existent `node.hrf_data` attribute. (KI-009 / H2)
+- **`_copy_payload`** copies all HRF payload fields except `left`/`right` children, `np.copy`s trace/trace_std to avoid aliasing, copies the `built` flag, and intentionally does NOT copy `hrf_processes`/`process_names`/`process_options` (bound methods that would cross-reference `src` into `dst`)
+- **`tree.gather(None)`** returns `{}` instead of crashing on `node.left` access (3.8)
+- **`tree.merge`** inserts `node.copy()` so the merged tree's nodes are independent from the source; recursion still walks the SOURCE's children to traverse the full subtree (NE-006)
+- **`tree.nearest_neighbor`** explicit `if self.root is None: return None, float("inf")` early return, plus tightened `== None` / `if best:` to `is None` / `is not None` (NE-007)
+- **`tree.insert`** jitter branch directly mutates `hrf.x/y/z` instead of a loop variable; refreshes `h_val` for the current axis routing (3.5, KI-013)
+- **`tree.insert`** first-insert path no longer stamps `context['method'] = 'canonical'` on the user's first HRF (NE-001)
+- **`tree.insert`** no longer creates an eager canonical sentinel at `root.right` (S4 — see "canonical HRF" section below)
+- **`HRF.__init__`** mutable default args (`estimates=[], locations=[], context=[]`) replaced with `None` sentinels and per-instance materialization (3.7, KI-002)
+- **`HRF.__init__`** `process_options = [None]` so `build()`'s zip produces one iteration (pre-fix was `[]` causing zero iterations) (NE-003)
+- **`HRF.build`** derives `hrf_type` from `self.oxygenation` instead of reading the never-set `self.type` (3.10, KI-018)
+- **`HRF.spline_interp`** accepts an optional trace argument so `build()` can call it via the `process(self.trace)` pipeline pattern (NE-003 complement)
+- **`HRF.smooth`** imports `scipy.ndimage.gaussian_filter1d` at module level and calls it as a free function instead of the non-existent `self.gaussian_filter1d` (NE-004)
+
+### Bug fixes — API surface
+
+- **`montage.__repr__`** safe on unconfigured instances via `getattr` fallback; reports configured vs unconfigured state (H3)
+- **`montage.estimate_activity`** zero-trace HRF fallback: detects `None`, empty, or all-zero traces and falls back to the canonical HRF with a warning instead of silently producing NaN (H1)
+- **`montage.estimate_activity`** drops orphaned channel entries from `self.channels` / `hbo_channels` / `hbr_channels` after a failed channel drop, so downstream iterators (`correlate_hrf`, `generate_distribution`) don't trip on stale pointers (M4)
+- **`montage.estimate_activity`** deconvolution closure catches generic `Exception` (not just `TimeoutError`) so every solve failure routes through the drop-and-cleanup path
+- **`montage.configure`** transactional: commits scalar/list state and `_merge_montages` result atomically. First-time configure rolls back via `self.root = None`; re-configure rolls back via `tree.delete` on newly-inserted nodes (M6 — moved here from `fix/state-lifecycle` to sit on top of working `tree.delete`)
+- **`montage.correlate_canonical`** raises a clean `ValueError` on unconfigured montage instead of AttributeError on `self.root.trace` (lint-sweep finding)
+- **`load_montage`** per-entry schema validation with `try/except` wrapping — raises `ValueError` naming the offending entry and field, preserves original exception via `__cause__`, and never returns a half-populated montage (M3, M5)
+- **`load_montage`** passes `channel['context']` to the `HRF` constructor so loaded nodes carry their actual metadata. Pre-NE-002 this was hidden because the hasher was populated by dict keys; post-NE-002 the regression would have caused silent compare_context / branch / filter mismatches. Caught by the cross-branch audit.
+- **`estimate_hrf`** rejects `duration <= 0`, non-list `events`, empty events, and `lmbda <= 0` at the top of the function (M2a, M2b)
+- **`estimate_activity`** rejects `lmbda <= 0` at the top of the function (M2b)
+
+### Bug fixes — helpers
+
+- **`_utils.standardize_name`** entry guard raises `TypeError` on non-str and `ValueError` on strings shorter than 3 characters (M1)
+- **`_utils._is_oxygenated`** matching entry guard plus a structure guard for the `ch_name[-2] == 'b'` branch — pre-fix strings like `'abc'` / `'abb'` passed the length check but crashed `split[1][0]` with IndexError (mini-branch)
+
+### Bug fixes — canonical HRF
+
+- **S4**: canonical HRFs are now lazily generated at the calling scan's actual sample rate via a new `tree.get_canonical_hrf(oxygenation, sfreq, duration)` helper with a per-`(ox, sfreq, duration)` cache. Pre-fix the canonical was hardcoded to `t_r=0.128` (7.81 Hz) and eagerly constructed during the first `tree.insert`, which meant scans at any other sample rate got a kernel of the wrong length and downstream deconvolution math silently produced wrong results.
+- `tree.insert` no longer creates a canonical sentinel at `root.right`. The tree is a pure kd-tree of user HRFs.
+- `tree.nearest_neighbor` fallback returns `(None, inf)` on miss instead of `(root.right, inf)`. Callers handle `None` explicitly by calling `get_canonical_hrf` with their own sfreq.
+- `montage.estimate_activity`, `montage.localize_hrfs`, and `montage._merge_montages` all updated to the new pattern.
+
+### Bug fixes — lint sweep (v1.2.0 in-scope)
+
+These were caught by a targeted `ruff` + `mypy` pass during `fix/observer-and-typos` and fixed in the same branch:
+
+- **`lens.calc_snr` PSD variable swap**: pre-fix `psd_noise_slow = preproc_noise_FAST.compute_psd(slow_band)` — the filter had removed all energy from the requested band, so `noise_power_slow` and `noise_power_fast` were both near zero and `SNR = signal / ~0` came out effectively infinite. Silent wrong scientific result.
+- **`lens.calc_snr` mutable default**: `noise_bands=[(0.0, 0.01), (0.1, 0.5)]` → `None` sentinel + per-call materialization
+- **`montage.correlate_canonical` None-root guard**: raises clean `ValueError` on unconfigured montage instead of AttributeError
+- **`lens.__init__`** initializes `self.sfreq` and `self.channels` so direct `calc_snr` calls don't AttributeError (3.9)
+
+### Bug fixes — infrastructure
+
+- **f-string syntax error** in `montage.__repr__`: nested quotes inside f-string was invalid Python < 3.12, extracted to a local variable (1.1, KI-026)
+- **Missing `scipy.stats` import** added to `hrfunc.py` (1.2, KI-027)
+- **`return ValueError` → `raise ValueError`** in multiple validators (1.4, KI-004)
+- **Bare `except:` → specific exception types** in `_is_oxygenated` wavelength parsing (1.5)
+- **`double_probe(key, hashkey, False)`** invalid third positional arg removed — `False` was being passed as the linear probe coefficient `a`, clustering every probe to slot 1 (1.6, KI-016)
+- **"Configureding" → "Configuring"** (1.7)
+- **"Cannonical" → "Canonical"** in correlate_canonical plot labels (4 occurrences) (L1)
+- **"intiialized" → "initialized"** in tree init warning (L2)
+- **"ommited" → "omitted"** in estimate_hrf edge-expansion warning (L3)
+
+### Refactor — circular imports
+
+- New `src/hrfunc/_utils.py` holds `standardize_name`, `_is_oxygenated`, and `_LIB_DIR`
+- `hrfunc.py` no longer imports itself (was importing `hrfunc.__file__` for the library path)
+- `hrtree.py` no longer imports from `hrfunc.py`
+- Breaks the circular import that previously only worked by accident of function-body references instead of module-level references
+
+---
+
+## Architecture state at 1.2.0
+
+At the end of the correctness release the library is structurally the same as 1.1.2 — no API rename, no composition refactor, no new top-level modules except `_utils.py`. All v2.0.0-class architectural concerns (composition, type hints, logging, magic number extraction, test suite restructure, performance optimizations) were deliberately deferred.
+
+**What is different:**
+- Every reachable user-facing code path either works correctly or raises a clean exception naming the problem
+- All documented pytest targets pass (213 tests, 0 xfailed) after the full in-flight stack
+- All bundled test fixtures survive a `load_montage` round-trip
+- `tree.filter` + `tree.delete` + `tree.branch` work end-to-end for the first time
+- Canonical HRFs match the calling scan's actual sample rate
+- Input validation fires at API boundaries with `ValueError` / `TypeError` naming the offending parameter
+- Malformed JSON files fail load with a clear error and don't leave partial state behind
+- Mutable default args across the codebase (HRF, lens) no longer leak state between instances
+- Observer SNR metric is no longer silently infinite
+
+**What is NOT different:**
+- `montage` still inherits from `tree` (composition refactor is v2.0.0)
+- Channel solves are still sequential (parallelization is v2.0.0)
+- Logging is still `print()` (structured logging is v2.0.0)
+- No type hints (v2.0.0)
+- Magic numbers are still scattered in the code (v2.0.0)
+- `experiment/ppf-validation` is still open — `ppf=0.1` vs `ppf=6.0` in `preprocess_fnirs` needs Denny's experimental test on real data before release
+
+---
+
+## Testing
+
+Each branch added its own `tests/test_<branch>.py` file. The cumulative targeted gate across the full in-flight stack is:
+
+```bash
+pytest \
+  tests/test_phase1a.py \
+  tests/test_phase1bc.py \
+  tests/test_phase2.py \
+  tests/test_threading.py \
+  tests/test_input_validation.py \
+  tests/test_state_lifecycle.py \
+  tests/test_oxygenation_guard.py \
+  tests/test_tree_delete_filter.py \
+  tests/test_hasher_branch.py \
+  tests/test_tree_hrf.py \
+  tests/test_canonical_hrf.py \
+  tests/test_tree_edge_cases.py \
+  tests/test_observer_and_typos.py \
+  -q
+```
+
+Result: **213 passed, 0 xfailed**.
+
+The integration tests `tests/test_estimation.py` and `tests/test_localization.py` are still excluded because their module-level code crashes pytest on collection (KI-033). Fixing that is scoped to `feat/test-suite-restructure` in v2.0.0.
+
+---
+
+## Release gate for `release/1.2.0`
+
+See [../plans/plan_v1_2_0.md](../plans/plan_v1_2_0.md) `release/1.2.0` section for the packaging checklist:
+
+1. `pyproject.toml` dependency lower-bound pins (numpy, mne, mne_nirs, scipy, nilearn, matplotlib)
+2. `pyproject.toml` `[tool.setuptools.package-data]` for `hrfs/*.json`
+3. `MANIFEST.in` sdist inclusion
+4. Version bump to `1.2.0`
+5. CHANGELOG.md entry (use this file as the source)
+6. `python -m build` + `twine check dist/*`
+7. Wheel contents check: `unzip -l dist/hrfunc-1.2.0-py3-none-any.whl | grep hrfs`
+8. Fresh-venv install test
+9. Git tag + GitHub release
+10. `twine upload dist/*`

--- a/docs/plans/phase_breakdown.md
+++ b/docs/plans/phase_breakdown.md
@@ -1,0 +1,158 @@
+# HRFunc Release Roadmap
+
+**Current version:** 1.1.2
+**Next release:** 1.2.0 — Correctness Release (PyPI)
+**Release after that:** 2.0.0 — Architectural Refactor
+
+**Last updated:** 2026-04-14
+
+---
+
+## Release Strategy
+
+HRFunc is a scientific library that researchers rely on for publishable data. We split refactoring into two releases with distinct goals:
+
+### **1.2.0 — Correctness Release**
+Every user-facing path works without crashes, silent wrong results, or data corruption. No architectural changes. No breaking API changes. This is a **minor version bump** so existing users can upgrade without code changes and gain stability. Detailed plan: [plan_v1_2_0.md](plan_v1_2_0.md).
+
+### **2.0.0 — Architectural Refactor**
+Code cleanliness, performance, type safety, and breaking API improvements (notably the composition refactor that removes `montage(tree)` inheritance). This is a **major version bump** because `isinstance(m, tree)` behavior changes. Ships after 1.2.0 has been validated in Denny's own pipeline. Detailed plan: [plan_v2_0_0.md](plan_v2_0_0.md).
+
+**Why this split:** Researchers need stability more urgently than cleanliness. A bug-fix release can ship in weeks; the composition refactor needs more design thought and a breaking-change release cycle.
+
+---
+
+## Working Practices (Apply to Every Branch)
+
+Every branch in either release follows the review protocol defined in the "Working Practices for HRFunc Sessions" memory:
+
+1. **Feature-branch-per-change** — each branch addresses one cohesive fix or refactor, stacks on the previous branch in the dependency chain
+2. **Targeted unit tests** — add a `tests/test_<branch-name>.py` file exercising the specific behavior changed. Must run in under a few seconds and require no fNIRS data files
+3. **Pre-PR review protocol** — always run two reviews before pushing:
+   - Architecture & Execution Flow (primary)
+   - A secondary lens chosen for the change type (data integrity, API surface, threading, etc.)
+4. **Pre-PR test gate** — `python -m pytest tests/test_*.py -q` must pass (integration tests still deferred to v2.0.0 per KI-033)
+5. **Editable install** — `pip install -e .` before running tests. Verify imports resolve to `src/hrfunc/__init__.py`, not site-packages
+6. **Conventional commits** — branches named `fix/...`, `refactor/...`, `feat/...`, `perf/...`, `experiment/...`, `release/...`
+
+---
+
+## Status of Work Completed to Date (2026-04-14)
+
+The v1.2.0 chain is nearly complete. Most branches are merged to main; the remaining four are pushed and stacked waiting for merge. The only un-started work is `experiment/ppf-validation` (waiting on Denny's experimental test) and `release/1.2.0` (packaging).
+
+| Branch | Status | Scope |
+|---|---|---|
+| `fix/critical-bugs-phase1a` | ✅ Merged | Syntax errors, missing imports, return-vs-raise, filter() inversion (ND-001), double_probe args, typos |
+| `fix/critical-bugs-phase1bc` | ✅ Merged | Pipeline ordering in estimate_hrf, preprocess_fnirs return capture, load_montage tree overwrite, subject_info guard, _is_oxygenated fallthrough, hasher probe_count/shared-list/repr/search, estimate_activity return, context similarity denominator (ND-002), polynomial_detrend order=3 |
+| `refactor/circular-imports-phase2` | ✅ Merged | `_utils.py` created, `hrfunc.py` self-import removed, `hrtree.py` no longer imports `hrfunc`, `_LIB_DIR` constant |
+| `fix/estimate-activity-threading` | ✅ Merged | ND-003 (success variable scope via `nonlocal`), ND-004 (default `timeout=30`) |
+| `fix/input-validation` | ✅ Merged | M1 standardize_name guard, M2a/M2b duration/events/lmbda validation, M3 load_montage schema validation, H1 zero-trace canonical fallback |
+| `fix/state-lifecycle` | ✅ Merged | H3 `__repr__` unconfigured guard, M4 drop-channel orphaning cleanup + deconvolution closure generic-exception catch, M5 `load_montage` partial-load wrapping. (M6 moved to `fix/tree-delete-filter`.) |
+| `fix/oxygenation-guard` | ✅ Merged | Mini-branch. `_is_oxygenated` entry guards and `[-2]=='b'` structure guard preventing `split[1][0]` IndexError on short/unstructured inputs |
+| `fix/tree-delete-filter` | ✅ Merged | KI-009 `_delete_recursive` rewrite with `_copy_payload` helper, 3.8 `gather(None)` guard, `test_filter_removes_low_similarity_nodes` xfail → pass, M6 configure commit-on-success with tree rollback |
+| `fix/hasher-branch-correctness` | ⏳ Pushed | 3.3/H4 hasher list contract, NE-002 populate by values, 3.1 `compare_context` scalar wrap, 3.2 `tree.branch` AND-on-kwargs, dead code removal, filter no-op cleanup |
+| `fix/tree-hrf-correctness` | ⏳ Pushed | NE-001 canonical label, 3.5 jitter, NE-003 process_options + spline_interp signature, NE-004 gaussian_filter1d import, 3.7 mutable defaults, 3.10 `hrf_type` |
+| `fix/canonical-hrf-sfreq` | ⏳ Pushed | S4 lazy `tree.get_canonical_hrf` with cache, no more eager canonical sentinel, callers updated |
+| `fix/tree-edge-cases` | ⏳ Pushed | NE-006 `merge` deep copy, NE-007 empty-tree early return, cross-branch fix for `load_montage` dropping `channel['context']` |
+| `fix/observer-and-typos` | ⏳ Pushed | 3.9 `lens.sfreq` init, L1-L3 typos, lint-sweep bonuses (`calc_snr` PSD swap, `noise_bands` mutable default, `correlate_canonical` None-root guard) |
+
+Full gate after the complete stack: **213 passed, 0 xfailed**.
+
+---
+
+## v1.2.0 Branch Decomposition
+
+Full detail and sub-issue mapping in [plan_v1_2_0.md](plan_v1_2_0.md). Dependency chain (each stacks on the previous):
+
+```
+main
+├── fix/critical-bugs-phase1a                    ✅ pushed
+├── fix/critical-bugs-phase1bc                   ✅ pushed
+├── refactor/circular-imports-phase2             ✅ pushed
+├── fix/estimate-activity-threading              ✅ pushed
+├── fix/input-validation                         ⏳ next
+│   └── fix/state-lifecycle
+│       └── fix/tree-delete-filter
+│           └── fix/hasher-branch-correctness
+│               └── fix/tree-hrf-correctness
+│                   └── fix/canonical-hrf-sfreq
+│                       └── fix/tree-edge-cases
+│                           └── fix/observer-and-typos
+│                               └── experiment/ppf-validation
+│                                   └── release/1.2.0
+```
+
+### v1.2.0 Branch Summary
+
+See [plan_v1_2_0.md](plan_v1_2_0.md) for detailed per-branch scope and the Completed Branches section for what each one actually landed. The two remaining branches are:
+
+| Branch | Addresses | Depends on |
+|---|---|---|
+| `experiment/ppf-validation` | **S1**: `ppf=0.1` vs MNE default `ppf=6.0` in `preprocess_fnirs`. Denny tests both values experimentally on a real dataset and decides which is scientifically defensible before release. | observer-and-typos |
+| `release/1.2.0` | Phase 11 packaging (`package-data` for `hrfs/*.json`, dependency version pins in `pyproject.toml`, `MANIFEST.in`), CHANGELOG, version bump to 1.2.0, tag, PyPI upload | ppf-validation |
+
+All of the correctness-fix branches that preceded these two are complete (merged or pushed pending merge — see the status table above).
+
+---
+
+## v2.0.0 Branch Decomposition
+
+Full detail in [plan_v2_0_0.md](plan_v2_0_0.md). These branches have fewer hard dependencies and can be sequenced more flexibly after 1.2.0 ships.
+
+| Branch | Scope | Notes |
+|---|---|---|
+| `refactor/composition` | Phase 4: `montage` → composition (`_tree` attribute, delegation methods); fixes ND-005 global HRFs | Breaking change; needs Denny's explicit sign-off |
+| `perf/estimate-hrf-batch` | Batch-solve all channels in one `np.linalg.solve` call (20–40× speedup) | Low risk, high payoff; doable as early 2.0 work |
+| `refactor/shared-helpers` | Phase 8 + ND-006: extract `_build_toeplitz`, `_solve_regularized` | Unblocks further parallelism |
+| `perf/estimate-activity-parallel` | Multi-worker ThreadPool for per-channel deconvolution | Depends on shared-helpers |
+| `feat/logging` | Phase 5: replace `print()` with structured logging | Helps debug everything downstream |
+| `feat/type-hints` | Phase 7: type annotations, `from __future__ import annotations` | Low risk cleanup |
+| `feat/constants` | Phase 9: magic numbers → named constants | Low risk cleanup |
+| `feat/test-suite-restructure` | Phase 12: fix KI-033 (integration tests crash pytest collection), unify targeted + integration suites | Final gate for 2.0.0 |
+| `feat/robustness-io` | Phase 6 spillover: nicer error messages for JSON load/save edge cases | Nice-to-have |
+| `feat/event-edge-warning` | Count and report silently dropped events in `estimate_hrf` edge expansion | Correctness-adjacent |
+| `feat/adaptive-regularization` | Investigate `lmbda` scaling with matrix norm | Design question, needs Denny's judgment |
+
+---
+
+## Testing Gate for v1.2.0 Release
+
+Before tagging 1.2.0 and pushing to PyPI, verify:
+
+- [ ] All targeted test files pass: `pytest tests/test_phase1a.py tests/test_phase1bc.py tests/test_phase2.py tests/test_threading.py tests/test_input_validation.py tests/test_state_lifecycle.py tests/test_tree_delete_filter.py tests/test_hasher_branch.py tests/test_tree_hrf.py tests/test_canonical_hrf.py tests/test_tree_edge_cases.py tests/test_observer_typos.py`
+- [ ] `import hrfunc` works cleanly with no warnings
+- [ ] `from hrfunc import montage, tree, load_montage, localize_hrfs, preprocess_fnirs` all resolve
+- [ ] `montage()` → `montage.estimate_hrf(...)` → `montage.estimate_activity(...)` → `montage.save(...)` round-trips on bundled test data
+- [ ] `load_montage(bundled_hrfs_path)` succeeds without partial-state or tree overwrite
+- [ ] `tree.filter()` remove-path no longer xfailed (KI-009 unblocked)
+- [ ] Built wheel includes `src/hrfunc/hrfs/*.json` (`python -m build && unzip -l dist/*.whl | grep hrfs`)
+- [ ] Denny validates experimentally on real data whether `ppf=0.1` or `ppf=6.0` is correct (S1 decision) before tagging
+- [ ] Version bumped in `pyproject.toml` to `1.2.0`
+- [ ] `CHANGELOG.md` updated with all bug fixes, grouped by category
+- [ ] `python -m build` succeeds; `twine check dist/*` passes
+- [ ] Tag `v1.2.0`, push, GitHub release notes, `twine upload dist/*`
+
+---
+
+## Testing Gate for v2.0.0 Release
+
+Before tagging 2.0.0, in addition to all 1.2.0 gates:
+
+- [ ] `refactor/composition` merged, `isinstance(m, tree)` removed (documented in CHANGELOG as breaking change)
+- [ ] Integration test suite (KI-033) restructured and runs in CI
+- [ ] `perf/estimate-hrf-batch` benchmarked against 1.2.0 baseline — should demonstrate ~20× speedup on a realistic fNIRS dataset
+- [ ] `feat/logging` replaces all `print()` calls; `logging.basicConfig(level=logging.WARNING)` silences routine output
+- [ ] Type hints pass `mypy --strict` on `src/hrfunc/`
+- [ ] Migration guide written for users upgrading from 1.x to 2.0
+- [ ] Version bumped to `2.0.0`
+- [ ] Tag, release notes, upload
+
+---
+
+## Related Documents
+
+- [plan_v1_2_0.md](plan_v1_2_0.md) — detailed v1.2.0 branch-by-branch work
+- [plan_v2_0_0.md](plan_v2_0_0.md) — detailed v2.0.0 branch-by-branch work
+- [../internal/known_issues.md](../internal/known_issues.md) — authoritative issue catalogue (KI-001 through KI-034, NE-001 through NE-007, ND-001 through ND-006, S1-S4, H1-H4, M1-M6, L1-L3)
+- [../internal/architecture.md](../internal/architecture.md) — module map and execution paths

--- a/docs/plans/plan_v1_2_0.md
+++ b/docs/plans/plan_v1_2_0.md
@@ -32,7 +32,30 @@
 
 ## Completed Branches (2026-04-13 → 2026-04-14)
 
-These are pushed to origin and pending merge to main:
+Most of the v1.2.0 chain has shipped. The merge state below is current as of
+2026-04-14. Each branch has its own `tests/test_*.py` file; the full gate
+stands at **213 passed, 0 xfailed** across the merged + in-flight stack
+(the `fix/tree-edge-cases` full gate; later branches extend from the same
+base).
+
+**Merged to main (7 branches):**
+- `fix/critical-bugs-phase1a`
+- `fix/critical-bugs-phase1bc`
+- `refactor/circular-imports-phase2`
+- `fix/estimate-activity-threading`
+- `fix/input-validation`
+- `fix/state-lifecycle`
+- `fix/oxygenation-guard`
+- `fix/tree-delete-filter`
+
+**Pushed to origin, pending merge (4 branches stacked on each other in this order):**
+- `fix/hasher-branch-correctness`
+- `fix/tree-hrf-correctness`
+- `fix/canonical-hrf-sfreq`
+- `fix/tree-edge-cases`
+- `fix/observer-and-typos`
+
+Only `experiment/ppf-validation` and `release/1.2.0` remain unstarted.
 
 ### `fix/critical-bugs-phase1a` ✅
 - **1.1** f-string syntax error in `montage.__repr__` (extracted `context_str` variable)
@@ -72,7 +95,76 @@ These are pushed to origin and pending merge to main:
 - Cleanup: `success == False` → `success is False`; TimeoutError print message now includes timeout value
 - **Tests:** `tests/test_threading.py` (9 passed)
 
-**Full suite after all four merged branches:** 66 passed, 1 xfailed (unblocked later by `fix/tree-delete-filter`)
+### `fix/input-validation` ✅
+- **M1** `standardize_name` guard on short/non-str input
+- **M2a** `estimate_hrf` validates `duration > 0`, `lmbda > 0`, non-empty `events`
+- **M2b** `estimate_activity` validates `lmbda > 0`
+- **M3** `load_montage` per-entry schema validation (top-level guard + per-entry try/except)
+- **H1** `estimate_activity` detects zero-trace HRFs and falls back to canonical with warning
+- **Tests:** `tests/test_input_validation.py` (24 passed)
+
+### `fix/state-lifecycle` ✅
+- **H3** `montage.__repr__` safe on unconfigured instances (getattr fallback)
+- **M4** `estimate_activity` snapshot-iterates `self.channels` and pops orphaned entries after drop; deconvolution closure now catches general `Exception`, not just `TimeoutError`
+- **M5** `load_montage` per-entry try/except wraps with entry-key context and `__cause__` chaining
+- M6 was originally in this branch but was **moved to `fix/tree-delete-filter`** after the parallel review caught that proper tree rollback needs a working `tree.delete`
+- **Tests:** `tests/test_state_lifecycle.py` (13 passed)
+
+### `fix/oxygenation-guard` ✅ (mini-branch)
+- `_utils._is_oxygenated` entry guards (type + length) — M1 coverage at the sibling helper
+- `_is_oxygenated` 'b' branch structure guard — 3+ char strings like `'abc'`, `'abb'` that pass the length guard but have no `'hb'` substring now raise `ValueError` instead of `IndexError`
+- **Tests:** `tests/test_oxygenation_guard.py` (18 passed)
+
+### `fix/tree-delete-filter` ✅
+- **KI-009 / H2** `tree._delete_recursive` rewritten with proper 3-arg recursive signature and new `_copy_payload` helper that copies all HRF payload fields except `left`/`right`, with `np.copy` on trace/trace_std and dict/list copies for context/estimates/locations. Skips `hrf_processes`/`process_names`/`process_options` because they contain bound methods pointing at src.
+- **3.8** `tree.gather(None)` returns `{}` (pulled in from `fix/tree-edge-cases` to unblock xfail)
+- **xfail cleanup** `test_filter_removes_low_similarity_nodes` flipped from xfailed to a normal pass
+- **M6** `montage.configure` commit-on-success with tree rollback. Snapshots scalar/list/dict state plus identity-indexed set of pre-call node references. First-time configure fast-pathed to `self.root = None`; re-configure uses `tree.delete` on newly-inserted nodes.
+- **Tests:** `tests/test_tree_delete_filter.py` (19 passed)
+
+### `fix/hasher-branch-correctness` ⏳ (pushed, pending merge)
+- **3.3 + H4** `hasher.add` appends pointers to slot list with identity dedup; `hasher.search` returns `list[pointer]` (empty on miss). `fill` / `double_check` dead code deleted.
+- **NE-002** `load_hrfs` and `load_montage` now populate the hasher keyed by channel context VALUES, not dict KEYS. New `_flatten_context_value` helper handles scalar vs list values.
+- **3.1** `compare_context` auto-wraps scalar values, handles missing keys in second_context
+- **3.2** `tree.branch` AND-on-kwargs / OR-within-kwarg semantics, empty kwargs returns empty branch, sub-tree hasher populated by copied node values
+- Cleanup: historical no-op `self.branch()` inside `filter()` replaced with direct `self.branched = True`
+- **Tests:** `tests/test_hasher_branch.py` (23 passed)
+
+### `fix/tree-hrf-correctness` ⏳ (pushed, pending merge)
+- **NE-001** `tree.insert` labels the canonical sentinel, not the first user HRF
+- **3.5** jitter branch mutates `hrf.x/y/z` directly and refreshes `h_val`
+- **NE-003** `HRF.process_options = [None]`; `spline_interp` accepts optional `trace` arg so `build()` pipeline works
+- **NE-004** `HRF.smooth` uses module-level `scipy.ndimage.gaussian_filter1d`
+- **3.7** mutable default args → None sentinels + per-instance materialization
+- **3.10** `HRF.build` derives `hrf_type` from `self.oxygenation`
+- **Tests:** `tests/test_tree_hrf.py` (14 passed)
+
+### `fix/canonical-hrf-sfreq` ⏳ (pushed, pending merge)
+- **S4** `tree.get_canonical_hrf(oxygenation, sfreq, duration)` lazy generator with per-`(ox, sfreq, duration)` cache
+- `tree.insert` no longer creates a canonical sentinel at `root.right`
+- `nearest_neighbor` returns `(None, inf)` on miss instead of `(root.right, inf)`
+- `estimate_activity` canonical branch, `localize_hrfs`, and `_merge_montages` all updated to use the helper and handle `None`
+- Scientific reviewer flagged `oversampling=1` as aliasing; **declined** — Glover HRF energy is <0.3 Hz, Nyquist at fNIRS rates is far above. Documented as v2.0.0 validation item.
+- **Tests:** `tests/test_canonical_hrf.py` (17 passed)
+
+### `fix/tree-edge-cases` ⏳ (pushed, pending merge)
+- **NE-006** `tree.merge` inserts `node.copy()` so merged tree is independent; recursion walks SOURCE's children; empty-source early return
+- **NE-007** `tree.nearest_neighbor` explicit `if self.root is None: return None, inf` early return; tightened `== None` to `is None` and `if best:` to `if best is not None:`
+- **Cross-branch regression fix**: `load_montage` was not passing `channel['context']` to the `HRF` constructor; post-NE-002 this meant hasher had real context values but the nodes themselves carried only the default template. Caught by a pre-push comprehensive cross-branch audit of the full in-flight stack.
+- **Tests:** `tests/test_tree_edge_cases.py` (10 passed)
+
+### `fix/observer-and-typos` ⏳ (pushed, pending merge)
+- **3.9** `lens.__init__` initializes `self.sfreq` (default 7.81) and `self.channels = []`
+- **L1** "Cannonical" → "Canonical" (4 occurrences)
+- **L2** "intiialized" → "initialized"
+- **L3** "ommited" → "omitted"
+- Lint-sweep bonuses (real correctness bugs found by `ruff` + `mypy`, in v1.2.0 scope):
+  - `calc_snr` PSD variable swap — pre-fix each band's PSD was read from the signal filtered to the WRONG band, producing near-zero noise power and infinite SNR
+  - `calc_snr` `noise_bands` mutable default → None sentinel
+  - `correlate_canonical` None-root guard (was AttributeError on unconfigured montage)
+- **Tests:** `tests/test_observer_and_typos.py` (10 passed)
+
+**Full suite after all in-flight branches:** 213 passed, 0 xfailed
 
 ---
 

--- a/docs/plans/plan_v2_0_0.md
+++ b/docs/plans/plan_v2_0_0.md
@@ -1,0 +1,559 @@
+# HRFunc v2.0.0 — Architectural Refactor Plan
+
+**Release type:** Major version bump (1.2.0 → 2.0.0)
+**Prerequisite:** 1.2.0 shipped and validated in Denny's pipeline
+**Goal:** Code cleanliness, performance, type safety, and breaking API improvements. The composition refactor is the major-version trigger.
+
+**High-level roadmap:** [phase_breakdown.md](phase_breakdown.md)
+**Correctness release (prerequisite):** [plan_v1_2_0.md](plan_v1_2_0.md)
+
+---
+
+## Scope Philosophy
+
+**IN scope for 2.0.0:**
+- Architectural refactors (composition, shared helpers)
+- Performance optimizations (batch solves, parallel channels)
+- Type hints and static analysis
+- Structured logging replacing `print()`
+- Magic-number extraction to named constants
+- Test suite restructuring (fixing KI-033)
+- Breaking API changes where they materially improve ergonomics
+- Nice-to-have robustness (better error messages, edge-case warnings)
+
+**OUT of scope for 2.0.0:**
+- Scientific model changes (HRF model selection, deconvolution math)
+- Major new features that expand the library's charter
+- Anything already shipped in 1.2.0
+
+**Rule of thumb:** 2.0.0 should make the library nicer to *maintain* and *extend* without changing what it computes.
+
+---
+
+## Branch Decomposition
+
+Fewer hard dependencies than 1.2.0 — most of these can be sequenced flexibly. The only hard ordering is that `refactor/composition` should land before `perf/estimate-activity-parallel` and before `feat/type-hints` (to avoid retyping delegate methods).
+
+---
+
+### `refactor/composition`
+
+**Priority:** First. This is the major-version trigger.
+
+**Scope — Phase 4 from the original plan + ND-005:**
+
+Replace `class montage(tree)` inheritance with composition:
+
+```python
+class montage:
+    # Class-level constants (moved from magic numbers)
+    HBO_HRF_PATH = "hrfs/hbo_hrfs.json"
+    HBR_HRF_PATH = "hrfs/hbr_hrfs.json"
+    DEFAULT_DURATION = 30.0
+    DEFAULT_LAMBDA = 1e-3
+    DEFAULT_EDGE_EXPANSION = 0.15
+    DEFAULT_MAX_DISTANCE = 0.01
+
+    def __init__(self, nirx_obj=None, **kwargs):
+        self._tree = tree()  # Internal tree, not inherited
+        self.hbo_tree = tree(f"{_LIB_DIR}/{self.HBO_HRF_PATH}", **kwargs)
+        self.hbr_tree = tree(f"{_LIB_DIR}/{self.HBR_HRF_PATH}", **kwargs)
+        ...
+
+    # Delegation methods
+    @property
+    def root(self):
+        return self._tree.root
+
+    def insert(self, hrf, depth=0, node=None):
+        return self._tree.insert(hrf, depth, node)
+
+    def gather(self, node=None, oxygenation=None):
+        return self._tree.gather(node if node is not None else self._tree.root, oxygenation)
+
+    def nearest_neighbor(self, optode, max_distance, **kw):
+        return self._tree.nearest_neighbor(optode, max_distance, **kw)
+
+    def delete(self, hrf):
+        return self._tree.delete(hrf)
+
+    def filter(self, similarity_threshold=0.95, **kw):
+        return self._tree.filter(similarity_threshold, **kw)
+```
+
+**Also fixes ND-005** (the hidden third tree): `generate_distribution()` currently inserts global HRFs into `self.insert()`, which goes to `montage.root` (the inherited tree root) — a tree that nothing else searches. After composition, `self._tree` is explicitly the "global HRFs for this montage" tree and is searched by `nearest_neighbor()` fallbacks.
+
+**Breaking changes:**
+- `isinstance(m, tree)` will return `False` for montages — document in migration guide
+- Any user code that directly accessed tree methods via inheritance still works through delegation but the MRO is different
+
+**Review protocol:**
+- Architecture & Execution Flow review — every `self.insert`, `self.root`, `self.gather`, `self.filter`, `self.nearest_neighbor`, `self.delete` call inside `montage` must be traced and verified against the delegation layer
+- API surface review — confirm no method signatures change observably for existing users
+
+**Tests:** `tests/test_composition.py` — verify every delegated method works, verify `isinstance(m, tree) == False`, verify `generate_distribution` inserts globals into `self._tree` and `nearest_neighbor` finds them.
+
+**Estimated complexity:** Medium — well-understood refactor, but lots of call sites to audit. Worth splitting into multiple commits within the branch: (a) add `_tree` alongside inheritance, (b) add delegation methods, (c) switch `class montage(tree)` → `class montage`, (d) remove inheritance-based fallbacks.
+
+---
+
+### `perf/estimate-hrf-batch`
+
+**Priority:** Early — biggest performance win, low risk, standalone.
+
+**Scope:**
+
+In `estimate_hrf`, the Toeplitz matrix `X` built from events is **the same for every channel**. Only the signal `Y` differs. Currently the code recomputes `lhs = X.T @ X + lmbda*I` and calls `lstsq` per channel — O(N) solves. Replace with one solve over all channels stacked:
+
+```python
+X = scipy.linalg.toeplitz(events, np.zeros(hrf_len))
+lhs = X.T @ X + lmbda * np.eye(X.shape[1])
+
+# Z-score every channel along the time axis
+Y_matrix = (data - data.mean(axis=1, keepdims=True)) / data.std(axis=1, keepdims=True)
+Y_matrix = Y_matrix.T  # shape: (n_time, n_channels)
+
+# One solve, all channels at once
+rhs = X.T @ Y_matrix
+HRF_matrix = np.linalg.solve(lhs, rhs)  # shape: (hrf_len, n_channels)
+```
+
+Then iterate the resulting columns to assign per-optode estimates. Same math, same numerical result (up to floating-point), but N solves → 1 solve.
+
+**Expected speedup:** 20–40× for typical montages (20–40 channels). Tested empirically in the review branch.
+
+**Risks:**
+- Numerical stability should be identical since `np.linalg.solve` is just as well-conditioned as `lstsq` on a square positive-definite LHS
+- Memory: `Y_matrix` is `(n_time × n_channels)` — for a 10-min scan at 10 Hz with 40 channels that's 240k floats, negligible
+- Any per-channel processing that can't be batched (e.g., per-channel `cond_thresh` pinv fallback) needs a fallback path
+
+**Review protocol:**
+- Data Integrity review — verify batch output is numerically equivalent to per-channel output within machine epsilon on a synthetic test case
+- Performance benchmark — measure baseline vs batched on a realistic dataset
+
+**Tests:** `tests/test_estimate_hrf_batch.py` — synthetic dataset where the answer is known analytically; assert batched and per-channel outputs agree.
+
+---
+
+### `refactor/shared-helpers`
+
+**Priority:** Before `perf/estimate-activity-parallel`.
+
+**Scope — Phase 8 + ND-006:**
+
+Extract shared math into private module-level helpers:
+
+```python
+def _build_toeplitz_matrix(kernel_or_events, n_time):
+    """Build a Toeplitz convolution/deconvolution design matrix."""
+    n_k = len(kernel_or_events)
+    first_col = np.r_[kernel_or_events, np.zeros(n_time - n_k)]
+    first_row = np.r_[kernel_or_events[0], np.zeros(n_time - 1)]
+    return scipy.linalg.toeplitz(first_col, first_row)
+
+
+def _solve_regularized_lstsq(lhs, rhs, cond_thresh=None):
+    """Solve regularized least squares with optional pinv fallback."""
+    if cond_thresh is not None and np.linalg.cond(lhs) >= cond_thresh:
+        return scipy.linalg.pinv(lhs) @ rhs
+    result, *_ = np.linalg.lstsq(lhs, rhs, rcond=None)
+    return result
+```
+
+`estimate_hrf` and the `estimate_activity` deconvolution closure both delegate to these. The MNE `apply_function` single-argument constraint (ND-006) still forces the closure pattern in `estimate_activity`, but the closure body becomes thin.
+
+**Also extract:** `montage._plot_matrix` (Phase 8.1/8.2) — the plotting code duplicated between `correlate_hrf` and `correlate_canonical` gets factored out.
+
+**Review protocol:**
+- Architecture review — confirm both callers reach identical numerical output through the shared helpers
+
+**Tests:** `tests/test_shared_helpers.py` — direct unit tests for `_build_toeplitz_matrix` and `_solve_regularized_lstsq` with known inputs.
+
+---
+
+### `perf/estimate-activity-parallel`
+
+**Priority:** After `refactor/shared-helpers`.
+
+**Scope:**
+
+Currently `estimate_activity` creates a `ThreadPoolExecutor(max_workers=1)` per channel inside the deconvolution closure and calls `apply_function` sequentially per channel. Two problems:
+1. `max_workers=1` is an executor with no parallelism — pure overhead
+2. Channels are processed sequentially — a 40-channel montage runs 40 serial solves
+
+Proposal: break out of the `apply_function` per-channel pattern. Pre-compute all deconvolved channel signals using a shared `ThreadPoolExecutor(max_workers=os.cpu_count())`, then assign them back to the Raw object's `_data` array in one pass.
+
+```python
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+with ThreadPoolExecutor(max_workers=os.cpu_count()) as executor:
+    futures = {}
+    for ch_idx, (ch_name, hrf) in enumerate(self.channels.items()):
+        if 'global' in ch_name:
+            continue
+        Y = nirx_obj._data[ch_idx]
+        futures[executor.submit(_deconvolve_channel, Y, hrf, lmbda, cond_thresh)] = ch_idx
+
+    for future in as_completed(futures):
+        ch_idx = futures[future]
+        try:
+            nirx_obj._data[ch_idx] = future.result(timeout=timeout)
+        except TimeoutError:
+            logger.warning(f"Channel {ch_idx} timed out after {timeout}s, dropping")
+            dropped_channels.append(ch_idx)
+
+nirx_obj.drop_channels([nirx_obj.ch_names[i] for i in dropped_channels])
+```
+
+NumPy's `lstsq` releases the GIL, so threading is real parallelism.
+
+**Expected speedup:** 4–8× on a typical multi-core laptop.
+
+**Risks:**
+- Writing directly to `nirx_obj._data` bypasses `apply_function`'s safety checks. Verify that MNE handles this cleanly or use a thin wrapper.
+- Ordering: `drop_channels` must come AFTER all futures resolve to avoid index invalidation mid-loop.
+- Edge case: if some channels drop, the remaining channel indices shift — test carefully.
+
+**Review protocol:**
+- Threading & concurrency review (primary)
+- Data integrity review — confirm per-channel output matches sequential output
+
+**Tests:** `tests/test_estimate_activity_parallel.py` — construct a montage with a mix of fast-converging and slow-converging HRF kernels (mocked), verify parallel version produces same result as sequential and drops the right channels.
+
+---
+
+### `feat/logging`
+
+**Priority:** Anytime — standalone cleanup.
+
+**Scope — Phase 5:**
+
+Replace every `print(...)` call in `src/hrfunc/` with `logger.info/debug/warning/error` as appropriate:
+
+| Current | Log level |
+|---|---|
+| `print(f"Deconvolving channel {ch_name}...")` | `logger.debug` |
+| `print(f"Tree initialized...")` | `logger.info` |
+| `print(f"WARNING: Using canonical HRF...")` | `logger.warning` |
+| `print(f"lstsq exceeded {timeout}s...")` | `logger.warning` |
+| Error paths | `logger.error` |
+
+Add to each module:
+```python
+import logging
+logger = logging.getLogger(__name__)
+```
+
+Scientists can then:
+```python
+import logging
+logging.basicConfig(level=logging.WARNING)  # silence routine output
+```
+
+**Risks:** None — pure substitution.
+
+**Review protocol:**
+- Quick grep review to confirm every `print` has been replaced with the right log level
+
+**Tests:** `tests/test_logging.py` — use `caplog` fixture to verify key messages are emitted at the right level.
+
+---
+
+### `feat/type-hints`
+
+**Priority:** After `refactor/composition` (to avoid typing methods that get removed) and after `feat/logging` (fewer surface changes).
+
+**Scope — Phase 7:**
+
+Add `from __future__ import annotations` to every module. Add type hints to all public function signatures. Aim for `mypy --strict` compliance on `src/hrfunc/`.
+
+Key signatures:
+
+```python
+# hrfunc.py
+def localize_hrfs(
+    nirx_obj: mne.io.Raw,
+    max_distance: float = 0.01,
+    verbose: bool = False,
+    **kwargs
+) -> montage: ...
+
+def load_montage(
+    json_filename: str,
+    rich: bool = False,
+    **kwargs
+) -> montage: ...
+
+class montage:
+    def __init__(self, nirx_obj: mne.io.Raw | None = None, **kwargs) -> None: ...
+    def estimate_hrf(
+        self,
+        nirx_obj: mne.io.Raw,
+        events: list[int] | np.ndarray,
+        duration: float = 30.0,
+        lmbda: float = 1e-3,
+        edge_expansion: float = 0.15,
+        preprocess: bool = True,
+    ) -> None: ...
+    def estimate_activity(
+        self,
+        nirx_obj: mne.io.Raw,
+        lmbda: float = 1e-4,
+        hrf_model: str = 'toeplitz',
+        preprocess: bool = True,
+        cond_thresh: float | None = None,
+        timeout: float = 30,
+    ) -> mne.io.Raw | None: ...
+    def save(self, filename: str = 'montage_hrfs.json') -> None: ...
+
+def preprocess_fnirs(
+    scan: mne.io.Raw,
+    deconvolution: bool = False,
+) -> mne.io.Raw | None: ...
+```
+
+**Add a `py.typed` marker file** in `src/hrfunc/` so downstream users get type checking.
+
+**Risks:**
+- MNE types may not be fully annotated — may need `# type: ignore` in a few places
+- Protocol types for duck-typed arguments (e.g. `events` accepts lists and ndarrays)
+
+**Tests:** Run `mypy --strict src/hrfunc/` as part of the test gate.
+
+---
+
+### `feat/constants`
+
+**Priority:** Anytime after `refactor/composition`.
+
+**Scope — Phase 9:**
+
+Replace magic numbers with module-level named constants:
+
+```python
+# hrtree.py
+DEFAULT_DURATION: float = 30.0
+DEFAULT_SFREQ: float = 7.81
+CANONICAL_LOCATION: list[float] = [359.0, 359.0, 359.0]
+
+# hrfunc.py
+DEFAULT_LAMBDA_HRF: float = 1e-3
+DEFAULT_LAMBDA_ACTIVITY: float = 1e-4
+DEFAULT_EDGE_EXPANSION: float = 0.15
+DEFAULT_MAX_DISTANCE: float = 0.01
+DEFAULT_TIMEOUT_SECONDS: float = 30.0
+SCI_THRESHOLD: float = 0.95
+CANONICAL_HRF_PEAK_RATIO: float = 1.0
+HBR_WAVELENGTH_LOW: int = 760
+HBR_WAVELENGTH_HIGH: int = 780
+HBO_WAVELENGTH_LOW: int = 830
+HBO_WAVELENGTH_HIGH: int = 850
+```
+
+**Risks:** Low — mechanical substitution.
+
+**Tests:** None specific; existing tests should pass unchanged.
+
+---
+
+### `feat/test-suite-restructure`
+
+**Priority:** Near the end of 2.0.0 work, after other refactors land.
+
+**Scope — Phase 12 + KI-033:**
+
+The `tests/test_estimation.py` and `tests/test_localization.py` files currently execute code at module-import time, which crashes pytest collection (KI-033). Move the module-level code into proper test functions, add `@pytest.mark.slow` or `@pytest.mark.integration` markers, and wire them into the CI pipeline.
+
+**Work:**
+
+1. **Convert existing scripts to pytest tests:**
+    ```python
+    # Currently:
+    print("TEST: Estimating HRF...")
+    for filetype_load, filetype in zip(...):
+        ...
+
+    # Should become:
+    @pytest.mark.integration
+    def test_hrf_estimation_nirx():
+        ...
+    ```
+
+2. **Add fixtures for common data loading:**
+    ```python
+    @pytest.fixture
+    def events():
+        return load_events()
+
+    @pytest.fixture(scope='session')
+    def nirx_scans():
+        return load_nirx_test_data()
+    ```
+
+3. **Mark data-heavy tests so they can be skipped in fast runs:**
+    ```python
+    @pytest.mark.slow
+    @pytest.mark.integration
+    def test_full_pipeline_on_real_dataset():
+        ...
+    ```
+
+4. **Guard optional data files:**
+    ```python
+    @pytest.fixture
+    def test_data_path():
+        path = Path('tests/data/sNIRF_formatted')
+        if not path.exists():
+            pytest.skip("Test data not available")
+        return path
+    ```
+
+5. **Unify the test gate:**
+    - Fast gate (CI, pre-commit): `pytest -m "not slow and not integration"`
+    - Full gate (pre-release): `pytest`
+
+6. **Fix test_localization.py RuntimeError-not-raised bug:**
+    ```python
+    # Currently (line 33, 50):
+    RuntimeError(f"ERROR: True channel {ch_name} not found...")
+
+    # Fix:
+    raise RuntimeError(f"ERROR: True channel {ch_name} not found...")
+    ```
+
+7. **Ensure the targeted test files from 1.2.0 are preserved and still run** as part of the fast gate.
+
+**Review protocol:**
+- Verify pytest collection succeeds on the full `tests/` directory
+- Verify fast and full gates each produce sensible output
+
+---
+
+### `feat/robustness-io`
+
+**Priority:** Anytime — standalone.
+
+**Scope — Phase 6 spillover:**
+
+Robustness guards that weren't critical enough for 1.2.0 but improve error messages:
+
+1. **JSON load:**
+    ```python
+    try:
+        with open(filename, 'r') as file:
+            data = json.load(file)
+    except FileNotFoundError:
+        raise FileNotFoundError(f"HRFunc montage file not found: {filename}")
+    except json.JSONDecodeError as e:
+        raise ValueError(f"Invalid JSON in {filename}: {e}")
+    ```
+
+2. **JSON save:**
+    ```python
+    try:
+        os.makedirs(os.path.dirname(filename), exist_ok=True)
+        with open(filename, "w") as file:
+            json.dump(data, file, indent=4)
+    except (IOError, OSError) as e:
+        raise IOError(f"Failed to save montage to {filename}: {e}")
+    ```
+
+3. **Plot paths:** `os.makedirs(os.path.dirname(plot_path), exist_ok=True)` before any `plt.savefig`.
+
+**Risks:** None.
+
+**Tests:** `tests/test_io_robustness.py` — trigger each error path with synthetic bad inputs.
+
+---
+
+### `feat/event-edge-warning`
+
+**Priority:** Anytime — standalone.
+
+**Scope:**
+
+In `estimate_hrf`, the edge expansion logic shifts events backward by `timeshift` samples and silently `continue`s any event that falls off the beginning of the scan. This biases HRF estimation toward late-session events if early events are preferentially lost.
+
+**Fix:**
+Track the count of dropped events and emit a `logger.warning` (or `UserWarning` via `warnings.warn`) when nonzero, including the count and the suggestion to reduce `edge_expansion` if this happens frequently.
+
+```python
+dropped_events = 0
+for ind in range(events.shape[0]):
+    if events[ind] != 0:
+        if (ind - timeshift) < 0:
+            dropped_events += 1
+            continue
+        new_events[ind - timeshift] = 1
+
+if dropped_events > 0:
+    logger.warning(
+        f"Dropped {dropped_events} event(s) during edge expansion "
+        f"(timeshift={timeshift} samples). Consider reducing edge_expansion "
+        f"or ensuring events are not at the scan start."
+    )
+```
+
+**Tests:** `tests/test_event_edge.py` — construct events near the boundary, verify warning is emitted with correct count.
+
+---
+
+### `feat/adaptive-regularization`
+
+**Priority:** Last, or deferred to 2.1.0 — design question, not a pure refactor.
+
+**Scope:**
+
+Currently `lmbda` is a fixed default (`1e-3` for estimate_hrf, `1e-4` for estimate_activity) regardless of the matrix magnitude. Tikhonov regularization works best when `lmbda` is scaled relative to the norm of the LHS (e.g. to a fraction of the largest eigenvalue or the Frobenius norm).
+
+**Investigation (not a fix):**
+
+1. Profile `np.linalg.cond(X.T @ X)` on realistic fNIRS datasets.
+2. Compare fixed `lmbda=1e-3` vs `lmbda = 1e-3 * np.linalg.norm(X, 'fro')` on several test datasets.
+3. Survey the fMRI/fNIRS literature for standard lmbda-scaling conventions.
+4. Report findings to Denny; decide whether to change the default or expose a `lmbda_scale='norm'` option alongside the fixed mode.
+
+**This is a design question, not a bug.** May not ship in 2.0.0 — document findings and defer if unclear.
+
+---
+
+## Sequencing Recommendation
+
+```
+1.2.0 ships, validated in real pipeline
+│
+├── refactor/composition              ← start here, biggest architectural change
+│   ├── refactor/shared-helpers
+│   │   ├── perf/estimate-hrf-batch
+│   │   └── perf/estimate-activity-parallel
+│   ├── feat/logging
+│   ├── feat/constants
+│   ├── feat/robustness-io
+│   └── feat/event-edge-warning
+│
+├── feat/type-hints                   ← after composition, before release
+│
+├── feat/test-suite-restructure       ← final gate
+│
+└── release/2.0.0                     ← tag, migration guide, PyPI
+```
+
+Branches in the same tier can proceed in parallel if someone wants to split the work across multiple sessions.
+
+---
+
+## Migration Guide for v1.2.0 → v2.0.0 Users
+
+To be written during `release/2.0.0`. Must cover:
+
+- **`isinstance(m, tree)` returns False now**: use duck-typed methods instead of type checks
+- **All `print` output is now logging**: users who want the old verbose behavior call `logging.basicConfig(level=logging.DEBUG)`
+- **`estimate_hrf` performance improvement** — same results, much faster
+- **Type hints available** — downstream projects can now `mypy` HRFunc usages
+- Any other observable changes from the refactors
+
+---
+
+## Summary
+
+11 branches across architectural, performance, cleanliness, and tooling work. Estimated work unit: 2–4 sessions for the heavy branches (`composition`, `parallel`, `test-suite-restructure`), 1 session each for the rest. Total scope is larger than 1.2.0 but lower risk per branch.

--- a/docs/plans/refactoring_plan.md
+++ b/docs/plans/refactoring_plan.md
@@ -1,0 +1,40 @@
+# HRFunc Refactoring Plan — Index
+
+**Status:** This document was decomposed on 2026-04-14 into three cohesive plans. Use the documents below instead of this one.
+
+---
+
+## Active Plans
+
+- **[phase_breakdown.md](phase_breakdown.md)** — Release roadmap. High-level v1.2.0 → v2.0.0 strategy, branch dependency chains, status of completed work, review protocol, release testing gates.
+
+- **[plan_v1_2_0.md](plan_v1_2_0.md)** — Detailed correctness-release plan. Branch-by-branch fixes scoped to 1.2.0 (crashes, silent wrong results, input validation, packaging). Target: PyPI release.
+
+- **[plan_v2_0_0.md](plan_v2_0_0.md)** — Detailed architectural-refactor plan. Branch-by-branch work scoped to 2.0.0 (composition refactor, performance, type hints, logging, test suite restructure). Ships after 1.2.0 validates in production.
+
+---
+
+## Supporting Documents
+
+- **[../internal/known_issues.md](../internal/known_issues.md)** — Authoritative issue catalogue with file:line refs. Contains KI-001..KI-034, NE-001..NE-007, ND-001..ND-006 plus newer findings (S1-S4, H1-H4, M1-M6, L1-L3) from the 2026-04-14 parallel review.
+
+- **[../internal/architecture.md](../internal/architecture.md)** — Module map, class responsibilities, execution paths, data pipeline.
+
+---
+
+## Why This Decomposition?
+
+The original monolithic `refactoring_plan.md` was 957 lines of code snippets frozen at the 2026-04-13 state of the codebase. Since then:
+
+- Four branches have landed on origin (phase1a, phase1bc, circular-imports-phase2, estimate-activity-threading)
+- Parallel agent reviews uncovered new issue classes (scientific correctness, state lifecycle, input validation) not in the original plan
+- Denny resolved several open questions (timeout=30s, poly order=3, S2/S3 are intentional a.u. conventions)
+- Release strategy was refined to split correctness (1.2.0) from architectural refactor (2.0.0)
+
+Rather than keep editing a single 1000-line document that mixes completed and pending work, the plan is now split by release target with each document focused on one release's scope.
+
+---
+
+## Historical Note
+
+The original `refactoring_plan.md` content (including detailed code snippets for Phases 1 through 12) is preserved in git history at commit `bb388a5` (`fix: phase 1b+1c — pipeline correctness, hash stability, context scoring`) and earlier. Pull it from git if you need the old snippet-level detail.


### PR DESCRIPTION
Brings every document under docs/ up to date with the current state of the v1.2.0 correctness release in-flight stack. Adds two new documents to cover gaps that became apparent during the audit.

## Updated

docs/external/api_reference.md
  - Version bumped from 1.1.2 to 1.2.0
  - Every function signature refreshed: estimate_activity timeout=30 (was 1500), load_montage schema-validation raises, estimate_hrf input validation raises, estimate_activity zero-trace canonical fallback, canonical HRF generated at scan sfreq, tree.branch AND-on-kwargs semantics, nearest_neighbor returns None on miss
  - New sections: return-value capture pattern, units convention, error handling table
  - hasher contract documented (list on miss, not False)
  - tree.delete no longer flagged as broken (fixed in fix/tree-delete-filter)
  - lens.__init__ sfreq kwarg documented

docs/internal/architecture.md
  - Module dependency graph updated to show _utils.py breaking the circular import
  - Every class responsibility section rewritten to match current state: lazy canonical via get_canonical_hrf, _copy_payload helper, _flatten_context_value helper, list-valued hasher, M4 drop-channel cleanup, M6 transactional configure, tree.insert jitter fix
  - Execution paths updated with the current ordering
  - "Known Architectural Problems" section now lists only v2.0.0 items
  - Links to v1_2_0_changelog_summary.md for per-fix attribution

docs/internal/known_issues.md
  - Restructured into RESOLVED (with branch attribution) vs OPEN
  - ~35 issues moved to the resolved column with branch citations
  - Open section split into v1.2.0 remaining (S1 ppf, release) and v2.0.0 scope (composition, logging, type hints, test restructure, etc.)
  - Issue ID key added at the bottom

docs/plans/plan_v1_2_0.md
  - Progress block now shows merged-vs-pushed status for 13 branches
  - Detailed per-branch change summaries for every landed branch (previously only had the first 4)
  - Full gate reports 213 passed, 0 xfailed

docs/plans/phase_breakdown.md
  - Status table expanded to 13 rows with merge state
  - Branch summary collapsed to only the 2 remaining branches

## Added

docs/internal/v1_2_0_changelog_summary.md
  - Authoritative per-branch change summary grouped by theme (pipeline correctness, data structures, API surface, helpers, canonical HRF, lint sweep, infrastructure, circular import refactor)
  - Source of truth for the eventual CHANGELOG.md entry and PyPI release notes
  - Architecture state contrast: what is and isn't different after v1.2.0
  - Release gate reference for release/1.2.0 packaging

docs/external/workflow_examples.md
  - Six end-to-end user workflows:
    1. Localize pre-trained HRFs to a new scan
    2. Estimate per-subject HRFs then deconvolve neural activity
    3. Load a saved montage and apply it
    4. Filter HRFs by experimental context
    5. QC metrics with lens
    6. Minimal sanity check without real data
  - Error-handling cheat sheet mapping common exceptions to causes
  - Units reminder and supported scan formats section

Also tracks the previously-untracked docs/plans/phase_breakdown.md, plan_v2_0_0.md, and refactoring_plan.md which had existed locally across sessions but had never been committed.