### PR TITLE
feat: add progress_callback to estimate_hrf and estimate_activity (GU…

### DIFF
--- a/src/hrfunc/hrfunc.py
+++ b/src/hrfunc/hrfunc.py
@@ -324,9 +324,9 @@ class montage(tree):
         
         return estimate
 
-    def estimate_hrf(self, nirx_obj, events, duration = 30.0, lmbda = 1e-3, edge_expansion = 0.15, preprocess = True):
+    def estimate_hrf(self, nirx_obj, events, duration = 30.0, lmbda = 1e-3, edge_expansion = 0.15, preprocess = True, progress_callback = None):
         """
-        Estimate an HRF subject wise given a nirx object and event impulse series using toeplitz 
+        Estimate an HRF subject wise given a nirx object and event impulse series using toeplitz
         deconvolution with regularization.
 
         Arguments:
@@ -336,7 +336,13 @@ class montage(tree):
             lmbda (float) - Regularization parameter to apply during deconvolution
             edge_expansion (float) - Fraction of the duration to expand the events and duration by to account for toeplitz edge artifacts
             preprocess (bool) - If True, preprocess the fNIRS data before estimating the HRF
-        
+            progress_callback (callable or None) - Optional callable invoked at the start of each
+                channel iteration with (current_index, total_channels, channel_name). current_index
+                is 0-indexed; the final iteration is (total_channels - 1, total_channels, name).
+                channel_name is the standardized form (matching self.channels keys) so callers
+                see the same naming convention as estimate_activity. Used by GUI/batch tooling to
+                surface progress; exceptions raised by the callback propagate. Default None (no-op).
+
         Returns:
             None
         """
@@ -399,7 +405,10 @@ class montage(tree):
 
         # Build Toeplitz matrix
         X = scipy.linalg.toeplitz(events, np.zeros(hrf_len))
-        for fnirs_signal, channel in zip(data[:], nirx_obj.info['chs']) : # For each channel
+        total_channels = len(nirx_obj.info['chs'])
+        for i, (fnirs_signal, channel) in enumerate(zip(data[:], nirx_obj.info['chs'])): # For each channel
+            if progress_callback is not None:
+                progress_callback(i, total_channels, standardize_name(channel['ch_name']))
             print(f"Deconvolving HRF from channel {channel}")
             # Grab channel data and normalize
             #Y = fnirs_signal / np.max(np.abs(fnirs_signal))
@@ -430,7 +439,7 @@ class montage(tree):
             optode.locations.append(list(channel['loc'][:3]))
 
 
-    def estimate_activity(self, nirx_obj, lmbda = 1e-4, hrf_model = 'toeplitz', preprocess = True, cond_thresh = None, timeout = 30):
+    def estimate_activity(self, nirx_obj, lmbda = 1e-4, hrf_model = 'toeplitz', preprocess = True, cond_thresh = None, timeout = 30, progress_callback = None):
         """
         Deconvlve a fNIRS scan using estimated HRF's localized to optodes location
         to gain a neural activity estimate
@@ -445,6 +454,11 @@ class montage(tree):
                 Default 30 is a generous ceiling — realistic fNIRS inputs solve in tens of milliseconds,
                 so this fires only on genuinely pathological matrices. Can be tightened once empirical
                 solve-time data is collected from real runs.
+            progress_callback (callable or None) - Optional callable invoked at the start of each
+                channel iteration with (current_index, total_channels, channel_name). current_index
+                is 0-indexed and counts every entry in self.channels including 'global' entries that
+                are skipped internally, so the callback fires exactly total_channels times. Exceptions
+                raised by the callback propagate. Default None (no-op).
 
         Returns:
             nirx_obj (mne raw object) - Raw with deconvolved neural activity, or None if skipped
@@ -521,7 +535,11 @@ class montage(tree):
         # Iterate a snapshot of channel names so we can safely pop orphaned
         # entries inside the loop when deconvolution fails (M4).
         dropped_channels = []
-        for ch_name in list(self.channels.keys()):
+        all_channels = list(self.channels.keys())
+        total_channels = len(all_channels)
+        for i, ch_name in enumerate(all_channels):
+            if progress_callback is not None:
+                progress_callback(i, total_channels, ch_name)
             hrf = self.channels[ch_name]
             success = None  # reset per channel so stale state can't leak from prior iteration
 

--- a/tests/test_progress_callbacks.py
+++ b/tests/test_progress_callbacks.py
@@ -1,0 +1,176 @@
+"""
+Targeted unit tests for feat/progress-callbacks (v1.3.0 GUI foundation).
+
+Adds an optional `progress_callback(current_index, total_channels, channel_name)`
+parameter to `montage.estimate_hrf` and `montage.estimate_activity`. The callback
+fires once at the start of each channel iteration so GUI/batch tooling can render
+progress without polling.
+
+Tests verify the wiring without exercising the full pipeline (which requires a
+real fNIRS Raw fixture). Behavior under real data is covered by integration
+tests in test_estimation.py (currently disabled at module level — KI-033).
+"""
+
+import inspect
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Signature contracts: parameter exists with default None
+# ---------------------------------------------------------------------------
+
+class TestEstimateHrfSignature:
+    def test_progress_callback_is_a_parameter(self):
+        from hrfunc.hrfunc import montage
+        sig = inspect.signature(montage.estimate_hrf)
+        assert 'progress_callback' in sig.parameters
+
+    def test_progress_callback_defaults_to_none(self):
+        from hrfunc.hrfunc import montage
+        sig = inspect.signature(montage.estimate_hrf)
+        assert sig.parameters['progress_callback'].default is None
+
+    def test_progress_callback_is_keyword_compatible(self):
+        """Must be passable as a keyword arg so callers don't need to know
+        the position of every other parameter."""
+        from hrfunc.hrfunc import montage
+        sig = inspect.signature(montage.estimate_hrf)
+        param = sig.parameters['progress_callback']
+        assert param.kind in (
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+            inspect.Parameter.KEYWORD_ONLY,
+        )
+
+
+class TestEstimateActivitySignature:
+    def test_progress_callback_is_a_parameter(self):
+        from hrfunc.hrfunc import montage
+        sig = inspect.signature(montage.estimate_activity)
+        assert 'progress_callback' in sig.parameters
+
+    def test_progress_callback_defaults_to_none(self):
+        from hrfunc.hrfunc import montage
+        sig = inspect.signature(montage.estimate_activity)
+        assert sig.parameters['progress_callback'].default is None
+
+    def test_progress_callback_is_keyword_compatible(self):
+        from hrfunc.hrfunc import montage
+        sig = inspect.signature(montage.estimate_activity)
+        param = sig.parameters['progress_callback']
+        assert param.kind in (
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+            inspect.Parameter.KEYWORD_ONLY,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Source-pattern contracts: the callback is invoked inside the per-channel loop
+# with the expected (index, total, name) signature
+# ---------------------------------------------------------------------------
+
+class TestEstimateHrfCallbackWiring:
+    def test_loop_uses_enumerate(self):
+        """Without enumerate(), there is no per-iteration index to pass to
+        the callback. Regression guard: a future refactor that drops the
+        index would silently break progress reporting."""
+        from hrfunc.hrfunc import montage
+        source = inspect.getsource(montage.estimate_hrf)
+        assert 'for i, (fnirs_signal, channel) in enumerate(' in source
+
+    def test_total_channels_computed_before_loop(self):
+        from hrfunc.hrfunc import montage
+        source = inspect.getsource(montage.estimate_hrf)
+        assert 'total_channels = len(nirx_obj.info[\'chs\'])' in source
+
+    def test_callback_invoked_with_index_total_standardized_name(self):
+        """Name passed to callback must be the standardized form (matching
+        self.channels keys) so GUI code can use a single naming convention
+        across both estimate_hrf and estimate_activity callbacks."""
+        from hrfunc.hrfunc import montage
+        source = inspect.getsource(montage.estimate_hrf)
+        assert "progress_callback(i, total_channels, standardize_name(channel['ch_name']))" in source
+
+    def test_callback_guarded_by_none_check(self):
+        """None default must short-circuit so existing callers see no behavior
+        change. Bare `progress_callback(...)` would raise TypeError on None."""
+        from hrfunc.hrfunc import montage
+        source = inspect.getsource(montage.estimate_hrf)
+        assert 'if progress_callback is not None:' in source
+
+
+class TestEstimateActivityCallbackWiring:
+    def test_loop_uses_enumerate_over_channel_snapshot(self):
+        from hrfunc.hrfunc import montage
+        source = inspect.getsource(montage.estimate_activity)
+        assert 'all_channels = list(self.channels.keys())' in source
+        assert 'for i, ch_name in enumerate(all_channels):' in source
+
+    def test_total_channels_computed_before_loop(self):
+        from hrfunc.hrfunc import montage
+        source = inspect.getsource(montage.estimate_activity)
+        assert 'total_channels = len(all_channels)' in source
+
+    def test_callback_invoked_with_index_total_name(self):
+        from hrfunc.hrfunc import montage
+        source = inspect.getsource(montage.estimate_activity)
+        assert 'progress_callback(i, total_channels, ch_name)' in source
+
+    def test_callback_guarded_by_none_check(self):
+        from hrfunc.hrfunc import montage
+        source = inspect.getsource(montage.estimate_activity)
+        assert 'if progress_callback is not None:' in source
+
+    def test_callback_fires_before_global_skip(self):
+        """A 'global' channel entry is skipped via `continue` but the callback
+        must still fire for it — total_channels counts every entry in
+        self.channels so the caller sees a monotonic 0..N-1 progression.
+        Regression guard: if the callback moves below the continue, the
+        progress bar will appear to stall on global entries."""
+        from hrfunc.hrfunc import montage
+        source = inspect.getsource(montage.estimate_activity)
+        # Locate both lines and assert the callback appears first
+        callback_idx = source.index('progress_callback(i, total_channels, ch_name)')
+        global_skip_idx = source.index("if 'global' in ch_name: continue")
+        assert callback_idx < global_skip_idx, (
+            "progress_callback must fire before the 'global' skip so "
+            "total_channels and the current_index stay consistent"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Backwards-compatibility contracts: existing call patterns still work
+# ---------------------------------------------------------------------------
+
+class TestBackwardsCompatibility:
+    """progress_callback is purely additive. Existing kwargs must still bind."""
+
+    def test_estimate_hrf_existing_kwargs_unchanged(self):
+        from hrfunc.hrfunc import montage
+        sig = inspect.signature(montage.estimate_hrf)
+        for name in ('nirx_obj', 'events', 'duration', 'lmbda',
+                     'edge_expansion', 'preprocess'):
+            assert name in sig.parameters
+
+    def test_estimate_activity_existing_kwargs_unchanged(self):
+        from hrfunc.hrfunc import montage
+        sig = inspect.signature(montage.estimate_activity)
+        for name in ('nirx_obj', 'lmbda', 'hrf_model', 'preprocess',
+                     'cond_thresh', 'timeout'):
+            assert name in sig.parameters
+
+    def test_estimate_hrf_progress_callback_is_last_param(self):
+        """Positional ordering: progress_callback must come after the existing
+        params so old positional calls like
+        `estimate_hrf(nirx, events, 30.0, 1e-3, 0.15, True)` keep binding the
+        same names."""
+        from hrfunc.hrfunc import montage
+        sig = inspect.signature(montage.estimate_hrf)
+        params = list(sig.parameters.keys())
+        assert params[-1] == 'progress_callback'
+
+    def test_estimate_activity_progress_callback_is_last_param(self):
+        from hrfunc.hrfunc import montage
+        sig = inspect.signature(montage.estimate_activity)
+        params = list(sig.parameters.keys())
+        assert params[-1] == 'progress_callback'


### PR DESCRIPTION
…I foundation 1/4)

First of four foundation branches for the v1.3.0 GUI. Adds an optional progress_callback parameter to both deconvolution entry points so a GUI or batch caller can render per-channel progress without polling or patching the per-channel print statements. Default None preserves all existing call semantics.

Why this lands first:
The v1.3.0 GUI runs estimation in a background task. Without a callback hook, the UI either freezes for minutes (estimation is the longest- running operation in the library) or has to scrape stdout. Both are unacceptable. Building the callback into the core means every caller — GUI, future batch CLI, notebooks — gets progress reporting from one public API.

Changes:
- montage.estimate_hrf gains progress_callback=None as the last parameter. Loop is now `for i, (fnirs_signal, channel) in enumerate(...)` and the callback fires at the top of each iteration with (current_index, total_channels, channel_name).
- montage.estimate_activity gains the same parameter with the same semantics. all_channels is hoisted to a local list outside the enumerate so total_channels is computed once. The callback fires before the `if 'global' in ch_name: continue` skip so total and current_index stay consistent across all entries in self.channels.
- Both methods pass the standardized channel name (matching self.channels keys) for cross-method consistency. estimate_hrf calls standardize_name(channel[ch_name]); estimate_activity passes ch_name directly since it is already standardized. GUI display code can use a single naming convention regardless of which method is running.

API contract:
- callback(current_index, total_channels, channel_name)
- current_index is 0-indexed; final call is (total - 1, total, name)
- Exceptions raised by the callback propagate (intentional — silent swallowing would hide user errors)
- Slow callbacks slow estimation by design — the GUI callback will do nothing but update state, so this is a non-issue in practice

Tests (tests/test_progress_callbacks.py, 19 new tests):
- Signature contracts: parameter exists, defaults to None, is keyword- compatible, sits last in the signature (positional back-compat)
- Source-pattern contracts: enumerate is used, total is hoisted, the callback line uses the (i, total, name) signature, the None guard is present, and (estimate_activity only) the callback fires before the global skip
- Backwards-compatibility: every existing kwarg remains in both signatures

Gate:
  pytest tests/test_phase1a.py tests/test_phase1bc.py tests/test_phase2.py tests/test_threading.py tests/test_input_validation.py tests/test_state_lifecycle.py tests/test_oxygenation_guard.py tests/test_tree_delete_filter.py tests/test_hasher_branch.py tests/test_tree_hrf.py tests/test_canonical_hrf.py tests/test_tree_edge_cases.py tests/test_observer_and_typos.py tests/test_progress_callbacks.py -q → 232 passed in 3.00s (213 prior + 19 new, zero regressions)

Reviews:
- Architecture & Execution Flow: additive within two methods. No new imports, no new exports, no module-graph changes. Callback runs in the outer thread; the per-channel ThreadPoolExecutor in estimate_activity is unaffected. No data-flow impact — callback is informational only.
- API Surface & Usability: caught a name-convention inconsistency in the initial draft (estimate_hrf was passing MNE-style "S1_D1 hbo" while estimate_activity was passing standardized "s1_d1_hbo"). Fixed by standardizing in both. 0-indexed convention chosen for compatibility with percent-done math and documented explicitly in both docstrings.

Gotchas:
- progress_callback fires for 'global' channel entries in estimate_activity even though the loop body skips them via continue. This keeps total_channels and current_index consistent; the GUI sees a clean 0..N-1 progression without gaps.
- Sprints 2-4 of the v1.3.0 foundation (io.detect, io.scan + manifest
  + XDG cache, io.raw_cache) are coming on separate branches.