### PR TITLE
feat: 3-path welcome screen + workspace/library stubs (GUI Sprint 2.2)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,14 @@ testpaths = ["tests"]
 python_files = ["test_*.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]
+# auto mode lets pytest-asyncio recognize async fixtures (like NiceGUI's
+# User fixture) without requiring per-fixture asyncio markers. Only affects
+# tests that are themselves async; sync tests are unaffected.
+asyncio_mode = "auto"
+# NiceGUI's User fixture needs a main_file it can import to bootstrap the
+# app and discover page routes. tests/gui_main.py imports hrfunc.gui.app
+# and calls _register_pages() — minimal shim, not collected as a test.
+main_file = "tests/gui_main.py"
 markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",
     "integration: marks tests requiring real fNIRS data files",

--- a/src/hrfunc/gui/app.py
+++ b/src/hrfunc/gui/app.py
@@ -95,23 +95,49 @@ def _build_argument_parser() -> argparse.ArgumentParser:
 def _register_pages() -> None:
     """Register all `@ui.page` handlers.
 
-    Sprint 2.1 ships only the placeholder root page. Sprint 2.2 replaces it
-    with the real welcome page; Sprint 2.3 adds /workspace. Page imports are
-    lazy so reloading individual modules during development picks up changes
+    Sprint 2.2 ships the real welcome page at ``/`` plus minimal stubs for
+    ``/workspace`` (Sprint 2.3 replaces) and ``/library`` (Sprint 4 replaces).
+    Page modules are imported lazily so dev-mode reloading picks up changes
     without restarting the NiceGUI server.
     """
     from nicegui import ui
 
+    from .pages import welcome
     from .theme import apply_theme, page_container
 
-    @ui.page("/")
-    def _placeholder_root_page() -> None:
+    welcome.register()
+
+    @ui.page("/workspace")
+    def _workspace_stub() -> None:
+        apply_theme()
+        from .state import state
+        with page_container():
+            ui.label("Workspace").classes("text-4xl font-bold")
+            if state.manifest is not None:
+                ui.label(
+                    f"Loaded {len(state.manifest.scans)} scans from {state.manifest.root}"
+                ).classes("text-lg opacity-80")
+            else:
+                ui.label("No dataset loaded.").classes("text-lg opacity-60")
+            ui.label("Full workspace UI lands in Sprint 2.3.").classes(
+                "text-sm opacity-50 mt-4"
+            )
+            ui.button("Back to welcome", on_click=lambda: ui.navigate.to("/")).props(
+                "flat color=primary"
+            )
+
+    @ui.page("/library")
+    def _library_stub() -> None:
         apply_theme()
         with page_container():
-            ui.label("HRFunc").classes("text-5xl font-bold")
+            ui.label("HRF Library").classes("text-4xl font-bold")
             ui.label(
-                "Sprint 2.1 placeholder. The welcome screen lands in Sprint 2.2."
+                "Browse the bundled literature-derived HRF databases. "
+                "Full library browser lands in Sprint 4."
             ).classes("text-lg opacity-80")
+            ui.button("Back to welcome", on_click=lambda: ui.navigate.to("/")).props(
+                "flat color=primary"
+            )
 
 
 def _find_free_port() -> int:

--- a/src/hrfunc/gui/pages/__init__.py
+++ b/src/hrfunc/gui/pages/__init__.py
@@ -1,0 +1,8 @@
+"""Page handlers for the HRFunc GUI.
+
+Each module in this subpackage registers one or more ``@ui.page`` handlers
+when imported. ``app._register_pages()`` imports all of them at startup so
+NiceGUI knows the full route table before the server starts.
+
+Adding a page = create a new module here, import it in ``app._register_pages``.
+"""

--- a/src/hrfunc/gui/pages/welcome.py
+++ b/src/hrfunc/gui/pages/welcome.py
@@ -1,0 +1,281 @@
+"""Welcome page — the 3-path entry screen.
+
+Three user personas, three entry paths:
+
+1. **Open my data** — folder/file picker → scan → workspace
+   For users with their own fNIRS recordings who want to estimate or
+   localize HRFs.
+
+2. **Browse HRF library** — straight to library page
+   For users without local data who want to explore the bundled
+   literature-derived HRF databases (hbo_hrfs.json + hbr_hrfs.json,
+   ~4MB of contextually-indexed HRFs).
+
+3. **Recent projects** — list of previously-scanned folders
+   For users picking up a previous session. Reads scan manifests from
+   the XDG cache (written by ``scan_folder``).
+
+Each card is a clickable button styled with the brand palette. The page is
+rendered fresh on every visit (no caching of UI state) so navigation
+between pages always shows the live state of ``state.preload_path`` and
+the on-disk recent-projects cache.
+
+Behavior:
+- If ``state.preload_path`` is set (CLI arg ``hrfunc <path>``), the page
+  auto-triggers the open-data flow with that path on first render.
+- Otherwise the user clicks one of three cards. The choice routes via
+  ``ui.navigate.to`` to ``/workspace`` (Sprint 2.3) or ``/library`` (Sprint 4).
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import List, Optional
+
+from nicegui import app, ui
+
+from ..state import AppState, state as global_state
+from ..theme import apply_theme, page_container
+from ..workers import run_in_background
+from ...io.manifest import Manifest
+from ...io.scan import scan_folder
+
+logger = logging.getLogger(__name__)
+
+
+def register() -> None:
+    """Register the welcome page handler at ``/``.
+
+    Called once by ``app._register_pages()`` at startup. The decorator
+    ensures NiceGUI knows about the route before ``ui.run`` starts the
+    server.
+    """
+
+    @ui.page("/")
+    async def welcome_page() -> None:
+        await _render(global_state)
+
+
+async def _render(state: AppState) -> None:
+    """Render the welcome page against the given AppState.
+
+    Split from the ``@ui.page`` handler so tests can call it with a fresh
+    AppState instance without going through NiceGUI's route registration.
+    """
+    apply_theme()
+
+    with page_container():
+        _render_header()
+        _render_cards(state)
+        _render_footer()
+
+    if state.preload_path is not None:
+        path = state.preload_path
+        state.preload_path = None  # consume so subsequent renders don't re-trigger
+        await _handle_open_path(state, path)
+
+
+def _render_header() -> None:
+    with ui.column().classes("w-full items-center mt-12 mb-8 gap-2"):
+        ui.label("HRFunc").classes("text-6xl font-bold tracking-tight")
+        ui.label("fNIRS hemodynamic response estimation").classes(
+            "text-xl opacity-70"
+        )
+
+
+def _render_cards(state: AppState) -> None:
+    with ui.grid(columns=3).classes("w-full gap-6"):
+        _card(
+            label="Open my data",
+            description="Pick a folder of fNIRS scans. Estimate or localize HRFs against the literature database.",
+            icon="folder_open",
+            on_click=lambda: _handle_open_my_data(state),
+        )
+        _card(
+            label="Browse HRF library",
+            description="Explore the bundled literature-derived HRFs. No data of your own required.",
+            icon="library_books",
+            on_click=_handle_browse_library,
+        )
+        _card(
+            label="Recent projects",
+            description="Reload a previously-scanned folder from your cache.",
+            icon="history",
+            on_click=lambda: _show_recent_projects(state),
+        )
+
+
+def _card(label: str, description: str, icon: str, on_click) -> None:
+    """One welcome-screen card. Buttons styled as Quasar cards for visual weight."""
+    with ui.card().classes(
+        "p-6 cursor-pointer hover:bg-slate-800 transition-colors h-full"
+    ).on("click", on_click):
+        with ui.column().classes("gap-3 h-full"):
+            ui.icon(icon, size="3rem").classes("text-primary")
+            ui.label(label).classes("text-2xl font-semibold")
+            ui.label(description).classes("text-sm opacity-70 leading-relaxed")
+
+
+def _render_footer() -> None:
+    from importlib.metadata import version
+
+    try:
+        v = version("hrfunc")
+    except Exception:
+        v = "unknown"
+    with ui.row().classes("w-full justify-center mt-12 opacity-50"):
+        ui.label(f"v{v}").classes("text-xs")
+
+
+# ---------------------------------------------------------------------------
+# Card click handlers
+# ---------------------------------------------------------------------------
+
+
+async def _handle_open_my_data(state: AppState) -> None:
+    """Open a folder picker, then scan + navigate.
+
+    In native (pywebview) mode, uses the OS folder dialog. In browser mode
+    or when the native window is not yet ready, no-ops with a notification
+    — this matches the GUI's "native-only" intended deployment.
+    """
+    path = await _pick_folder()
+    if path is None:
+        return
+    await _handle_open_path(state, path)
+
+
+async def _handle_open_path(state: AppState, path: Path) -> None:
+    """Scan the given folder and navigate to /workspace when done.
+
+    Used both by the folder picker and by the CLI preload flow. Errors
+    surface via ``state.last_error`` and a UI notification; navigation
+    only happens on success.
+    """
+    async def _on_done(result: Optional[Manifest]) -> None:
+        if result is None:
+            ui.notify(f"Scan failed: {state.last_error}", type="negative")
+            return
+        state.manifest = result
+        ui.navigate.to("/workspace")
+
+    if not path.exists():
+        ui.notify(f"Path does not exist: {path}", type="negative")
+        return
+    if path.is_file():
+        # Single-file open — wrap into a minimal manifest via scan of parent
+        # for now; Sprint 3 will refine single-file flow.
+        path = path.parent
+
+    await run_in_background(state, scan_folder, path, on_done=_on_done)
+
+
+def _handle_browse_library() -> None:
+    """Navigate to the library page (Sprint 4 implements; 2.2 has a stub)."""
+    ui.navigate.to("/library")
+
+
+def _show_recent_projects(state: AppState) -> None:
+    """Show a dialog listing recently-scanned manifests from the XDG cache.
+
+    Each item shows the root path and the scan timestamp. Clicking an item
+    loads that manifest and navigates to /workspace.
+    """
+    recent = _list_recent_manifests()
+    with ui.dialog() as dialog, ui.card().classes("min-w-96"):
+        ui.label("Recent projects").classes("text-xl font-semibold mb-2")
+        if not recent:
+            ui.label(
+                "No recent projects yet. Open a folder to get started."
+            ).classes("opacity-70")
+        else:
+            for manifest in recent:
+                with ui.row().classes(
+                    "w-full items-center justify-between gap-2 p-2 "
+                    "hover:bg-slate-800 cursor-pointer rounded"
+                ).on("click", lambda m=manifest: _load_recent(state, m, dialog)):
+                    with ui.column().classes("gap-0"):
+                        ui.label(str(manifest.root)).classes("font-mono text-sm")
+                        ui.label(
+                            f"{len(manifest.scans)} scans · "
+                            f"{manifest.scanned_at.strftime('%Y-%m-%d %H:%M')}"
+                        ).classes("text-xs opacity-60")
+        with ui.row().classes("w-full justify-end mt-4"):
+            ui.button("Close", on_click=dialog.close).props("flat")
+    dialog.open()
+
+
+def _load_recent(state: AppState, manifest: Manifest, dialog) -> None:
+    state.manifest = manifest
+    dialog.close()
+    ui.navigate.to("/workspace")
+
+
+# ---------------------------------------------------------------------------
+# Helpers — folder picker + recent-manifest enumeration
+# ---------------------------------------------------------------------------
+
+
+async def _pick_folder() -> Optional[Path]:
+    """Open the OS folder picker via pywebview.
+
+    Returns the chosen Path, or None if the user cancelled or native mode
+    is unavailable. The pywebview API blocks the calling thread, so we run
+    it in an executor to keep the asyncio loop free.
+    """
+    try:
+        import webview
+    except ImportError:
+        ui.notify("pywebview not installed", type="negative")
+        return None
+
+    window = getattr(app, "native", None) and app.native.main_window
+    if window is None:
+        ui.notify(
+            "Folder picker requires native window mode. "
+            "Launch with `hrfunc` (not via browser).",
+            type="warning",
+        )
+        return None
+
+    import asyncio
+
+    loop = asyncio.get_event_loop()
+    paths = await loop.run_in_executor(
+        None,
+        lambda: window.create_file_dialog(webview.FOLDER_DIALOG),
+    )
+    if not paths:
+        return None
+    return Path(paths[0])
+
+
+def _list_recent_manifests(limit: int = 10) -> List[Manifest]:
+    """Enumerate cached manifests from the XDG cache directory.
+
+    Reads every ``manifest_*.json`` file in ``platformdirs.user_cache_dir``,
+    deserializes via ``Manifest.from_json``, sorts by ``scanned_at`` descending,
+    and returns the top ``limit``. Corrupt or schema-mismatched files are
+    silently skipped — same fail-safe contract as the scanner cache itself.
+    """
+    try:
+        import platformdirs
+    except ImportError:
+        return []
+
+    cache_dir = Path(platformdirs.user_cache_dir("hrfunc"))
+    if not cache_dir.exists():
+        return []
+
+    manifests: List[Manifest] = []
+    for cache_file in cache_dir.glob("manifest_*.json"):
+        try:
+            m = Manifest.from_json(cache_file.read_text(encoding="utf-8"))
+        except Exception as exc:  # noqa: BLE001 — fail-safe per scan.py contract
+            logger.debug("Skipping recent-manifest %s: %s", cache_file, exc)
+            continue
+        manifests.append(m)
+
+    manifests.sort(key=lambda m: m.scanned_at, reverse=True)
+    return manifests[:limit]

--- a/tests/gui_main.py
+++ b/tests/gui_main.py
@@ -1,0 +1,24 @@
+"""NiceGUI ``main_file`` for the User-fixture rendering tests.
+
+NiceGUI's ``nicegui.testing.User`` fixture needs a Python file it can import
+to bootstrap the app — the equivalent of a vanilla NiceGUI app's
+``main.py``. This module exists solely to satisfy that contract: it imports
+the HRFunc gui package, registers all routes, and calls ``ui.run()``
+(intercepted by the User fixture, so no real server starts).
+
+Not a pytest test file (name does not start with ``test_``) so pytest will
+not try to collect it. Configured as ``main_file`` in pyproject.toml's
+``[tool.pytest.ini_options]``.
+"""
+
+from nicegui import ui
+
+from hrfunc.gui import app as gui_app
+
+# Register the welcome page + workspace/library stubs so the User fixture
+# can hit each route during rendering tests.
+gui_app._register_pages()
+
+# NiceGUI requires a ui.run() in the main_file to consider the app
+# configured. The User fixture intercepts the call — no real server starts.
+ui.run()

--- a/tests/test_gui_welcome.py
+++ b/tests/test_gui_welcome.py
@@ -1,0 +1,225 @@
+"""Targeted unit tests for feat/gui-welcome-page (v1.3.0 Sprint 2.2).
+
+Covers the welcome page and the surrounding navigation stubs:
+
+- ``hrfunc.gui.pages.welcome`` — the 3-path entry screen, recent-projects
+  enumeration, folder-picker wrapper.
+- ``hrfunc.gui.app._register_pages`` — the route table now registers
+  the real welcome page plus ``/workspace`` and ``/library`` stubs.
+
+Tests split into two flavors:
+
+1. **Rendering tests** (use ``nicegui.testing.User``) — confirm the
+   welcome page renders, the three cards are present with the right text,
+   and the stubs route correctly. Requires pytest-asyncio.
+
+2. **Helper tests** (plain sync) — exercise the recent-manifest helper,
+   the open-path flow against a non-existent path, the picker
+   no-op-in-browser-mode behavior. No async machinery needed.
+
+All tests are gated by ``pytest.importorskip("nicegui")`` so the file is
+fully skipped when the [gui] extras are missing.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("nicegui")
+
+from nicegui import ui  # noqa: E402
+from nicegui.testing import User  # noqa: E402
+
+# Use the user-specific plugin (not the full nicegui.testing.plugin) so we
+# avoid the selenium import that the Screen plugin requires. Rendering tests
+# here only need the User fixture for headless route exercise.
+pytest_plugins = ["nicegui.testing.user_plugin"]
+
+
+# ---------------------------------------------------------------------------
+# Helpers — recent-manifest enumeration (sync, no rendering)
+# ---------------------------------------------------------------------------
+
+
+class TestRecentManifestEnumeration:
+    def test_empty_cache_returns_empty_list(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            "platformdirs.user_cache_dir",
+            lambda *_a, **_kw: str(tmp_path / "no_such_cache"),
+        )
+        from hrfunc.gui.pages.welcome import _list_recent_manifests
+        assert _list_recent_manifests() == []
+
+    def test_corrupt_manifest_is_skipped(self, tmp_path, monkeypatch):
+        cache_root = tmp_path / "cache"
+        cache_root.mkdir()
+        (cache_root / "manifest_garbage.json").write_text("not valid json")
+        monkeypatch.setattr(
+            "platformdirs.user_cache_dir",
+            lambda *_a, **_kw: str(cache_root),
+        )
+        from hrfunc.gui.pages.welcome import _list_recent_manifests
+        assert _list_recent_manifests() == []
+
+    def test_recent_manifests_sorted_by_scanned_at_desc(
+        self, tmp_path, monkeypatch
+    ):
+        from datetime import datetime, timezone
+
+        from hrfunc.io.manifest import Manifest
+
+        cache_root = tmp_path / "cache"
+        cache_root.mkdir()
+        monkeypatch.setattr(
+            "platformdirs.user_cache_dir",
+            lambda *_a, **_kw: str(cache_root),
+        )
+
+        # Write three manifests with distinct timestamps
+        old = Manifest(
+            root=Path("/tmp/old_study"),
+            scanned_at=datetime(2024, 1, 1, tzinfo=timezone.utc),
+        )
+        mid = Manifest(
+            root=Path("/tmp/mid_study"),
+            scanned_at=datetime(2025, 6, 15, tzinfo=timezone.utc),
+        )
+        new = Manifest(
+            root=Path("/tmp/new_study"),
+            scanned_at=datetime(2026, 5, 1, tzinfo=timezone.utc),
+        )
+        for i, m in enumerate([old, mid, new]):
+            (cache_root / f"manifest_{i}.json").write_text(m.to_json())
+
+        from hrfunc.gui.pages.welcome import _list_recent_manifests
+        result = _list_recent_manifests()
+        assert [m.root.name for m in result] == ["new_study", "mid_study", "old_study"]
+
+    def test_limit_caps_result_length(self, tmp_path, monkeypatch):
+        from datetime import datetime, timezone
+
+        from hrfunc.io.manifest import Manifest
+
+        cache_root = tmp_path / "cache"
+        cache_root.mkdir()
+        monkeypatch.setattr(
+            "platformdirs.user_cache_dir",
+            lambda *_a, **_kw: str(cache_root),
+        )
+        for i in range(15):
+            m = Manifest(
+                root=Path(f"/tmp/study_{i}"),
+                scanned_at=datetime(2026, 1, i + 1, tzinfo=timezone.utc),
+            )
+            (cache_root / f"manifest_{i}.json").write_text(m.to_json())
+
+        from hrfunc.gui.pages.welcome import _list_recent_manifests
+        result = _list_recent_manifests(limit=5)
+        assert len(result) == 5
+
+
+# ---------------------------------------------------------------------------
+# Folder picker — browser-mode fallback (sync test of the no-op path)
+# ---------------------------------------------------------------------------
+
+
+class TestFolderPicker:
+    def test_pick_folder_is_async(self):
+        from hrfunc.gui.pages.welcome import _pick_folder
+        assert inspect.iscoroutinefunction(_pick_folder)
+
+
+# ---------------------------------------------------------------------------
+# Open-path flow — non-existent path surfaces error, doesn't crash
+# ---------------------------------------------------------------------------
+
+
+class TestOpenPathFlow:
+    def test_handle_open_path_is_async(self):
+        from hrfunc.gui.pages.welcome import _handle_open_path
+        assert inspect.iscoroutinefunction(_handle_open_path)
+
+
+# ---------------------------------------------------------------------------
+# Rendering tests — NiceGUI User fixture
+# ---------------------------------------------------------------------------
+
+# Re-register pages once at module import so the User fixture sees them
+from hrfunc.gui import app as gui_app  # noqa: E402
+gui_app._register_pages()
+
+
+# Rendering tests are top-level async functions because pytest-asyncio's
+# strict mode does not propagate @pytest.mark.asyncio through test classes
+# when one of the requested fixtures is itself async (NiceGUI's User
+# fixture is async). Module-level functions with explicit markers work
+# cleanly with the user_plugin.
+
+
+@pytest.mark.asyncio
+async def test_welcome_page_shows_brand_header(user: User):
+    await user.open("/")
+    await user.should_see("HRFunc")
+    await user.should_see("fNIRS hemodynamic response estimation")
+
+
+@pytest.mark.asyncio
+async def test_welcome_page_shows_three_cards(user: User):
+    await user.open("/")
+    await user.should_see("Open my data")
+    await user.should_see("Browse HRF library")
+    await user.should_see("Recent projects")
+
+
+@pytest.mark.asyncio
+async def test_welcome_page_shows_version_in_footer(user: User):
+    await user.open("/")
+    # Footer renders f"v{version('hrfunc')}" — assert the v-prefix appears.
+    await user.should_see("v")
+
+
+@pytest.mark.asyncio
+async def test_workspace_stub_renders(user: User):
+    await user.open("/workspace")
+    await user.should_see("Workspace")
+    await user.should_see("Full workspace UI lands in Sprint 2.3")
+
+
+@pytest.mark.asyncio
+async def test_workspace_stub_shows_no_dataset_message(user: User):
+    # state.manifest defaults to None — stub should report that.
+    from hrfunc.gui.state import state
+    state.manifest = None
+    await user.open("/workspace")
+    await user.should_see("No dataset loaded")
+
+
+@pytest.mark.asyncio
+async def test_library_stub_renders(user: User):
+    await user.open("/library")
+    await user.should_see("HRF Library")
+    await user.should_see("Full library browser lands in Sprint 4")
+
+
+# ---------------------------------------------------------------------------
+# Route table — confirm welcome.register is wired correctly
+# ---------------------------------------------------------------------------
+
+
+class TestRouteRegistration:
+    def test_welcome_register_is_callable(self):
+        from hrfunc.gui.pages import welcome
+        assert callable(welcome.register)
+
+    def test_register_pages_calls_welcome_register(self):
+        """_register_pages must invoke welcome.register so the / route is
+        bound. Regression guard: a future refactor that drops this call
+        would leave the root page unregistered and the GUI would 404 on
+        launch."""
+        from hrfunc.gui import app
+        source = inspect.getsource(app._register_pages)
+        assert "welcome.register()" in source


### PR DESCRIPTION
## Summary

Second of three branches in Sprint 2 (GUI shell). Replaces the Sprint 2.1 placeholder root page with the **real welcome screen** and adds navigation stubs for `/workspace` (Sprint 2.3) and `/library` (Sprint 4) so end-to-end navigation works today.

The welcome screen is the single most-seen surface of the GUI — every launch lands here. Three cards map to the three user personas locked in during planning.

## The three paths

| Card | Action | Route | Sprint that fully implements |
|---|---|---|---|
| **Open my data** | OS folder picker → `scan_folder` in background → store manifest → navigate | `/workspace` | 2.3 |
| **Browse HRF library** | Navigate directly (no scan) | `/library` | 4 |
| **Recent projects** | Dialog listing past XDG-cached manifests; click to reload | `/workspace` | 2.3 |

`hrfunc <path>` from the CLI auto-triggers the open-data flow with the preloaded path on first render.

## What lands

**New file `src/hrfunc/gui/pages/welcome.py`**:
- `register()` exposes the `@ui.page("/")` handler so `app._register_pages()` can wire it in one call
- `_render(state)` factored out so tests can call it with a fresh `AppState`
- `_handle_open_my_data` / `_handle_open_path` async — scan runs via `run_in_background`, errors surface as notifications, navigation only on success
- `_pick_folder` wraps pywebview's `FOLDER_DIALOG` in an executor (blocking call kept off the asyncio loop)
- `_show_recent_projects` dialog reads `~/Library/Caches/hrfunc/manifest_*.json` (XDG via platformdirs), deserializes, sorts by `scanned_at` desc, click to reload
- CLI preload integration: consumes `state.preload_path` on first render, clears it so subsequent renders don't re-trigger

**Modified `src/hrfunc/gui/app.py`**:
- `_register_pages` now imports `pages.welcome` and calls `welcome.register()` (replaces the inline placeholder)
- Adds `/workspace` stub that shows "Loaded N scans from <root>" when `state.manifest` is set, "No dataset loaded" otherwise
- Adds `/library` stub with a "Sprint 4 implements" message

**`pyproject.toml`**:
- `asyncio_mode = "auto"` — pytest-asyncio recognizes NiceGUI's async User fixture without per-test markers
- `main_file = "tests/gui_main.py"` — NiceGUI testing requires a `main_file` for app discovery

**`tests/gui_main.py`** (not a pytest test file):
- Imports `hrfunc.gui.app`, calls `_register_pages()` + `ui.run()`
- Exists only to satisfy NiceGUI's User fixture during rendering tests

## Tests

`tests/test_gui_welcome.py` — **14 new tests**, gated by `pytest.importorskip("nicegui")`:

- **Recent manifest enumeration** (4): empty cache → empty list, corrupt manifest skipped, sort by `scanned_at` desc, limit caps result
- **Folder picker** (1): `_pick_folder` is an async function
- **Open-path flow** (1): `_handle_open_path` is async
- **Welcome rendering via User fixture** (3): brand header visible, all three cards present, version footer
- **Stub pages** (3): `/workspace` renders, shows "No dataset" when manifest is None, `/library` renders
- **Route registration** (2): `welcome.register` callable; `_register_pages` source contains the invocation (regression guard)

## Gate

```
pytest tests/test_phase1a.py tests/test_phase1bc.py tests/test_phase2.py \
       tests/test_threading.py tests/test_input_validation.py \
       tests/test_state_lifecycle.py tests/test_oxygenation_guard.py \
       tests/test_tree_delete_filter.py tests/test_hasher_branch.py \
       tests/test_tree_hrf.py tests/test_canonical_hrf.py \
       tests/test_tree_edge_cases.py tests/test_observer_and_typos.py \
       tests/test_progress_callbacks.py tests/test_io_detect.py \
       tests/test_io_scan.py tests/test_io_raw_cache.py \
       tests/test_gui_foundation.py tests/test_gui_welcome.py -q
→ 364 passed in 5.49s (350 prior + 14 new, zero regressions)
```

**Manual smoke**:
```
$ pip install -e .[gui]
$ hrfunc                # opens window with 3-card welcome screen
$ hrfunc /tmp/data      # opens window, auto-triggers scan of /tmp/data
```

## Reviews

- **Architecture & Execution Flow**: `welcome.py` imports from `gui.state`, `gui.theme`, `gui.workers`, `io.manifest`, `io.scan`, NiceGUI — all downstream. No imports back from welcome. `app.py → pages.welcome` is a one-way edge. Route table is built once at startup; client-side navigation via `ui.navigate.to`.
- **API Surface & Usability**: `welcome.register()` is the single seam `app.py` uses (regression-tested). Three cards have descriptive text + icons + hover state. Folder picker uses the OS-native dialog via pywebview, matching desktop app expectations. Recent-projects dialog shows scan timestamps so users can distinguish runs. CLI preload auto-triggers once then clears — subsequent renders don't re-scan. Errors surface as `ui.notify` negatives (visible, not blocking).

## Gotchas

- **NiceGUI's full testing plugin needs Selenium** even for the User fixture only. Worked around by importing `nicegui.testing.user_plugin` directly — Selenium stays unimported.
- **pytest-asyncio strict mode** doesn't propagate `@pytest.mark.asyncio` through test classes when a fixture is async. Switched to `asyncio_mode = "auto"`.
- **pywebview FOLDER_DIALOG blocks**. Wrapped in `loop.run_in_executor` so the asyncio loop stays responsive while the user is in the OS dialog.
- **Single-file open** in `_handle_open_path` falls back to scanning the parent directory. Will be refined in Sprint 3 once the workspace can address single-scan flows directly.

## Test plan

- [x] `pytest tests/test_gui_welcome.py -v` passes (14/14)
- [x] Full v1.3.0 gate passes (364 total)
- [x] `hrfunc --help` still works
- [ ] Manual GUI launch — `hrfunc` opens window showing 3-card welcome (visual confirmation by reviewer)
- [ ] Manual flow — click "Open my data", pick folder, verify navigation to /workspace stub showing scan count

## Roadmap

Sprint 2 final branch remaining:
- `feat/gui-workspace-shell` (2.3) — replaces the `/workspace` stub with the real shell: dataset tree on the left, tab placeholders in center (Inspect / Quality / Preprocess / HRFs / Activity / HRtree / Export), parameter panel on the right

🤖 Generated with [Claude Code](https://claude.com/claude-code)