### PR TITLE
fix: generate_distribution(plot_dir=...) actually produces plots

### DIFF
--- a/src/hrfunc/hrfunc.py
+++ b/src/hrfunc/hrfunc.py
@@ -634,7 +634,16 @@ class montage(tree):
             optode.update_centroid()
 
             if plot_dir: # Plot if requested
-                optode.plot(plot_dir)
+                # HRF.plot was refactored to accept a full file path
+                # instead of a directory. Construct the per-channel
+                # filename here and ensure the directory exists.
+                # show=False so cluster / headless runs don't block on
+                # plt.show() and don't keep figure state around between
+                # channels.
+                os.makedirs(plot_dir, exist_ok=True)
+                plot_path = os.path.join(plot_dir, f"{optode.ch_name}_hrf.png")
+                optode.plot(plot_path, show=False)
+                plt.close('all')
             
             if optode.oxygenation: # Append data
                 hbo_estimates.append(optode.trace)

--- a/tests/test_generate_distribution_plotting.py
+++ b/tests/test_generate_distribution_plotting.py
@@ -1,0 +1,97 @@
+"""
+Targeted unit tests for montage.generate_distribution(plot_dir=...) plotting.
+
+Bug history: HRF.plot() was refactored from `plot(self, plot_dir)`
+(which built the per-channel filename internally as
+`{plot_dir}/{ch_name}_hrf_estimate.png`) to `plot(self, plot_path=None)`
+(treats the arg as the full file path). montage.generate_distribution
+was never updated and continued to pass the directory to plot(), so
+`plt.savefig("plots/")` silently failed or raised IsADirectoryError
+and no per-channel plots were produced.
+
+The fix: generate_distribution now builds the per-channel filename
+inside plot_dir, ensures plot_dir exists, and passes show=False so
+headless cluster runs don't block on plt.show().
+
+Tests use the Agg backend so they run on any environment.
+"""
+
+import os
+import matplotlib
+matplotlib.use("Agg")
+
+import numpy as np
+import pytest
+
+
+def _populated_montage():
+    """Build a montage with a couple of channels that have estimates ready
+    for generate_distribution to consume."""
+    from hrfunc.hrfunc import montage
+    from hrfunc.hrtree import HRF
+
+    m = montage()
+    m.sfreq = 7.81
+
+    # Insert two channels with synthetic estimates
+    hbo = HRF('doi', 's1_d1_hbo', 30.0, 7.81, np.zeros(234),
+              location=[0.0, 0.0, 0.0], estimates=[], locations=[])
+    hbo.estimates = [list(np.linspace(0, 1, 234))]
+    hbo.locations = [[0.0, 0.0, 0.0]]
+    hbr = HRF('doi', 's1_d1_hbr', 30.0, 7.81, np.zeros(234),
+              location=[0.01, 0.0, 0.0], estimates=[], locations=[])
+    hbr.estimates = [list(-np.linspace(0, 1, 234))]
+    hbr.locations = [[0.01, 0.0, 0.0]]
+
+    m.channels['s1_d1_hbo'] = m.hbo_tree.insert(hbo)
+    m.channels['s1_d1_hbr'] = m.hbr_tree.insert(hbr)
+    m.hbo_channels = ['s1_d1_hbo']
+    m.hbr_channels = ['s1_d1_hbr']
+
+    return m
+
+
+class TestGenerateDistributionPlotting:
+    def test_plot_dir_creates_per_channel_files(self, tmp_path):
+        m = _populated_montage()
+        plot_dir = str(tmp_path / "plots")
+
+        m.generate_distribution(plot_dir=plot_dir)
+
+        # Both channels should have produced a PNG
+        assert os.path.isdir(plot_dir)
+        files = os.listdir(plot_dir)
+        assert any('s1_d1_hbo' in f and f.endswith('.png') for f in files), files
+        assert any('s1_d1_hbr' in f and f.endswith('.png') for f in files), files
+
+    def test_plot_dir_created_if_missing(self, tmp_path):
+        m = _populated_montage()
+        # Use a nested dir that doesn't exist yet
+        plot_dir = str(tmp_path / "deep" / "nested" / "plots")
+        assert not os.path.exists(plot_dir)
+
+        m.generate_distribution(plot_dir=plot_dir)
+
+        assert os.path.isdir(plot_dir)
+        assert any(f.endswith('.png') for f in os.listdir(plot_dir))
+
+    def test_no_plot_dir_skips_plotting(self, tmp_path, monkeypatch):
+        """When plot_dir is None / falsy, no plots should be produced and
+        no directory should be created."""
+        m = _populated_montage()
+        # Run inside tmp_path so any accidental relative writes are caught
+        monkeypatch.chdir(tmp_path)
+
+        m.generate_distribution()  # plot_dir defaults to None
+
+        # No stray files written in cwd
+        assert os.listdir(tmp_path) == []
+
+    def test_plot_call_does_not_block_on_show(self, tmp_path):
+        """Regression guard for the show=True default: generate_distribution
+        must pass show=False so headless / cluster runs don't try to
+        open an interactive window."""
+        import inspect
+        from hrfunc.hrfunc import montage
+        src = inspect.getsource(montage.generate_distribution)
+        assert 'show=False' in src


### PR DESCRIPTION
Caught during stress-test of the v1.2.0 stack on Denny's P-CAT pipeline — montage.generate_distribution(plot_dir="plots/") completed without errors but produced no PNG files.

Root cause:

HRF.plot() was refactored at some point from
    def plot(self, plot_dir, show_legend=True):
        ...
        plt.savefig(f"{plot_dir}/{self.ch_name}_hrf_estimate.png")
to
    def plot(self, plot_path=None, show_legend=True, show=True):
        ...
        if plot_path is not None:
            plt.savefig(plot_path)

The new API treats the first arg as a FULL FILE PATH instead of a directory. montage.generate_distribution was not updated for the new contract and continued to pass the directory:

    if plot_dir:
        optode.plot(plot_dir)   # <-- plt.savefig("plots/") -> IsADirectoryError

The IsADirectoryError either crashed silently (depending on backend / exception handling chain) or wrote a single weirdly-named file that was overwritten by every subsequent channel. Either way, no per-channel plots were produced.

Pre-existing bug; the Jan 27 plots in Denny's LCBDtools/scripts plots/ directory were generated by the OLD HRF.plot API. After the refactor the plotting silently stopped working.

Fix (src/hrfunc/hrfunc.py:636-644):
  - Construct the per-channel filename inside plot_dir: `{plot_dir}/{ch_name}_hrf.png`
  - `os.makedirs(plot_dir, exist_ok=True)` so the directory is created if missing (matches the v2.0.0 robustness plan for plot paths)
  - Pass `show=False` so headless / cluster runs don't block on plt.show() and figures don't accumulate between channels
  - `plt.close('all')` after each channel to release memory

Tests: tests/test_generate_distribution_plotting.py (4 tests)
  - Plot dir creates per-channel files
  - Nested plot dir is created if missing
  - plot_dir=None produces no files (no stray writes)
  - Source-level regression guard for show=False

Gate: 217 passed, 0 xfailed across the full targeted suite.