### PR TITLE
feat: scan_folder with Manifest + XDG cache (GUI foundation 3/4)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "scipy",
     "nilearn",
     "matplotlib",
+    "platformdirs>=3.0",
     ]
 
 [project.urls]
@@ -32,7 +33,7 @@ Documentation = "https://www.hrfunc.org"
 
 [tool.setuptools]
 package-dir = {"" = "src"}
-packages = ["hrfunc"]
+packages = ["hrfunc", "hrfunc.io"]
 include-package-data = true
 
 [tool.pytest.ini_options]

--- a/src/hrfunc/io/__init__.py
+++ b/src/hrfunc/io/__init__.py
@@ -3,9 +3,19 @@ and Raw caching for the v1.3.0 GUI.
 
 Public API:
     classify_path(path) -> FormatHit | None
-    FormatHit (dataclass)
+    scan_folder(root, ...) -> Manifest
+    FormatHit, ScanEntry, ScanError, Manifest (dataclasses)
 """
 
 from .detect import FormatHit, classify_path
+from .manifest import Manifest, ScanEntry, ScanError
+from .scan import scan_folder
 
-__all__ = ["FormatHit", "classify_path"]
+__all__ = [
+    "FormatHit",
+    "Manifest",
+    "ScanEntry",
+    "ScanError",
+    "classify_path",
+    "scan_folder",
+]

--- a/src/hrfunc/io/manifest.py
+++ b/src/hrfunc/io/manifest.py
@@ -1,0 +1,154 @@
+"""Manifest dataclasses for ``hrfunc.io.scan_folder``.
+
+A Manifest is the structured result of walking a folder for fNIRS datasets:
+one ScanEntry per detected dataset, plus any ScanError encountered along the
+way. Manifests are designed to be:
+
+- **Frozen and tuple-backed** so they can be cached safely and shared across
+  threads (the v1.3.0 GUI dataset tree is rendered from a cached manifest).
+- **JSON-round-trippable** so the XDG cache on disk can be reloaded into the
+  same shape on the next launch.
+
+The dataclasses live in their own module (rather than inside ``scan.py``) so
+they can be imported without pulling in MNE — the GUI's dataset-tree widget
+needs the types but not the scanning machinery.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional, Tuple, Union
+
+MANIFEST_SCHEMA_VERSION = 1
+
+
+@dataclass(frozen=True)
+class ScanEntry:
+    """One detected fNIRS dataset.
+
+    Attributes:
+        format: ``"snirf"``, ``"nirx_dir"``, or ``"fif"`` — matches the values
+            produced by ``hrfunc.io.classify_path``.
+        path: Absolute path to the dataset (file for snirf/fif, directory for
+            nirx_dir).
+        bids_subject: Subject identifier parsed opportunistically from the
+            path (``"sub-XX"`` segment) or None.
+        bids_session: Session identifier (``"ses-YY"``) or None.
+        bids_task: Task identifier (``"_task-NNN"`` filename infix) or None.
+        bids_run: Run identifier (``"_run-N"`` filename infix) or None.
+        display_name: Human-readable label for the GUI tree. BIDS components
+            when available, otherwise ``<parent>/<filename>``.
+        n_channels: Channel count when cheaply available, otherwise None.
+        sfreq: Sampling frequency in Hz when cheaply available, otherwise None.
+    """
+
+    format: str
+    path: Path
+    bids_subject: Optional[str] = None
+    bids_session: Optional[str] = None
+    bids_task: Optional[str] = None
+    bids_run: Optional[str] = None
+    display_name: str = ""
+    n_channels: Optional[int] = None
+    sfreq: Optional[float] = None
+
+    def to_dict(self) -> dict:
+        return {
+            "format": self.format,
+            "path": str(self.path),
+            "bids_subject": self.bids_subject,
+            "bids_session": self.bids_session,
+            "bids_task": self.bids_task,
+            "bids_run": self.bids_run,
+            "display_name": self.display_name,
+            "n_channels": self.n_channels,
+            "sfreq": self.sfreq,
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "ScanEntry":
+        return cls(
+            format=d["format"],
+            path=Path(d["path"]),
+            bids_subject=d.get("bids_subject"),
+            bids_session=d.get("bids_session"),
+            bids_task=d.get("bids_task"),
+            bids_run=d.get("bids_run"),
+            display_name=d.get("display_name", ""),
+            n_channels=d.get("n_channels"),
+            sfreq=d.get("sfreq"),
+        )
+
+
+@dataclass(frozen=True)
+class ScanError:
+    """A path that could not be classified during scanning.
+
+    Errors are collected non-fatally so the GUI can surface "we couldn't read
+    these N paths" without losing the rest of the scan. The reason field is a
+    short human-readable string suitable for display.
+    """
+
+    path: Path
+    reason: str
+
+    def to_dict(self) -> dict:
+        return {"path": str(self.path), "reason": self.reason}
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "ScanError":
+        return cls(path=Path(d["path"]), reason=d["reason"])
+
+
+@dataclass(frozen=True)
+class Manifest:
+    """Frozen result of a folder scan.
+
+    Attributes:
+        root: Absolute path of the scan root.
+        scans: Tuple of detected datasets, ordered by walk order.
+        errors: Tuple of paths that failed classification.
+        scanned_at: UTC timestamp of when the scan completed.
+        schema_version: Format version of the cached representation; used to
+            invalidate caches when this module's schema changes.
+    """
+
+    root: Path
+    scans: Tuple[ScanEntry, ...] = field(default_factory=tuple)
+    errors: Tuple[ScanError, ...] = field(default_factory=tuple)
+    scanned_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+    schema_version: int = MANIFEST_SCHEMA_VERSION
+
+    def to_dict(self) -> dict:
+        return {
+            "schema_version": self.schema_version,
+            "root": str(self.root),
+            "scans": [s.to_dict() for s in self.scans],
+            "errors": [e.to_dict() for e in self.errors],
+            "scanned_at": self.scanned_at.isoformat(),
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "Manifest":
+        if d.get("schema_version") != MANIFEST_SCHEMA_VERSION:
+            raise ValueError(
+                f"Manifest schema version mismatch: cache is "
+                f"{d.get('schema_version')}, current is {MANIFEST_SCHEMA_VERSION}"
+            )
+        return cls(
+            root=Path(d["root"]),
+            scans=tuple(ScanEntry.from_dict(s) for s in d.get("scans", [])),
+            errors=tuple(ScanError.from_dict(e) for e in d.get("errors", [])),
+            scanned_at=datetime.fromisoformat(d["scanned_at"]),
+            schema_version=d["schema_version"],
+        )
+
+    def to_json(self) -> str:
+        return json.dumps(self.to_dict(), indent=2)
+
+    @classmethod
+    def from_json(cls, text: Union[str, bytes]) -> "Manifest":
+        return cls.from_dict(json.loads(text))

--- a/src/hrfunc/io/scan.py
+++ b/src/hrfunc/io/scan.py
@@ -1,0 +1,328 @@
+"""Folder scanner producing a Manifest of detected fNIRS datasets.
+
+``scan_folder(root)`` walks a directory tree, classifies each path via
+``hrfunc.io.classify_path``, and returns a frozen ``Manifest``. Results are
+persisted to an XDG cache so subsequent scans of the same root are instant.
+
+Design notes:
+- NIRx directories are *not* recursed into. Once a directory classifies as
+  ``nirx_dir``, its subtree is pruned. This avoids wasted work on
+  ``*.wl1``/``*.wl2``/``*.hdr`` files inside the acquisition.
+- Common noise directories (``.git``, ``.venv``, ``__pycache__``,
+  ``node_modules``) are pruned by name. Researchers regularly drop fNIRS data
+  into project trees that also contain code/build artifacts.
+- BIDS metadata is parsed opportunistically via regex. No ``pybids``
+  dependency; this works for ``sub-XX/ses-YY/`` style layouts even when the
+  full BIDS spec is not followed.
+- Cache invalidation is explicit (``force_rescan=True``) rather than
+  mtime-driven. Auto-invalidation would require walking the tree to compare
+  mtimes, defeating the purpose of the cache. The GUI will expose a "Rescan"
+  button so users can refresh on demand.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+import re
+from pathlib import Path
+from typing import Iterator, List, Optional, Set, Union
+
+from .detect import FormatHit, classify_path
+from .manifest import Manifest, ScanEntry, ScanError
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_MAX_DEPTH = 6
+DEFAULT_IGNORE_NAMES: frozenset = frozenset({
+    ".git",
+    ".venv",
+    "venv",
+    "__pycache__",
+    "node_modules",
+    ".pytest_cache",
+    ".mypy_cache",
+    ".idea",
+    ".vscode",
+})
+
+# Opportunistic BIDS parsers — match the standard sub-/ses-/task-/run- entities.
+# Intentionally lenient: any path segment matching the pattern wins.
+_BIDS_SUBJECT_RE = re.compile(r"sub-([A-Za-z0-9]+)")
+_BIDS_SESSION_RE = re.compile(r"ses-([A-Za-z0-9]+)")
+_BIDS_TASK_RE = re.compile(r"_task-([A-Za-z0-9]+)")
+_BIDS_RUN_RE = re.compile(r"_run-([A-Za-z0-9]+)")
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+def scan_folder(
+    root: Union[str, Path],
+    max_depth: int = DEFAULT_MAX_DEPTH,
+    ignore_names: Optional[Set[str]] = None,
+    use_cache: bool = True,
+    force_rescan: bool = False,
+) -> Manifest:
+    """Walk a folder and return a manifest of detected fNIRS datasets.
+
+    Args:
+        root: Directory to scan. Must exist and be a directory.
+        max_depth: Maximum directory depth (relative to root) to descend.
+            Default 6 — deep enough for ``study/sub-XX/ses-YY/nirs/file``
+            layouts plus headroom, shallow enough to bound runtime.
+        ignore_names: Directory names to skip wholesale. Defaults to
+            DEFAULT_IGNORE_NAMES (venv/git/cache directories). Pass an
+            explicit set to override.
+        use_cache: If True, save the resulting manifest to the XDG cache
+            and load existing cached manifests on subsequent calls.
+        force_rescan: If True, ignore any cached manifest for this root
+            and always walk the tree. Cache is still written (overwriting
+            the old entry) when ``use_cache`` is True.
+
+    Returns:
+        A Manifest. Always returned — empty scans tuple if nothing matched.
+
+    Raises:
+        FileNotFoundError: If root does not exist.
+        NotADirectoryError: If root is not a directory.
+    """
+    root_path = Path(root).resolve()
+    if not root_path.exists():
+        raise FileNotFoundError(f"Scan root does not exist: {root_path}")
+    if not root_path.is_dir():
+        raise NotADirectoryError(f"Scan root is not a directory: {root_path}")
+
+    if use_cache and not force_rescan:
+        cached = _load_cached_manifest(root_path)
+        if cached is not None:
+            return cached
+
+    ignore = ignore_names if ignore_names is not None else set(DEFAULT_IGNORE_NAMES)
+
+    scans: List[ScanEntry] = []
+    errors: List[ScanError] = []
+
+    for hit_or_error in _walk_and_classify(root_path, max_depth, ignore):
+        if isinstance(hit_or_error, ScanError):
+            errors.append(hit_or_error)
+        else:
+            scans.append(_build_entry(hit_or_error, root_path))
+
+    manifest = Manifest(
+        root=root_path,
+        scans=tuple(scans),
+        errors=tuple(errors),
+    )
+
+    if use_cache:
+        _save_manifest(manifest)
+
+    return manifest
+
+
+# ---------------------------------------------------------------------------
+# Walk + classify
+# ---------------------------------------------------------------------------
+
+
+def _walk_and_classify(
+    root: Path,
+    max_depth: int,
+    ignore_names: Set[str],
+) -> Iterator:
+    """Walk the tree, yielding FormatHit or ScanError for each interesting path.
+
+    The walker:
+    1. Classifies the current directory first — catches NIRx acquisition dirs.
+    2. If the current dir is a NIRx hit, yields the hit and prunes its subtree.
+    3. Otherwise classifies each contained file and yields any hit.
+
+    Directories named in ``ignore_names`` are pruned wholesale before any
+    classification work.
+    """
+    for current_dir_str, subdirs, files in os.walk(root):
+        current_dir = Path(current_dir_str)
+
+        try:
+            depth = len(current_dir.relative_to(root).parts)
+        except ValueError:
+            depth = 0
+
+        if depth > max_depth:
+            subdirs.clear()
+            continue
+
+        # Prune well-known noise directories before recursing into them
+        subdirs[:] = [d for d in subdirs if d not in ignore_names]
+
+        # Classify the directory itself first — catches NIRx acquisition dirs
+        try:
+            dir_hit = classify_path(current_dir)
+        except Exception as exc:
+            errors_yield = ScanError(path=current_dir, reason=str(exc))
+            yield errors_yield
+            dir_hit = None
+
+        if dir_hit is not None and dir_hit.format == "nirx_dir":
+            yield dir_hit
+            subdirs.clear()  # do not descend into the acquisition
+            continue
+
+        # Classify each file in this directory
+        for filename in files:
+            file_path = current_dir / filename
+            try:
+                file_hit = classify_path(file_path)
+            except Exception as exc:
+                yield ScanError(path=file_path, reason=str(exc))
+                continue
+            if file_hit is not None:
+                yield file_hit
+
+
+# ---------------------------------------------------------------------------
+# Entry construction — BIDS parsing + display name
+# ---------------------------------------------------------------------------
+
+
+def _build_entry(hit: FormatHit, root: Path) -> ScanEntry:
+    """Convert a FormatHit into a ScanEntry with BIDS metadata and display name."""
+    bids = _parse_bids_metadata(hit.path, root)
+    display = _make_display_name(hit, bids)
+    return ScanEntry(
+        format=hit.format,
+        path=hit.path,
+        bids_subject=bids.get("subject"),
+        bids_session=bids.get("session"),
+        bids_task=bids.get("task"),
+        bids_run=bids.get("run"),
+        display_name=display,
+        n_channels=hit.n_channels,
+        sfreq=hit.sfreq,
+    )
+
+
+def _parse_bids_metadata(path: Path, root: Path) -> dict:
+    """Extract BIDS entities from a path opportunistically.
+
+    Searches the relative path (root-anchored) plus the filename for
+    standard BIDS entity patterns. Returns {subject, session, task, run},
+    each value either the matched identifier or None.
+
+    Order of search: all path components joined as a single string, so
+    matches in any segment count. ``_task-`` and ``_run-`` are typically
+    in the filename; ``sub-`` and ``ses-`` are typically in path segments.
+    """
+    try:
+        rel = path.relative_to(root)
+    except ValueError:
+        rel = path
+
+    search_target = "/".join(rel.parts) + "/" + path.name
+
+    def _first(pattern: re.Pattern) -> Optional[str]:
+        m = pattern.search(search_target)
+        return m.group(1) if m else None
+
+    return {
+        "subject": _first(_BIDS_SUBJECT_RE),
+        "session": _first(_BIDS_SESSION_RE),
+        "task": _first(_BIDS_TASK_RE),
+        "run": _first(_BIDS_RUN_RE),
+    }
+
+
+def _make_display_name(hit: FormatHit, bids: dict) -> str:
+    """Build a human-readable label for the GUI dataset tree.
+
+    BIDS components win when available — researchers expect to see
+    "sub-01 / ses-pre / task-flanker" rather than a filename. For
+    non-BIDS paths, fall back to ``<parent>/<name>`` which is the
+    most-recognizable short identifier.
+    """
+    parts = []
+    if bids.get("subject"):
+        parts.append(f"sub-{bids['subject']}")
+    if bids.get("session"):
+        parts.append(f"ses-{bids['session']}")
+    if bids.get("task"):
+        parts.append(f"task-{bids['task']}")
+    if bids.get("run"):
+        parts.append(f"run-{bids['run']}")
+
+    if parts:
+        return " / ".join(parts)
+
+    return f"{hit.path.parent.name}/{hit.path.name}"
+
+
+# ---------------------------------------------------------------------------
+# XDG cache I/O
+# ---------------------------------------------------------------------------
+
+
+def _cache_root() -> Optional[Path]:
+    """Return the XDG cache root for hrfunc, or None if unavailable.
+
+    Uses ``platformdirs`` for cross-platform XDG resolution. Falls back to
+    None if platformdirs is missing (declared as a core dep but a graceful
+    fallback keeps the scanner usable in stripped-down environments).
+    """
+    try:
+        import platformdirs
+    except ImportError:
+        logger.debug("platformdirs not installed; cache disabled")
+        return None
+    return Path(platformdirs.user_cache_dir("hrfunc"))
+
+
+def _cache_path_for_root(root: Path) -> Optional[Path]:
+    """Return the cache file path for a given scan root, or None if cache
+    is unavailable.
+
+    The filename embeds a SHA-1 of the absolute root path so multiple roots
+    can coexist in the same cache directory without collision.
+    """
+    cache_root = _cache_root()
+    if cache_root is None:
+        return None
+    root_hash = hashlib.sha1(str(root).encode("utf-8")).hexdigest()[:16]
+    return cache_root / f"manifest_{root_hash}.json"
+
+
+def _load_cached_manifest(root: Path) -> Optional[Manifest]:
+    """Load a cached manifest for the given root, or None on any failure.
+
+    Returns None for: missing cache file, JSON parse errors, schema version
+    mismatches, or any other deserialization failure. The next scan will
+    rebuild the cache on disk.
+    """
+    cache_path = _cache_path_for_root(root)
+    if cache_path is None or not cache_path.exists():
+        return None
+    try:
+        return Manifest.from_json(cache_path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        logger.debug("Cached manifest at %s could not be loaded: %s", cache_path, exc)
+        return None
+
+
+def _save_manifest(manifest: Manifest) -> None:
+    """Persist a manifest to the XDG cache directory.
+
+    Silently no-ops if the cache directory cannot be written (e.g.
+    read-only filesystem). The scanner returns the manifest in-memory
+    either way, so cache write failures never block a scan.
+    """
+    cache_path = _cache_path_for_root(manifest.root)
+    if cache_path is None:
+        return
+    try:
+        cache_path.parent.mkdir(parents=True, exist_ok=True)
+        cache_path.write_text(manifest.to_json(), encoding="utf-8")
+    except OSError as exc:
+        logger.debug("Could not write manifest cache to %s: %s", cache_path, exc)

--- a/tests/test_io_scan.py
+++ b/tests/test_io_scan.py
@@ -1,0 +1,457 @@
+"""Targeted unit tests for feat/io-scanner (v1.3.0 GUI foundation 3/4).
+
+Covers two modules:
+
+- ``hrfunc.io.manifest`` — Manifest / ScanEntry / ScanError dataclasses and
+  their JSON round-trip behavior. Tested separately because the GUI dataset
+  tree imports just the dataclasses (not the scanning machinery).
+
+- ``hrfunc.io.scan`` — ``scan_folder()`` walking a directory tree, applying
+  ``classify_path`` to each entry, pruning known noise directories, and
+  caching results to the XDG cache.
+
+Most tests use ``tmp_path`` for synthetic trees. A handful exercise the real
+fixtures at tests/data/ to confirm end-to-end behavior, but those are scoped
+to individual subdirectories (FIF_formatted, NIRX_formatted, sNIRF_formatted)
+rather than scanning all of tests/data — the latter contains a virtualenv
+and is not a clean target.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from hrfunc.io.manifest import (
+    MANIFEST_SCHEMA_VERSION,
+    Manifest,
+    ScanEntry,
+    ScanError,
+)
+from hrfunc.io.scan import (
+    DEFAULT_IGNORE_NAMES,
+    DEFAULT_MAX_DEPTH,
+    scan_folder,
+)
+
+DATA_ROOT = Path(__file__).parent / "data"
+SNIRF_DIR = DATA_ROOT / "sNIRF_formatted"
+NIRX_DIR = DATA_ROOT / "NIRX_formatted"
+FIF_DIR = DATA_ROOT / "FIF_formatted"
+
+
+# ---------------------------------------------------------------------------
+# Manifest / ScanEntry / ScanError dataclass contracts
+# ---------------------------------------------------------------------------
+
+
+class TestScanEntryRoundTrip:
+    def test_minimal_entry_round_trips(self):
+        e = ScanEntry(format="snirf", path=Path("/tmp/x.snirf"))
+        assert ScanEntry.from_dict(e.to_dict()) == e
+
+    def test_fully_populated_entry_round_trips(self):
+        e = ScanEntry(
+            format="fif",
+            path=Path("/tmp/study/sub-01/ses-01/nirs/sub-01_task-flanker_run-1_nirs.fif"),
+            bids_subject="01",
+            bids_session="01",
+            bids_task="flanker",
+            bids_run="1",
+            display_name="sub-01 / ses-01 / task-flanker / run-1",
+            n_channels=42,
+            sfreq=7.8125,
+        )
+        assert ScanEntry.from_dict(e.to_dict()) == e
+
+
+class TestScanErrorRoundTrip:
+    def test_round_trip(self):
+        err = ScanError(path=Path("/tmp/bad.fif"), reason="corrupt")
+        assert ScanError.from_dict(err.to_dict()) == err
+
+
+class TestManifestRoundTrip:
+    def test_empty_manifest_round_trips_via_json(self):
+        m = Manifest(root=Path("/tmp/study"))
+        loaded = Manifest.from_json(m.to_json())
+        assert loaded.root == m.root
+        assert loaded.scans == ()
+        assert loaded.errors == ()
+
+    def test_populated_manifest_round_trips_via_json(self):
+        scans = (
+            ScanEntry(format="snirf", path=Path("/tmp/a.snirf"), display_name="a"),
+            ScanEntry(format="fif", path=Path("/tmp/b.fif"), display_name="b",
+                      n_channels=20, sfreq=7.8125),
+        )
+        errors = (ScanError(path=Path("/tmp/bad.fif"), reason="corrupt"),)
+        m = Manifest(
+            root=Path("/tmp"),
+            scans=scans,
+            errors=errors,
+            scanned_at=datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc),
+        )
+        loaded = Manifest.from_json(m.to_json())
+        assert loaded == m
+
+    def test_schema_version_mismatch_raises(self):
+        m = Manifest(root=Path("/tmp"))
+        d = m.to_dict()
+        d["schema_version"] = MANIFEST_SCHEMA_VERSION + 999
+        with pytest.raises(ValueError, match="schema version"):
+            Manifest.from_dict(d)
+
+    def test_manifest_carries_current_schema_version(self):
+        """If the schema_version constant is bumped without a migration path,
+        old caches will silently fail to load. This test fires when that
+        happens so the bump is visible in PR review."""
+        m = Manifest(root=Path("/tmp"))
+        assert m.schema_version == MANIFEST_SCHEMA_VERSION
+
+
+class TestManifestImmutability:
+    def test_manifest_is_frozen(self):
+        m = Manifest(root=Path("/tmp"))
+        with pytest.raises(AttributeError):
+            m.root = Path("/elsewhere")  # type: ignore[misc]
+
+    def test_scan_entry_is_frozen(self):
+        e = ScanEntry(format="snirf", path=Path("/tmp/x.snirf"))
+        with pytest.raises(AttributeError):
+            e.format = "fif"  # type: ignore[misc]
+
+    def test_scans_tuple_not_list(self):
+        """Tuple (not list) backing means callers cannot mutate the
+        manifest's scan list after the fact, preserving cache safety."""
+        m = Manifest(root=Path("/tmp"))
+        assert isinstance(m.scans, tuple)
+        assert isinstance(m.errors, tuple)
+
+
+# ---------------------------------------------------------------------------
+# scan_folder: top-level input validation
+# ---------------------------------------------------------------------------
+
+
+class TestScanFolderValidation:
+    def test_missing_root_raises_filenotfound(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            scan_folder(tmp_path / "no_such_dir")
+
+    def test_file_root_raises_not_a_directory(self, tmp_path):
+        f = tmp_path / "not_a_dir.txt"
+        f.write_text("x")
+        with pytest.raises(NotADirectoryError):
+            scan_folder(f)
+
+    def test_str_and_path_inputs_both_accepted(self, tmp_path):
+        m_str = scan_folder(str(tmp_path), use_cache=False)
+        m_path = scan_folder(tmp_path, use_cache=False)
+        assert m_str.root == m_path.root
+
+
+# ---------------------------------------------------------------------------
+# scan_folder: format detection inside a tree
+# ---------------------------------------------------------------------------
+
+
+class TestScanFolderFindsSnirf:
+    def test_finds_snirf_files_in_real_fixture(self):
+        m = scan_folder(SNIRF_DIR, use_cache=False)
+        snirf_paths = {s.path for s in m.scans if s.format == "snirf"}
+        assert SNIRF_DIR / "subject_1.snirf" in snirf_paths
+        assert SNIRF_DIR / "subject_2.snirf" in snirf_paths
+
+
+class TestScanFolderFindsNirxDirs:
+    def test_finds_nirx_dirs_and_does_not_recurse_into_them(self):
+        """NIRx acquisition directories must be yielded as one entry each,
+        not as N entries (one per .wl1/.wl2/.hdr inside)."""
+        m = scan_folder(NIRX_DIR, use_cache=False)
+        nirx_entries = [s for s in m.scans if s.format == "nirx_dir"]
+        assert len(nirx_entries) == 2
+        nirx_paths = {e.path for e in nirx_entries}
+        assert NIRX_DIR / "subject_1" in nirx_paths
+        assert NIRX_DIR / "subject_2" in nirx_paths
+
+    def test_nirx_acquisition_internals_not_classified(self):
+        """No .wl1/.hdr/.evt files should appear as separate entries — they
+        live inside an already-classified nirx_dir."""
+        m = scan_folder(NIRX_DIR, use_cache=False)
+        for entry in m.scans:
+            assert entry.path.suffix not in {".wl1", ".wl2", ".hdr", ".evt"}
+
+
+class TestScanFolderFindsFif:
+    def test_finds_fif_files_in_real_fixture(self):
+        m = scan_folder(FIF_DIR, use_cache=False)
+        fif_paths = {s.path for s in m.scans if s.format == "fif"}
+        assert FIF_DIR / "subject_1.fif" in fif_paths
+        assert FIF_DIR / "subject_2.fif" in fif_paths
+
+    def test_fif_entries_carry_n_channels_and_sfreq(self):
+        m = scan_folder(FIF_DIR, use_cache=False)
+        fif_entries = [s for s in m.scans if s.format == "fif"]
+        assert len(fif_entries) > 0
+        for e in fif_entries:
+            assert e.n_channels is not None and e.n_channels > 0
+            assert e.sfreq is not None and e.sfreq > 0
+
+
+class TestScanFolderEmptyAndNoise:
+    def test_empty_dir_returns_empty_manifest(self, tmp_path):
+        m = scan_folder(tmp_path, use_cache=False)
+        assert m.scans == ()
+        assert m.errors == ()
+        assert m.root == tmp_path.resolve()
+
+    def test_unrelated_files_produce_no_entries(self, tmp_path):
+        (tmp_path / "notes.txt").write_text("hello")
+        (tmp_path / "data.csv").write_text("a,b")
+        m = scan_folder(tmp_path, use_cache=False)
+        assert m.scans == ()
+
+
+# ---------------------------------------------------------------------------
+# scan_folder: pruning behavior
+# ---------------------------------------------------------------------------
+
+
+class TestIgnoredDirectories:
+    def test_default_ignore_set_includes_common_noise(self):
+        for name in {".git", ".venv", "venv", "__pycache__", "node_modules"}:
+            assert name in DEFAULT_IGNORE_NAMES
+
+    def test_default_ignored_dirs_are_pruned(self, tmp_path):
+        """A .venv directory containing a .snirf file should be pruned —
+        researchers often have virtualenvs next to their data."""
+        venv = tmp_path / ".venv"
+        venv.mkdir()
+        (venv / "fake.snirf").write_bytes(b"")
+        m = scan_folder(tmp_path, use_cache=False)
+        assert m.scans == ()
+
+    def test_custom_ignore_list_overrides_default(self, tmp_path):
+        """Passing an explicit ignore_names completely replaces the default —
+        no implicit merge. Test that .venv is now visible because we set
+        ignore_names to {} explicitly."""
+        venv = tmp_path / ".venv"
+        venv.mkdir()
+        (venv / "scan.snirf").write_bytes(b"")
+        m = scan_folder(tmp_path, ignore_names=set(), use_cache=False)
+        assert len(m.scans) == 1
+
+
+class TestMaxDepth:
+    def test_deep_file_beyond_max_depth_is_not_classified(self, tmp_path):
+        """max_depth caps the descent to keep scans bounded. A file buried
+        deeper than the cap must not appear."""
+        deep = tmp_path
+        for i in range(DEFAULT_MAX_DEPTH + 3):
+            deep = deep / f"level_{i}"
+            deep.mkdir()
+        (deep / "deep.snirf").write_bytes(b"")
+        m = scan_folder(tmp_path, use_cache=False)
+        assert m.scans == ()
+
+    def test_shallow_file_within_max_depth_is_classified(self, tmp_path):
+        d = tmp_path / "level_1" / "level_2"
+        d.mkdir(parents=True)
+        (d / "scan.snirf").write_bytes(b"")
+        m = scan_folder(tmp_path, max_depth=4, use_cache=False)
+        assert len(m.scans) == 1
+        assert m.scans[0].format == "snirf"
+
+
+# ---------------------------------------------------------------------------
+# scan_folder: BIDS-opportunistic parsing
+# ---------------------------------------------------------------------------
+
+
+class TestBidsParsing:
+    def test_subject_extracted_from_path_segment(self, tmp_path):
+        d = tmp_path / "sub-01" / "nirs"
+        d.mkdir(parents=True)
+        (d / "scan.snirf").write_bytes(b"")
+        m = scan_folder(tmp_path, use_cache=False)
+        assert len(m.scans) == 1
+        assert m.scans[0].bids_subject == "01"
+
+    def test_session_extracted_from_path_segment(self, tmp_path):
+        d = tmp_path / "sub-02" / "ses-pre" / "nirs"
+        d.mkdir(parents=True)
+        (d / "scan.snirf").write_bytes(b"")
+        m = scan_folder(tmp_path, use_cache=False)
+        assert m.scans[0].bids_session == "pre"
+
+    def test_task_extracted_from_filename_infix(self, tmp_path):
+        d = tmp_path / "sub-03" / "nirs"
+        d.mkdir(parents=True)
+        (d / "sub-03_task-flanker_nirs.snirf").write_bytes(b"")
+        m = scan_folder(tmp_path, use_cache=False)
+        assert m.scans[0].bids_task == "flanker"
+
+    def test_run_extracted_from_filename_infix(self, tmp_path):
+        d = tmp_path / "sub-04" / "nirs"
+        d.mkdir(parents=True)
+        (d / "sub-04_task-rest_run-2_nirs.snirf").write_bytes(b"")
+        m = scan_folder(tmp_path, use_cache=False)
+        assert m.scans[0].bids_run == "2"
+
+    def test_non_bids_path_leaves_fields_none(self, tmp_path):
+        (tmp_path / "random_file.snirf").write_bytes(b"")
+        m = scan_folder(tmp_path, use_cache=False)
+        e = m.scans[0]
+        assert e.bids_subject is None
+        assert e.bids_session is None
+        assert e.bids_task is None
+        assert e.bids_run is None
+
+
+class TestDisplayName:
+    def test_bids_path_produces_bids_display_name(self, tmp_path):
+        d = tmp_path / "sub-05" / "ses-pre" / "nirs"
+        d.mkdir(parents=True)
+        (d / "sub-05_task-flanker_nirs.snirf").write_bytes(b"")
+        m = scan_folder(tmp_path, use_cache=False)
+        assert m.scans[0].display_name == "sub-05 / ses-pre / task-flanker"
+
+    def test_non_bids_path_falls_back_to_parent_slash_name(self, tmp_path):
+        sub = tmp_path / "lab_scans"
+        sub.mkdir()
+        (sub / "subject_A.snirf").write_bytes(b"")
+        m = scan_folder(tmp_path, use_cache=False)
+        assert m.scans[0].display_name == "lab_scans/subject_A.snirf"
+
+
+# ---------------------------------------------------------------------------
+# scan_folder: error collection (non-fatal)
+# ---------------------------------------------------------------------------
+
+
+class TestErrorHandling:
+    def test_corrupt_fif_does_not_abort_scan(self, tmp_path):
+        """A corrupt FIF must yield None from classify_path (already covered
+        in test_io_detect), so it produces NO ScanError here — it is silently
+        skipped. The scan completes and finds the sibling .snirf."""
+        (tmp_path / "broken_raw.fif").write_bytes(b"garbage")
+        (tmp_path / "good.snirf").write_bytes(b"")
+        m = scan_folder(tmp_path, use_cache=False)
+        assert any(s.format == "snirf" for s in m.scans)
+
+
+# ---------------------------------------------------------------------------
+# scan_folder: XDG cache I/O
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def isolated_cache(tmp_path, monkeypatch):
+    """Redirect platformdirs.user_cache_dir to a tmp path so cache tests
+    do not touch the user's real XDG cache."""
+    cache_root = tmp_path / "xdg_cache"
+    monkeypatch.setattr(
+        "platformdirs.user_cache_dir",
+        lambda *_args, **_kw: str(cache_root),
+    )
+    return cache_root
+
+
+class TestCachePersistence:
+    def test_cache_written_after_scan(self, tmp_path, isolated_cache):
+        scan_root = tmp_path / "study"
+        scan_root.mkdir()
+        (scan_root / "scan.snirf").write_bytes(b"")
+        scan_folder(scan_root, use_cache=True)
+        # exactly one manifest file should be written
+        manifests = list((isolated_cache / "hrfunc").glob("manifest_*.json")) \
+                    if (isolated_cache / "hrfunc").exists() \
+                    else list(isolated_cache.glob("manifest_*.json"))
+        assert len(manifests) == 1
+
+    def test_second_scan_loads_from_cache(self, tmp_path, isolated_cache):
+        """Second call returns the cached manifest unchanged — verify by
+        adding a new file between scans and confirming it does NOT appear."""
+        scan_root = tmp_path / "study"
+        scan_root.mkdir()
+        (scan_root / "first.snirf").write_bytes(b"")
+        first = scan_folder(scan_root, use_cache=True)
+        # Add a new file; cache should hide it
+        (scan_root / "second.snirf").write_bytes(b"")
+        second = scan_folder(scan_root, use_cache=True)
+        assert {s.path.name for s in first.scans} == {s.path.name for s in second.scans}
+
+    def test_force_rescan_bypasses_cache(self, tmp_path, isolated_cache):
+        scan_root = tmp_path / "study"
+        scan_root.mkdir()
+        (scan_root / "first.snirf").write_bytes(b"")
+        scan_folder(scan_root, use_cache=True)
+        (scan_root / "second.snirf").write_bytes(b"")
+        rescanned = scan_folder(scan_root, use_cache=True, force_rescan=True)
+        names = {s.path.name for s in rescanned.scans}
+        assert "first.snirf" in names
+        assert "second.snirf" in names
+
+    def test_use_cache_false_does_not_write_cache(
+        self, tmp_path, isolated_cache
+    ):
+        scan_root = tmp_path / "study"
+        scan_root.mkdir()
+        (scan_root / "scan.snirf").write_bytes(b"")
+        scan_folder(scan_root, use_cache=False)
+        # No manifest file should have been written
+        if (isolated_cache / "hrfunc").exists():
+            assert list((isolated_cache / "hrfunc").glob("manifest_*.json")) == []
+        else:
+            assert list(isolated_cache.glob("manifest_*.json")) == []
+
+    def test_different_roots_get_different_cache_files(
+        self, tmp_path, isolated_cache
+    ):
+        """The cache filename embeds a hash of the root path so multiple
+        studies can coexist without collision."""
+        root_a = tmp_path / "study_a"
+        root_b = tmp_path / "study_b"
+        root_a.mkdir()
+        root_b.mkdir()
+        (root_a / "x.snirf").write_bytes(b"")
+        (root_b / "y.snirf").write_bytes(b"")
+        scan_folder(root_a, use_cache=True)
+        scan_folder(root_b, use_cache=True)
+        manifests = list((isolated_cache / "hrfunc").glob("manifest_*.json")) \
+                    if (isolated_cache / "hrfunc").exists() \
+                    else list(isolated_cache.glob("manifest_*.json"))
+        assert len(manifests) == 2
+
+
+class TestCacheSchemaMismatch:
+    def test_old_schema_cache_is_ignored(self, tmp_path, isolated_cache, monkeypatch):
+        """A cache written by an old version of the scanner has a schema
+        version that no longer parses. The next scan should treat it as a
+        miss (not crash, not silently use stale data)."""
+        scan_root = tmp_path / "study"
+        scan_root.mkdir()
+        (scan_root / "scan.snirf").write_bytes(b"")
+
+        # Manually pre-write a bad cache for this root
+        from hrfunc.io.scan import _cache_path_for_root
+        cache_file = _cache_path_for_root(scan_root.resolve())
+        assert cache_file is not None
+        cache_file.parent.mkdir(parents=True, exist_ok=True)
+        cache_file.write_text(json.dumps({
+            "schema_version": 999,
+            "root": str(scan_root.resolve()),
+            "scans": [],
+            "errors": [],
+            "scanned_at": datetime(2020, 1, 1, tzinfo=timezone.utc).isoformat(),
+        }))
+
+        # Scan must still work and produce a real manifest
+        m = scan_folder(scan_root, use_cache=True)
+        assert len(m.scans) == 1
+        assert m.scans[0].path.name == "scan.snirf"


### PR DESCRIPTION
## Summary

Third of four foundation branches for the v1.3.0 GUI. Adds the folder scanner that the "Open my data" path in the welcome screen will call. Walks a directory, classifies each path via `hrfunc.io.classify_path`, parses BIDS metadata opportunistically, and returns a frozen `Manifest`. Results persist to an XDG cache so re-opening a recent project is instant.

## Motivation

The v1.3.0 dataset-tree widget needs a structured manifest of detected fNIRS scans, grouped by subject/session/task. Without a scanner, the GUI either makes users pick files one at a time (painful for multi-subject studies) or scrapes folder structure inline (duplicates logic across views). The scanner centralizes the walk-and-classify pipeline and makes it cacheable.

## Public API

```python
from hrfunc.io import scan_folder, Manifest, ScanEntry, ScanError

m = scan_folder("/path/to/study")
# m.root            — absolute path of the scan root
# m.scans           — tuple[ScanEntry, ...] one per detected dataset
# m.errors          — tuple[ScanError, ...] paths that failed classification
# m.scanned_at      — datetime, UTC
# m.schema_version  — int, for cache invalidation
```

Each `ScanEntry` carries: `format`, `path`, `bids_subject`, `bids_session`, `bids_task`, `bids_run`, `display_name`, `n_channels`, `sfreq`.

Optional kwargs: `max_depth=6`, `ignore_names=None`, `use_cache=True`, `force_rescan=False`.

## Design choices

| Choice | Rationale |
|---|---|
| **NIRx subtree pruning** | Once a dir is classified `nirx_dir`, its `.wl1`/`.wl2`/`.hdr` files are not re-classified. |
| **Default ignore set** (`.git`, `.venv`, `__pycache__`, `node_modules`, etc.) | Researchers regularly drop fNIRS data into project trees with code/build artifacts. |
| **`max_depth=6`** | Deep enough for `study/sub-XX/ses-YY/nirs/file`, shallow enough to bound runtime. |
| **Opportunistic BIDS** via regex on path + filename | No `pybids` dependency. Patterns: `sub-`, `ses-`, `_task-`, `_run-`. Non-BIDS paths leave fields `None`. |
| **Schema-versioned cache** | `schema_version=1` on the Manifest. Old caches with a different version are silently treated as misses. |
| **Explicit `force_rescan`** | Auto-invalidation would require walking the tree to compare mtimes, defeating the cache. GUI exposes a "Rescan" button. |
| **Lazy `platformdirs` import** | Inside `_cache_root()`. If unavailable, cache silently no-ops. |
| **Frozen dataclasses, tuple-backed** | Manifests are cached and shared across threads — immutability prevents in-place mutation bugs. |

## `pyproject.toml` changes

- Added `platformdirs>=3.0` to dependencies (small pure-Python package, no transitive deps)
- Added `hrfunc.io` to packages list so the subpackage ships in wheels

## Tests

`tests/test_io_scan.py` — 39 new tests across 12 test classes:

- **Dataclass round-trip** (5): minimal/full `ScanEntry`, `ScanError`, empty/populated `Manifest`, schema-version mismatch raises
- **Immutability** (3): `Manifest`, `ScanEntry` are frozen; `scans`/`errors` are tuples not lists
- **Input validation** (3): missing root → `FileNotFoundError`, file as root → `NotADirectoryError`, `str` and `Path` both work
- **Format detection inside trees** (4): SNIRF files found, NIRx dirs found with subtree pruning, NIRx internals NOT classified, FIF entries carry `n_channels`+`sfreq`
- **Empty/noise** (2): empty dir → empty manifest, unrelated files produce no entries
- **Pruning** (3): default ignore set has expected names, `.venv` pruned by default, empty ignore_names exposes everything
- **`max_depth`** (2): file beyond cap not classified, file within cap classified
- **BIDS parsing** (5): subject/session/task/run all extract correctly, non-BIDS paths leave fields `None`
- **Display name** (2): BIDS path → `"sub-XX / ses-YY / task-NNN"`, non-BIDS → `<parent>/<filename>`
- **Error handling** (1): corrupt FIF doesn't abort the scan
- **XDG cache** (5): cache written, second scan loads from cache, `force_rescan` bypasses, `use_cache=False` writes nothing, different roots get different cache filenames
- **Cache schema mismatch** (1): cached manifest with wrong schema_version is silently ignored

## Gate

```
pytest tests/test_phase1a.py tests/test_phase1bc.py tests/test_phase2.py \
       tests/test_threading.py tests/test_input_validation.py \
       tests/test_state_lifecycle.py tests/test_oxygenation_guard.py \
       tests/test_tree_delete_filter.py tests/test_hasher_branch.py \
       tests/test_tree_hrf.py tests/test_canonical_hrf.py \
       tests/test_tree_edge_cases.py tests/test_observer_and_typos.py \
       tests/test_progress_callbacks.py tests/test_io_detect.py \
       tests/test_io_scan.py -q
→ 296 passed in 3.82s (257 prior + 39 new, zero regressions)
```

## Reviews

- **Architecture & Execution Flow**: `hrfunc.io.manifest` imports nothing from hrfunc — the GUI dataset-tree widget can import just the types without pulling in the scanner. `hrfunc.io.scan` imports `classify_path` and the dataclasses, with lazy `platformdirs` import. No new module-graph cycles. No threading.
- **Data Integrity & Correctness**: frozen dataclasses with tuple backing (cache safety). `schema_version` on manifest with fail-closed deserialization. `Path.resolve()` before cache hashing so symlinks and relative paths hash consistently. NIRx subtree pruning verified by explicit test. BIDS regex is intentionally lenient (documented in `scan.py`).

## Test plan

- [x] `pytest tests/test_io_scan.py -v` passes (39/39)
- [x] Full foundation gate passes (296 total)
- [x] Manual smoke: `scan_folder("tests/data/sNIRF_formatted")` finds both `.snirf` files; `scan_folder("tests/data/NIRX_formatted")` finds both NIRx subject dirs without recursing
- [ ] GUI dataset-tree integration once Sprint 2 lands

## Gotchas

- **No TTL on cache.** Users must call `force_rescan=True` or delete the cache file to pick up new files. The GUI exposes a "Rescan" button.
- **Synchronous walk.** For 1000+ file folders with many FIF files (each requiring an MNE info read), can take several seconds. The GUI runs it in a background task.

## Roadmap

Foundation sprint for v1.3.0 GUI. Last branch remaining:
- `feat/io-raw-cache` — `src/hrfunc/io/raw_cache.py` LRU(3) MNE Raw loader (stacked on this)

🤖 Generated with [Claude Code](https://claude.com/claude-code)