### PR TITLE
feat: NiceGUI app shell with hrfunc CLI entry (GUI Sprint 2.1)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,13 +27,23 @@ dependencies = [
     "platformdirs>=3.0",
     ]
 
+[project.optional-dependencies]
+gui = [
+    "nicegui>=2.0",
+    "plotly>=5.18",
+    "pywebview>=5.0",
+    ]
+
+[project.scripts]
+hrfunc = "hrfunc.gui.app:main"
+
 [project.urls]
 Homepage = "https://github.com/dennys246/hrfunc"
 Documentation = "https://www.hrfunc.org"
 
 [tool.setuptools]
 package-dir = {"" = "src"}
-packages = ["hrfunc", "hrfunc.io"]
+packages = ["hrfunc", "hrfunc.io", "hrfunc.gui"]
 include-package-data = true
 
 [tool.pytest.ini_options]

--- a/src/hrfunc/gui/__init__.py
+++ b/src/hrfunc/gui/__init__.py
@@ -1,0 +1,14 @@
+"""HRFunc desktop GUI — NiceGUI-based interface for non-tech researchers.
+
+The GUI is an optional install (`pip install hrfunc[gui]`) that adds NiceGUI,
+plotly, and pywebview. The `hrfunc` CLI entry point launches `hrfunc.gui.app.main`,
+which opens a native desktop window backed by NiceGUI's pywebview integration.
+
+Public entry points (rarely imported directly; the CLI wires them up):
+    main(argv=None) -> int   - CLI entry (see hrfunc.gui.app)
+    state                     - module-level AppState singleton (see hrfunc.gui.state)
+
+This subpackage is **not** imported by the core library — `import hrfunc` does
+not load NiceGUI. Users without the [gui] extras can still use every public
+API in hrfunc and hrfunc.io.
+"""

--- a/src/hrfunc/gui/app.py
+++ b/src/hrfunc/gui/app.py
@@ -1,0 +1,142 @@
+"""HRFunc GUI entry point.
+
+`hrfunc` (the CLI command installed by ``pip install hrfunc[gui]``) calls
+``main()``, which:
+
+1. Parses argv for an optional dataset path
+2. Stashes the path on the AppState singleton for the welcome page to consume
+3. Registers page handlers
+4. Opens a native desktop window via NiceGUI + pywebview
+
+Usage:
+    hrfunc                              # launch the GUI
+    hrfunc /path/to/study               # launch with that folder preloaded
+    hrfunc subject_01.snirf             # launch with a single file preloaded
+    hrfunc --version                    # print version and exit
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+from pathlib import Path
+from typing import List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    """CLI entry point. Returns the exit code (0 on success).
+
+    Args:
+        argv: Argument list (excluding the program name). When None
+            (production), argparse pulls from sys.argv. Tests pass an
+            explicit list to exercise without touching sys.argv.
+
+    Returns:
+        Exit code. 0 if the GUI ran cleanly. Non-zero on argument-parsing
+        failure (argparse handles those itself via SystemExit).
+    """
+    parser = _build_argument_parser()
+    args = parser.parse_args(argv)
+
+    # Import NiceGUI lazily so `hrfunc --version` and `hrfunc --help` work
+    # even if the [gui] extras are not fully installed (e.g. user is checking
+    # what version they have before pip install hrfunc[gui]).
+    from nicegui import ui
+
+    from .state import state
+    from .theme import apply_theme
+
+    if args.path is not None:
+        state.preload_path = args.path.resolve()
+        logger.info("Preloading path from CLI: %s", state.preload_path)
+
+    _register_pages()
+
+    ui.run(
+        title="HRFunc",
+        native=True,
+        window_size=(1400, 900),
+        reload=False,
+        show=True,
+        port=_find_free_port(),
+        show_welcome_message_on_startup=False,
+    )
+    return 0
+
+
+def _build_argument_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="hrfunc",
+        description=(
+            "HRFunc — fNIRS hemodynamic response function estimation and "
+            "neural activity recovery. Launches the desktop GUI."
+        ),
+    )
+    parser.add_argument(
+        "path",
+        nargs="?",
+        default=None,
+        type=Path,
+        help=(
+            "Optional dataset to preload — a folder of scans, a single "
+            ".snirf/.fif file, or a NIRx acquisition directory."
+        ),
+    )
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"hrfunc {_get_version()}",
+    )
+    return parser
+
+
+def _register_pages() -> None:
+    """Register all `@ui.page` handlers.
+
+    Sprint 2.1 ships only the placeholder root page. Sprint 2.2 replaces it
+    with the real welcome page; Sprint 2.3 adds /workspace. Page imports are
+    lazy so reloading individual modules during development picks up changes
+    without restarting the NiceGUI server.
+    """
+    from nicegui import ui
+
+    from .theme import apply_theme, page_container
+
+    @ui.page("/")
+    def _placeholder_root_page() -> None:
+        apply_theme()
+        with page_container():
+            ui.label("HRFunc").classes("text-5xl font-bold")
+            ui.label(
+                "Sprint 2.1 placeholder. The welcome screen lands in Sprint 2.2."
+            ).classes("text-lg opacity-80")
+
+
+def _find_free_port() -> int:
+    """Return an unused localhost port for NiceGUI to bind.
+
+    NiceGUI defaults to 8080, which collides if anything else on the user's
+    machine is listening there (common — many dev servers default to 8080).
+    Letting the OS pick avoids a confusing "address already in use" crash
+    on launch.
+    """
+    import socket
+
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+def _get_version() -> str:
+    """Return the installed hrfunc version, or 'unknown' if not resolvable."""
+    try:
+        from importlib.metadata import version
+        return version("hrfunc")
+    except Exception:
+        return "unknown"
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/hrfunc/gui/state.py
+++ b/src/hrfunc/gui/state.py
@@ -1,0 +1,73 @@
+"""AppState — single source of truth for the running GUI.
+
+NiceGUI page handlers, components, and background workers all read and write
+the same `AppState` instance. A module-level `state` singleton is created at
+import time so any module can ``from hrfunc.gui.state import state`` without
+threading a reference through every function signature.
+
+Lifecycle:
+- One AppState per process. The `state` singleton is created on first import.
+- Tests can instantiate fresh AppState() instances for isolated unit testing
+  (the class itself is just a dataclass).
+- The singleton holds mutable fields by design — pages bind their UI elements
+  to these fields and re-render on changes.
+
+What lives here:
+- `manifest`           - last folder scan result (None until a scan completes)
+- `selected_scan`      - currently inspected ScanEntry, or None
+- `raw_cache`          - hot-path LRU(3) loader of MNE Raw objects
+- `preload_path`       - CLI arg from `hrfunc <path>`; consumed by welcome page on first render
+- `busy`               - True while a background task is running (drives spinner UI)
+- `estimation_progress`- (current, total, channel_name) tuple from the latest
+                         progress_callback fire; None when no estimation is in flight
+- `last_error`         - last error message surfaced to the user, or None
+
+Fields are added (not removed) as later sprints integrate more state. Keeping
+the AppState surface stable across sprints means GUI components written in
+Sprint 2 won't need updates as Sprint 3+ panels land.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional, Tuple
+
+from ..io.manifest import Manifest, ScanEntry
+from ..io.raw_cache import RawCache
+
+
+@dataclass
+class AppState:
+    """Mutable, single-process GUI state.
+
+    All fields default to `None` / empty so a freshly-constructed AppState
+    represents "no data loaded yet" — the state shown by the welcome page.
+    """
+
+    manifest: Optional[Manifest] = None
+    selected_scan: Optional[ScanEntry] = None
+    raw_cache: RawCache = field(default_factory=RawCache)
+    preload_path: Optional[Path] = None
+    busy: bool = False
+    estimation_progress: Optional[Tuple[int, int, str]] = None
+    last_error: Optional[str] = None
+
+    def reset(self) -> None:
+        """Return to the welcome-screen state.
+
+        Used when the user closes the current project / switches datasets.
+        Drops cached Raws so memory is released. The RawCache instance is
+        kept (not reassigned) so any references held elsewhere stay valid.
+        """
+        self.manifest = None
+        self.selected_scan = None
+        self.raw_cache.clear()
+        self.preload_path = None
+        self.busy = False
+        self.estimation_progress = None
+        self.last_error = None
+
+
+# Module-level singleton. Page handlers and components import this directly.
+state = AppState()

--- a/src/hrfunc/gui/theme.py
+++ b/src/hrfunc/gui/theme.py
@@ -1,0 +1,73 @@
+"""Quasar / Tailwind theming for the HRFunc GUI.
+
+NiceGUI ships Quasar (Vue) and Tailwind under the hood. This module sets the
+brand color tokens, default dark mode, and shared layout primitives so every
+page has a consistent look without duplicating styling code.
+
+`apply_theme()` must be called once per page render — typically at the top of
+each `@ui.page` handler — to set the dark-mode default and inject the brand
+palette via Quasar's `ui.colors`.
+
+Color choices reflect the v1.3.0 plan ("modern, scientific dashboard"):
+- Primary:   indigo-500   - main accent for buttons, active tabs, sliders
+- Secondary: violet-400   - secondary accent for HRF traces and HRtree edges
+- Accent:    cyan-400     - highlights, links, focus rings
+- Positive:  emerald-400  - good-quality channel indicators
+- Negative:  rose-400     - bad channels, errors, flagged data
+- Warning:   amber-400    - in-progress states, cautionary metrics
+- Info:      sky-400      - informational banners
+- Dark:      slate-900    - background base for dark mode
+
+Light mode is supported via a toggle but is not the default. Researchers
+typically work in dim environments; dark mode also makes plotly's default
+plot palette read better.
+"""
+
+from __future__ import annotations
+
+from nicegui import ui
+
+
+# Brand palette — hex strings matching Tailwind 500-level tones for legibility.
+COLORS = {
+    "primary": "#6366f1",     # indigo-500
+    "secondary": "#a78bfa",   # violet-400
+    "accent": "#22d3ee",      # cyan-400
+    "positive": "#34d399",    # emerald-400
+    "negative": "#fb7185",    # rose-400
+    "warning": "#fbbf24",     # amber-400
+    "info": "#38bdf8",        # sky-400
+    "dark": "#0f172a",        # slate-900
+}
+
+
+def apply_theme(dark: bool = True) -> None:
+    """Apply the HRFunc color palette and (optionally) enable dark mode.
+
+    Call once per page handler before constructing UI elements. Subsequent
+    calls are idempotent — Quasar caches the colors and `ui.dark_mode` is a
+    no-op when already in the requested state.
+
+    Args:
+        dark: If True (default), enable dark mode. The user-facing toggle in
+            the workspace toolbar can flip this at runtime.
+    """
+    ui.colors(**COLORS)
+    if dark:
+        ui.dark_mode().enable()
+    else:
+        ui.dark_mode().disable()
+
+
+def page_container():
+    """Return a top-level page container with consistent padding and width.
+
+    Standardizes the outer layout so welcome / workspace / library pages all
+    share the same gutter and max-width. Use as a context manager:
+
+        with page_container():
+            ui.label("contents")
+    """
+    return ui.column().classes(
+        "w-full max-w-screen-2xl mx-auto p-6 gap-4"
+    )

--- a/src/hrfunc/gui/workers.py
+++ b/src/hrfunc/gui/workers.py
@@ -1,0 +1,113 @@
+"""Background-task helpers for long-running GUI operations.
+
+NiceGUI runs page handlers on its event loop; any synchronous work that takes
+more than ~100ms blocks the UI. Scanning a large folder or estimating HRFs
+take seconds to minutes — they must run off the main thread.
+
+This module provides a thin wrapper around `asyncio.to_thread` plus a
+progress-state helper for surfacing `progress_callback` events to the UI.
+Sprint 2.1 ships the helper; Sprint 3 (estimate panel) wires it up to actual
+estimation calls.
+
+Design constraints:
+- **Single background worker at a time.** AppState.busy is a binary flag,
+  not a counter. The GUI disables long-task buttons while busy=True so the
+  user can't queue overlapping work. This matches the RawCache's not-thread-
+  safe contract (see hrfunc.io.raw_cache).
+- **Progress is pushed, not polled.** The callback writes (current, total,
+  name) into `state.estimation_progress`; UI components bind to that field
+  and re-render via NiceGUI's reactivity. No timer needed.
+- **Errors surface to `state.last_error`.** The worker catches exceptions
+  raised in the threaded function and stores the string message; the GUI
+  displays a toast / banner from there.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any, Awaitable, Callable, Optional
+
+from .state import AppState
+
+logger = logging.getLogger(__name__)
+
+
+def make_progress_callback(state: AppState) -> Callable[[int, int, str], None]:
+    """Return a `progress_callback` that writes into the given AppState.
+
+    The returned callable matches the signature expected by
+    `montage.estimate_hrf` and `montage.estimate_activity`:
+    `(current_index, total_channels, channel_name) -> None`.
+
+    Each call writes a `(current, total, name)` tuple into
+    `state.estimation_progress`. UI components bound to that field re-render
+    automatically via NiceGUI's reactivity.
+    """
+
+    def _callback(current: int, total: int, name: str) -> None:
+        state.estimation_progress = (current, total, name)
+
+    return _callback
+
+
+async def run_in_background(
+    state: AppState,
+    func: Callable[..., Any],
+    *args: Any,
+    on_done: Optional[Callable[[Any], Awaitable[None]]] = None,
+    **kwargs: Any,
+) -> Any:
+    """Run a blocking function off the main thread, surfacing busy/error state.
+
+    Sets `state.busy = True` before dispatch, clears it (and resets
+    `estimation_progress`) when the function returns. Any exception is
+    logged and stored in `state.last_error` as a string; the exception is
+    NOT re-raised so the GUI stays responsive.
+
+    Args:
+        state: AppState whose `busy`, `estimation_progress`, and `last_error`
+            fields will be updated.
+        func: Synchronous callable to run on a worker thread.
+        *args, **kwargs: Forwarded to `func`.
+        on_done: Optional async callable invoked with the result after `func`
+            completes successfully. Useful for "estimate, then refresh the
+            HRF gallery" flows.
+
+    Returns:
+        The result of `func`, or `None` if `func` raised.
+    """
+    if state.busy:
+        logger.warning(
+            "run_in_background: state.busy is already True; refusing to "
+            "start a second worker. The GUI should disable trigger buttons "
+            "while busy."
+        )
+        return None
+
+    state.busy = True
+    state.last_error = None
+    result: Any = None
+    try:
+        # Use run_in_executor instead of asyncio.to_thread (3.9+) so the GUI
+        # works on Python 3.8 to match the library's requires-python pin.
+        loop = asyncio.get_event_loop()
+        result = await loop.run_in_executor(
+            None, lambda: func(*args, **kwargs)
+        )
+    except Exception as exc:  # noqa: BLE001 — see module docstring
+        state.last_error = f"{type(exc).__name__}: {exc}"
+        logger.exception("Background worker failed: %s", exc)
+        return None
+    finally:
+        state.busy = False
+        state.estimation_progress = None
+
+    if on_done is not None:
+        try:
+            await on_done(result)
+        except Exception as exc:  # noqa: BLE001
+            state.last_error = f"on_done failed: {type(exc).__name__}: {exc}"
+            logger.exception("on_done callback failed: %s", exc)
+
+    return result

--- a/tests/test_gui_foundation.py
+++ b/tests/test_gui_foundation.py
@@ -1,0 +1,338 @@
+"""Targeted unit tests for feat/gui-foundation (v1.3.0 Sprint 2.1).
+
+Covers the GUI package skeleton: ``hrfunc.gui.app``, ``hrfunc.gui.state``,
+``hrfunc.gui.theme``, ``hrfunc.gui.workers``. These are the building blocks
+the welcome / workspace pages (Sprints 2.2 / 2.3) will compose against.
+
+NiceGUI rendering tests (via `nicegui.testing.User`) require pytest-asyncio
+and are introduced in Sprint 2.2 when the real welcome page lands. This
+file restricts itself to import / contract / behavior tests so it runs
+fast and stays close to the v1.2.0 testing pattern.
+
+All NiceGUI-dependent tests use `pytest.importorskip("nicegui")` so the
+file is fully skipped when the `[gui]` extras are not installed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+from pathlib import Path
+
+import pytest
+
+# Skip the whole module when nicegui is unavailable
+pytest.importorskip("nicegui")
+
+
+# ---------------------------------------------------------------------------
+# Package import contract
+# ---------------------------------------------------------------------------
+
+
+class TestPackageImports:
+    def test_hrfunc_gui_imports(self):
+        import hrfunc.gui  # noqa: F401
+
+    def test_app_module_imports(self):
+        from hrfunc.gui import app  # noqa: F401
+
+    def test_state_module_imports(self):
+        from hrfunc.gui import state  # noqa: F401
+
+    def test_theme_module_imports(self):
+        from hrfunc.gui import theme  # noqa: F401
+
+    def test_workers_module_imports(self):
+        from hrfunc.gui import workers  # noqa: F401
+
+    def test_importing_core_does_not_import_gui(self):
+        """`import hrfunc` must NOT pull in NiceGUI. Users without [gui] extras
+        should be able to use the library headlessly. Tested via sys.modules
+        after a fresh hrfunc import."""
+        import sys
+        # Drop any cached gui modules
+        for key in list(sys.modules):
+            if key.startswith("hrfunc.gui"):
+                del sys.modules[key]
+        import hrfunc  # noqa: F401
+        assert "hrfunc.gui" not in sys.modules
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point: argparse contract + version handling
+# ---------------------------------------------------------------------------
+
+
+class TestMainSignature:
+    def test_main_is_callable(self):
+        from hrfunc.gui.app import main
+        assert callable(main)
+
+    def test_main_accepts_optional_argv_list(self):
+        """main(argv=None) must accept either no args or an explicit list.
+        Tests call it with a list to avoid touching sys.argv."""
+        from hrfunc.gui.app import main
+        sig = inspect.signature(main)
+        assert "argv" in sig.parameters
+        assert sig.parameters["argv"].default is None
+
+
+class TestArgumentParser:
+    def test_no_args_produces_path_none(self):
+        from hrfunc.gui.app import _build_argument_parser
+        ns = _build_argument_parser().parse_args([])
+        assert ns.path is None
+
+    def test_positional_path_is_pathlib_path(self):
+        from hrfunc.gui.app import _build_argument_parser
+        ns = _build_argument_parser().parse_args(["/tmp/study"])
+        assert isinstance(ns.path, Path)
+        assert ns.path == Path("/tmp/study")
+
+    def test_version_flag_exits_zero(self, capsys):
+        """`hrfunc --version` must print the version and exit 0 — not crash
+        on import errors if [gui] extras are partially missing in CI."""
+        from hrfunc.gui.app import main
+        with pytest.raises(SystemExit) as exc_info:
+            main(["--version"])
+        assert exc_info.value.code == 0
+        captured = capsys.readouterr()
+        assert "hrfunc" in captured.out.lower()
+
+    def test_help_flag_exits_zero(self):
+        from hrfunc.gui.app import main
+        with pytest.raises(SystemExit) as exc_info:
+            main(["--help"])
+        assert exc_info.value.code == 0
+
+
+# ---------------------------------------------------------------------------
+# pyproject.toml entry point registration
+# ---------------------------------------------------------------------------
+
+
+class TestEntryPoint:
+    def test_hrfunc_console_script_resolves_to_gui_main(self):
+        """`pip install hrfunc[gui]` must register `hrfunc` -> hrfunc.gui.app:main.
+        Reads the entry point from the installed metadata so we exercise the
+        same resolution path pip uses."""
+        try:
+            from importlib.metadata import entry_points
+        except ImportError:  # py3.7 fallback (unused in this repo, but safe)
+            from importlib_metadata import entry_points  # type: ignore
+
+        eps = entry_points()
+        if hasattr(eps, "select"):
+            scripts = eps.select(group="console_scripts")
+        else:
+            scripts = eps.get("console_scripts", [])  # type: ignore[attr-defined]
+
+        hrfunc_eps = [ep for ep in scripts if ep.name == "hrfunc"]
+        assert len(hrfunc_eps) == 1, (
+            "Expected exactly one 'hrfunc' console_scripts entry point; "
+            f"found {len(hrfunc_eps)}. Run `pip install -e .[gui]` to refresh."
+        )
+        assert hrfunc_eps[0].value == "hrfunc.gui.app:main"
+
+
+# ---------------------------------------------------------------------------
+# AppState dataclass behavior
+# ---------------------------------------------------------------------------
+
+
+class TestAppStateDefaults:
+    def test_fresh_state_has_no_data(self):
+        from hrfunc.gui.state import AppState
+        s = AppState()
+        assert s.manifest is None
+        assert s.selected_scan is None
+        assert s.preload_path is None
+        assert s.busy is False
+        assert s.estimation_progress is None
+        assert s.last_error is None
+
+    def test_each_app_state_has_independent_raw_cache(self):
+        """RawCache uses field(default_factory) so two AppStates do NOT share
+        the same cache. Regression guard against accidentally writing
+        `raw_cache: RawCache = RawCache()` (mutable default)."""
+        from hrfunc.gui.state import AppState
+        a = AppState()
+        b = AppState()
+        assert a.raw_cache is not b.raw_cache
+
+    def test_module_level_singleton_exists(self):
+        from hrfunc.gui.state import state, AppState
+        assert isinstance(state, AppState)
+
+
+class TestAppStateReset:
+    def test_reset_clears_all_data_fields(self, tmp_path):
+        """reset() should return the state to its welcome-screen defaults."""
+        from hrfunc.gui.state import AppState
+        from hrfunc.io.manifest import Manifest, ScanEntry
+
+        s = AppState()
+        # Populate everything reset() should clear
+        s.manifest = Manifest(root=tmp_path)
+        s.selected_scan = ScanEntry(format="snirf", path=tmp_path / "x.snirf")
+        s.preload_path = tmp_path
+        s.busy = True
+        s.estimation_progress = (3, 10, "s1_d1_hbo")
+        s.last_error = "boom"
+
+        s.reset()
+
+        assert s.manifest is None
+        assert s.selected_scan is None
+        assert s.preload_path is None
+        assert s.busy is False
+        assert s.estimation_progress is None
+        assert s.last_error is None
+
+    def test_reset_clears_raw_cache_but_keeps_instance(self, tmp_path):
+        """Other code may hold a reference to state.raw_cache; reset() must
+        clear its contents without reassigning the instance, or those
+        references go stale."""
+        from hrfunc.gui.state import AppState
+
+        s = AppState()
+        cache_before = s.raw_cache
+        # We can't easily insert into the cache without real scans, but we
+        # can verify clear() is invoked (cache is empty after reset).
+        s.reset()
+        assert s.raw_cache is cache_before
+        assert len(s.raw_cache) == 0
+
+
+# ---------------------------------------------------------------------------
+# Theme: callable without crashing
+# ---------------------------------------------------------------------------
+
+
+class TestTheme:
+    def test_colors_dict_contains_required_keys(self):
+        """Quasar expects these specific keys; missing one would silently
+        leave that role using Quasar's default rather than the brand color."""
+        from hrfunc.gui.theme import COLORS
+        for key in ("primary", "secondary", "accent",
+                    "positive", "negative", "warning", "info", "dark"):
+            assert key in COLORS
+            assert COLORS[key].startswith("#") and len(COLORS[key]) == 7
+
+    def test_apply_theme_is_callable(self):
+        from hrfunc.gui import theme
+        assert callable(theme.apply_theme)
+
+    def test_page_container_is_callable(self):
+        from hrfunc.gui import theme
+        assert callable(theme.page_container)
+
+
+# ---------------------------------------------------------------------------
+# workers.make_progress_callback writes to AppState
+# ---------------------------------------------------------------------------
+
+
+class TestProgressCallback:
+    def test_callback_writes_tuple_to_state(self):
+        from hrfunc.gui.state import AppState
+        from hrfunc.gui.workers import make_progress_callback
+
+        s = AppState()
+        cb = make_progress_callback(s)
+        cb(3, 32, "s1_d1_hbo")
+        assert s.estimation_progress == (3, 32, "s1_d1_hbo")
+
+    def test_callback_overwrites_previous_value(self):
+        from hrfunc.gui.state import AppState
+        from hrfunc.gui.workers import make_progress_callback
+
+        s = AppState()
+        cb = make_progress_callback(s)
+        cb(0, 10, "a")
+        cb(5, 10, "b")
+        assert s.estimation_progress == (5, 10, "b")
+
+    def test_callback_signature_matches_montage_estimate_hrf_contract(self):
+        """The callback signature MUST match what montage.estimate_hrf calls.
+        Regression guard: if either side drifts, GUI progress reporting
+        silently breaks."""
+        from hrfunc.gui.state import AppState
+        from hrfunc.gui.workers import make_progress_callback
+
+        s = AppState()
+        cb = make_progress_callback(s)
+        sig = inspect.signature(cb)
+        params = list(sig.parameters.values())
+        assert len(params) == 3
+
+
+# ---------------------------------------------------------------------------
+# workers.run_in_background end-to-end (asyncio)
+# ---------------------------------------------------------------------------
+
+
+class TestRunInBackground:
+    def test_successful_run_returns_result_and_clears_busy(self):
+        from hrfunc.gui.state import AppState
+        from hrfunc.gui.workers import run_in_background
+
+        s = AppState()
+
+        def _work() -> int:
+            return 42
+
+        result = asyncio.run(run_in_background(s, _work))
+        assert result == 42
+        assert s.busy is False
+        assert s.last_error is None
+        assert s.estimation_progress is None
+
+    def test_failing_run_stores_error_and_clears_busy(self):
+        from hrfunc.gui.state import AppState
+        from hrfunc.gui.workers import run_in_background
+
+        s = AppState()
+
+        def _boom() -> None:
+            raise RuntimeError("kaboom")
+
+        result = asyncio.run(run_in_background(s, _boom))
+        assert result is None
+        assert s.busy is False
+        assert s.last_error is not None
+        assert "RuntimeError" in s.last_error
+        assert "kaboom" in s.last_error
+
+    def test_concurrent_run_refused_when_busy(self):
+        """Only one background worker at a time. A second call while busy
+        must return None without dispatching."""
+        from hrfunc.gui.state import AppState
+        from hrfunc.gui.workers import run_in_background
+
+        s = AppState()
+        s.busy = True  # simulate an in-flight worker
+
+        called = []
+
+        def _work() -> int:
+            called.append(1)
+            return 1
+
+        result = asyncio.run(run_in_background(s, _work))
+        assert result is None
+        assert called == []  # _work was never dispatched
+
+    def test_on_done_invoked_with_result(self):
+        from hrfunc.gui.state import AppState
+        from hrfunc.gui.workers import run_in_background
+
+        s = AppState()
+        captured = []
+
+        async def _on_done(result):
+            captured.append(result)
+
+        asyncio.run(run_in_background(s, lambda: "hello", on_done=_on_done))
+        assert captured == ["hello"]


### PR DESCRIPTION
## Summary

First of three branches in Sprint 2 (GUI shell). Adds the `hrfunc.gui` subpackage skeleton, registers the `hrfunc` CLI command, and lays the state / theme / workers groundwork that the welcome and workspace pages (Sprints 2.2 and 2.3) compose against.

After this lands: `pip install hrfunc[gui]` puts a `hrfunc` command on PATH that launches a native desktop window (currently showing a placeholder; real welcome screen comes in 2.2).

## What lands

**New subpackage** `src/hrfunc/gui/`:

| Module | Role |
|---|---|
| `app.py` | CLI entry. `main(argv=None)` parses optional positional `path` + `--version` + `--help`, sets `state.preload_path`, registers a placeholder root page, launches NiceGUI in `native=True` mode on an OS-picked free port. NiceGUI imported lazily so `--version`/`--help` work without `[gui]` extras fully resolving. |
| `state.py` | `AppState` dataclass + module-level singleton. Holds manifest, selected_scan, RawCache (per-instance via `field(default_factory)`), preload_path, busy, estimation_progress, last_error. `reset()` clears data without reassigning the cache. |
| `theme.py` | Quasar color palette (8 role tokens mapped to Tailwind 500 hexes) + dark-mode default + `page_container` helper. `apply_theme(dark=True)` is idempotent; meant to call at the top of each `@ui.page` handler. |
| `workers.py` | Background-task helpers. `make_progress_callback(state)` returns a `(current, total, name)` callback matching `montage.estimate_*` contracts. `run_in_background(state, func, ...)` runs blocking work via `loop.run_in_executor` (3.8-compat), captures errors to `state.last_error`, refuses concurrent dispatch when busy. |

## `pyproject.toml` changes

```toml
[project.optional-dependencies]
gui = [
    "nicegui>=2.0",
    "plotly>=5.18",
    "pywebview>=5.0",
]

[project.scripts]
hrfunc = "hrfunc.gui.app:main"

[tool.setuptools]
packages = ["hrfunc", "hrfunc.io", "hrfunc.gui"]
```

Core `pip install hrfunc` stays lean; the GUI is purely opt-in.

## CLI decision (locked)

`hrfunc` always launches the GUI. `hrfunc <path>` preloads a folder/file. **No `--gui` flag** — reserved for future subcommands. Position is `path` is optional; `--version`/`--help` are standard argparse.

```
hrfunc                              # launch GUI
hrfunc /path/to/study               # launch with folder preloaded
hrfunc subject_01.snirf             # launch with file preloaded
hrfunc --version                    # print version and exit
```

## Tests

`tests/test_gui_foundation.py` — **28 new tests**, all gated by `pytest.importorskip("nicegui")` so they skip when extras aren't installed:

- **Package imports** (6): each gui submodule imports; **critical**: `import hrfunc` does NOT pull in `hrfunc.gui` (verified via sys.modules) — keeps the library headless-friendly
- **Main signature** (2): callable, `argv=None` default
- **Argument parser** (4): no args → path=None; positional Path; `--version` exits 0; `--help` exits 0
- **Entry point** (1): `importlib.metadata.entry_points` confirms `hrfunc → hrfunc.gui.app:main` is registered
- **AppState defaults** (3): fresh state has no data; separate AppStates get separate RawCaches (mutable-default regression guard); module-level singleton exists
- **AppState.reset** (2): clears all data fields; RawCache cleared but instance identity preserved
- **Theme** (3): all 8 Quasar role keys present, `apply_theme` and `page_container` callable
- **Progress callback** (3): writes to state, overwrites on next call, signature matches `montage` callback contract
- **`run_in_background`** (4): success returns result + clears busy; failure stores typed error string + clears busy without reraising; concurrent dispatch refused when busy (work function never invoked); `on_done` invoked with result

## Gate

```
pytest tests/test_phase1a.py tests/test_phase1bc.py tests/test_phase2.py \
       tests/test_threading.py tests/test_input_validation.py \
       tests/test_state_lifecycle.py tests/test_oxygenation_guard.py \
       tests/test_tree_delete_filter.py tests/test_hasher_branch.py \
       tests/test_tree_hrf.py tests/test_canonical_hrf.py \
       tests/test_tree_edge_cases.py tests/test_observer_and_typos.py \
       tests/test_progress_callbacks.py tests/test_io_detect.py \
       tests/test_io_scan.py tests/test_io_raw_cache.py \
       tests/test_gui_foundation.py -q
→ 350 passed in 3.92s (322 prior + 28 new, zero regressions)
```

**Manual smoke**:
```
$ which hrfunc
/Users/.../envs/hrfunc-env/bin/hrfunc
$ hrfunc --version
hrfunc 1.1.2
$ hrfunc --help
usage: hrfunc [-h] [--version] [path]
```

## Reviews

- **Architecture & Execution Flow**: `hrfunc.gui` is a leaf subpackage. Imports from `hrfunc.io.manifest` and `hrfunc.io.raw_cache` only; nothing imports back from it. The "import hrfunc must not pull in NiceGUI" invariant is enforced by an explicit test that drops cached gui modules from sys.modules and re-imports the core package. Lazy NiceGUI import in `main()` keeps `--version`/`--help` working even with broken extras.
- **API Surface & Usability**: single CLI entry with no flags beyond standard `--version`/`--help` — matches the locked decision (no `--gui` flag until there's an inverse). `AppState` defaults represent the welcome-screen state so a freshly-constructed instance is well-defined. `reset()` preserves RawCache instance identity so held references stay valid. `run_in_background`'s error-capture behavior (store on state, don't reraise) is documented in the module docstring as deliberate — the GUI surfaces errors via banner, not crashes.

## Gotchas

- **3.8 compat fix during review**: initial draft used `asyncio.to_thread` (3.9+). Caught during review; switched to `loop.run_in_executor` to match `requires-python = ">=3.8"`.
- **`_find_free_port`** picks an ephemeral port so NiceGUI doesn't crash with "address already in use" when port 8080 is taken (common on dev machines).
- **Placeholder root page** is intentionally minimal. Sprint 2.2 replaces it with the real 3-path welcome screen.
- **Rendering tests** (via `nicegui.testing.User`) need `pytest-asyncio`. Deferred to Sprint 2.2 when there's a real page worth rendering.

## Test plan

- [x] `pytest tests/test_gui_foundation.py -v` passes (28/28)
- [x] Full v1.3.0 gate passes (350 total)
- [x] `pip install -e .[gui]` registers the `hrfunc` entry point on PATH
- [x] `hrfunc --version` prints version cleanly
- [x] `hrfunc --help` shows positional path + standard flags
- [ ] Manual GUI launch — running `hrfunc` opens a window with the placeholder (visual confirmation by reviewer)

## Roadmap

Sprint 2 remaining:
- `feat/gui-welcome-page` (2.2) — 3-path entry: "Open my data" / "Browse HRF library" / "Recent projects"
- `feat/gui-workspace-shell` (2.3) — workspace shell with dataset tree + tab placeholders

🤖 Generated with [Claude Code](https://claude.com/claude-code)