### PR TITLE
feat: workspace shell with dataset tree + tab placeholders (GUI Sprint 2.3)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,13 @@ Documentation = "https://www.hrfunc.org"
 
 [tool.setuptools]
 package-dir = {"" = "src"}
-packages = ["hrfunc", "hrfunc.io", "hrfunc.gui"]
+packages = [
+    "hrfunc",
+    "hrfunc.io",
+    "hrfunc.gui",
+    "hrfunc.gui.components",
+    "hrfunc.gui.pages",
+    ]
 include-package-data = true
 
 [tool.pytest.ini_options]

--- a/src/hrfunc/gui/app.py
+++ b/src/hrfunc/gui/app.py
@@ -102,29 +102,11 @@ def _register_pages() -> None:
     """
     from nicegui import ui
 
-    from .pages import welcome
+    from .pages import welcome, workspace
     from .theme import apply_theme, page_container
 
     welcome.register()
-
-    @ui.page("/workspace")
-    def _workspace_stub() -> None:
-        apply_theme()
-        from .state import state
-        with page_container():
-            ui.label("Workspace").classes("text-4xl font-bold")
-            if state.manifest is not None:
-                ui.label(
-                    f"Loaded {len(state.manifest.scans)} scans from {state.manifest.root}"
-                ).classes("text-lg opacity-80")
-            else:
-                ui.label("No dataset loaded.").classes("text-lg opacity-60")
-            ui.label("Full workspace UI lands in Sprint 2.3.").classes(
-                "text-sm opacity-50 mt-4"
-            )
-            ui.button("Back to welcome", on_click=lambda: ui.navigate.to("/")).props(
-                "flat color=primary"
-            )
+    workspace.register()
 
     @ui.page("/library")
     def _library_stub() -> None:

--- a/src/hrfunc/gui/components/__init__.py
+++ b/src/hrfunc/gui/components/__init__.py
@@ -1,0 +1,9 @@
+"""Reusable UI components for the HRFunc GUI.
+
+Each module here exports one component (or one closely related family) that
+pages compose. Components encapsulate rendering + event wiring; they do not
+own state — they read from and write to the shared ``AppState``.
+
+Adding a component = create a new module, export a top-level ``render`` or
+factory function, and import it from the page that uses it.
+"""

--- a/src/hrfunc/gui/components/dataset_tree.py
+++ b/src/hrfunc/gui/components/dataset_tree.py
@@ -1,0 +1,148 @@
+"""Dataset tree — left-pane navigation of a Manifest.
+
+Renders a Manifest's scans as a hierarchical tree grouped by BIDS subject /
+session when the metadata is available, or by parent directory for non-BIDS
+folders. Clicking a leaf node sets ``state.selected_scan``, which the
+workspace's center and right panes react to.
+
+Grouping rules:
+- ``bids_subject`` present  → group under ``sub-<id>``
+- ``bids_subject`` absent   → group under ``📁 <parent-dir-name>``
+- ``bids_session`` present  → sub-group ``ses-<id>``
+- ``bids_session`` absent   → sub-group ``(no session)``
+
+The leaf node label uses the ScanEntry's ``display_name`` (which itself
+combines BIDS components when available — see ``scan._make_display_name``).
+Node IDs are the absolute scan path stringified — this makes the click
+lookup O(1) given a dict from path → ScanEntry.
+
+Public API:
+    build_nodes(manifest) -> list[dict]   - tree node structure
+    render(state)                         - render the tree + wire selection
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Callable, Dict, List, Optional
+
+from nicegui import ui
+
+from ..state import AppState
+from ...io.manifest import Manifest, ScanEntry
+
+logger = logging.getLogger(__name__)
+
+_NO_SESSION_LABEL = "(no session)"
+
+OnScanSelect = Callable[[Optional[ScanEntry]], None]
+
+
+def build_nodes(manifest: Manifest) -> List[dict]:
+    """Convert a Manifest into the dict structure ``ui.tree`` expects.
+
+    Returns a list of subject-level nodes. Each subject node has children
+    (sessions); each session has children (scans). The scan-level nodes use
+    the stringified absolute path as the ``id`` so click handlers can do a
+    direct dict lookup back to the ScanEntry.
+
+    Stable ordering: subjects sorted alphabetically, sessions within a
+    subject sorted alphabetically, scans within a session sorted by
+    display_name. Without sorting, the tree would jitter between scans
+    depending on filesystem walk order.
+    """
+    # subject_key -> session_key -> list[ScanEntry]
+    subjects: Dict[str, Dict[str, List[ScanEntry]]] = {}
+
+    for scan in manifest.scans:
+        sub_key = (
+            f"sub-{scan.bids_subject}"
+            if scan.bids_subject
+            else f"📁 {scan.path.parent.name}"
+        )
+        ses_key = (
+            f"ses-{scan.bids_session}"
+            if scan.bids_session
+            else _NO_SESSION_LABEL
+        )
+        subjects.setdefault(sub_key, {}).setdefault(ses_key, []).append(scan)
+
+    nodes: List[dict] = []
+    for sub_key in sorted(subjects):
+        sub_node = {
+            "id": f"subject::{sub_key}",
+            "label": sub_key,
+            "children": [],
+        }
+        for ses_key in sorted(subjects[sub_key]):
+            ses_node = {
+                "id": f"session::{sub_key}::{ses_key}",
+                "label": ses_key,
+                "children": [
+                    {
+                        "id": str(scan.path),
+                        "label": scan.display_name or scan.path.name,
+                    }
+                    for scan in sorted(
+                        subjects[sub_key][ses_key],
+                        key=lambda s: s.display_name or str(s.path),
+                    )
+                ],
+            }
+            sub_node["children"].append(ses_node)
+        nodes.append(sub_node)
+    return nodes
+
+
+def render(
+    state: AppState,
+    on_select_scan: Optional[OnScanSelect] = None,
+) -> None:
+    """Render the dataset tree inside the current NiceGUI context.
+
+    Reads ``state.manifest`` to build nodes and wires the click handler to
+    update ``state.selected_scan``. If ``on_select_scan`` is provided, it
+    is called after the state update with the resolved ScanEntry (or
+    ``None`` if the user clicked a group node) — typically used by the
+    workspace to refresh the inspector panel.
+
+    Caller is responsible for placing this inside the desired layout
+    (typically the left pane of a splitter).
+    """
+    if state.manifest is None or not state.manifest.scans:
+        ui.label("No dataset loaded.").classes("opacity-60 text-sm p-4")
+        return
+
+    nodes = build_nodes(state.manifest)
+
+    # Path string -> ScanEntry, for O(1) lookup in the click handler.
+    path_to_scan: Dict[str, ScanEntry] = {
+        str(s.path): s for s in state.manifest.scans
+    }
+
+    def _on_select(event) -> None:
+        node_id = event.value
+        scan = path_to_scan.get(node_id)
+        # Group nodes (subject/session) have no entry in path_to_scan, so
+        # scan is None — clear selection to revert the inspector to empty.
+        state.selected_scan = scan
+        if scan is not None:
+            logger.debug("Selected scan: %s", scan.path)
+        if on_select_scan is not None:
+            on_select_scan(scan)
+
+    ui.tree(nodes, on_select=_on_select).classes("w-full")
+
+
+def find_scan(manifest: Optional[Manifest], path_id: str) -> Optional[ScanEntry]:
+    """Look up a ScanEntry by its stringified absolute path.
+
+    Convenience for tests and components that receive a node id from a
+    tree event and need the corresponding ScanEntry.
+    """
+    if manifest is None:
+        return None
+    for scan in manifest.scans:
+        if str(scan.path) == path_id:
+            return scan
+    return None

--- a/src/hrfunc/gui/pages/workspace.py
+++ b/src/hrfunc/gui/pages/workspace.py
@@ -1,0 +1,313 @@
+"""Workspace page — the main GUI surface once a dataset is loaded.
+
+Three-pane layout, all wrapped in resizable splitters so users can rearrange
+the available real estate:
+
+  ┌─────────────┬──────────────────────────────┬──────────────┐
+  │  Dataset    │  [Inspect][Quality][Preprocess]              │
+  │  tree       │  [HRFs][Activity][HRtree][Export]            │
+  │  (subjects, │  ───────────────────────────  │  Scan        │
+  │   sessions, │   active tab content here     │  inspector   │
+  │   scans)    │                                │              │
+  └─────────────┴──────────────────────────────┴──────────────┘
+
+Sprint 2.3 ships the shell: dataset tree (real), tab structure (real), and
+inspector showing selected ScanEntry metadata (real). Tab content beyond
+``Inspect`` is placeholder — Sprint 3+ replaces it with the estimation,
+quality, and visualization panels.
+
+Routing:
+- Welcome → workspace via ``ui.navigate.to("/workspace")`` after a
+  successful folder scan.
+- Workspace → welcome via the "Back to welcome" button in the toolbar.
+
+State:
+- Reads ``state.manifest`` (set by the welcome page's open-folder flow).
+- Reads/writes ``state.selected_scan`` (driven by dataset-tree clicks).
+- Tab change does not modify state — the visible tab is local to the
+  workspace render.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from nicegui import ui
+
+from ..components import dataset_tree
+from ..state import AppState, state as global_state
+from ..theme import apply_theme
+from ...io.manifest import ScanEntry
+
+logger = logging.getLogger(__name__)
+
+# Tabs in the order researchers typically traverse them.
+TAB_NAMES = (
+    "Inspect",
+    "Quality",
+    "Preprocess",
+    "HRFs",
+    "Activity",
+    "HRtree",
+    "Export",
+)
+
+
+def register() -> None:
+    """Register the workspace page handler at ``/workspace``.
+
+    Called by ``app._register_pages()``. Replaces the Sprint 2.2 inline
+    stub that just showed a scan count.
+    """
+
+    @ui.page("/workspace")
+    def workspace_page() -> None:
+        _render(global_state)
+
+
+def _render(state: AppState) -> None:
+    """Render the workspace against the given AppState.
+
+    Split from the page handler so tests can call it with a synthetic
+    state without going through NiceGUI's routing layer.
+    """
+    apply_theme()
+    _render_toolbar()
+
+    if state.manifest is None or not state.manifest.scans:
+        _render_empty_state()
+        return
+
+    _render_three_pane(state)
+
+
+# ---------------------------------------------------------------------------
+# Toolbar — top of every workspace render
+# ---------------------------------------------------------------------------
+
+
+def _render_toolbar() -> None:
+    with ui.row().classes(
+        "w-full items-center justify-between px-6 py-3 border-b border-slate-800"
+    ):
+        with ui.row().classes("items-center gap-3"):
+            ui.icon("psychology", size="2rem").classes("text-primary")
+            ui.label("HRFunc").classes("text-2xl font-semibold")
+        with ui.row().classes("items-center gap-2"):
+            ui.button(
+                "Back to welcome",
+                on_click=lambda: ui.navigate.to("/"),
+            ).props("flat color=primary")
+
+
+# ---------------------------------------------------------------------------
+# Empty state — manifest is None or has zero scans
+# ---------------------------------------------------------------------------
+
+
+def _render_empty_state() -> None:
+    with ui.column().classes(
+        "w-full items-center justify-center mt-24 gap-3"
+    ):
+        ui.icon("folder_off", size="4rem").classes("opacity-40")
+        ui.label("No dataset loaded.").classes("text-xl opacity-80")
+        ui.label(
+            "Open a folder from the welcome screen to start exploring scans."
+        ).classes("text-sm opacity-60")
+        ui.button(
+            "Back to welcome",
+            on_click=lambda: ui.navigate.to("/"),
+        ).props("color=primary")
+
+
+# ---------------------------------------------------------------------------
+# Three-pane layout — splitters for left | (center | right)
+# ---------------------------------------------------------------------------
+
+
+def _render_three_pane(state: AppState) -> None:
+    # Outer splitter: dataset tree on the left, everything else on the right.
+    with ui.splitter(value=20, limits=(10, 40)).classes(
+        "w-full h-screen"
+    ) as outer:
+        with outer.before:
+            _render_left_pane(state)
+        with outer.after:
+            # Inner splitter: center tabs (taking most space), right inspector.
+            with ui.splitter(value=72, limits=(50, 90)).classes(
+                "w-full h-full"
+            ) as inner:
+                with inner.before:
+                    _render_center_pane(state)
+                with inner.after:
+                    _render_right_pane(state)
+
+
+# ---------------------------------------------------------------------------
+# Left pane — dataset tree
+# ---------------------------------------------------------------------------
+
+
+def _render_left_pane(state: AppState) -> None:
+    with ui.column().classes("w-full h-full p-3 gap-2 overflow-auto"):
+        ui.label("Dataset").classes("text-xs uppercase opacity-60 tracking-wide")
+        if state.manifest is not None:
+            ui.label(str(state.manifest.root)).classes(
+                "text-xs font-mono opacity-70 break-all"
+            )
+        dataset_tree.render(state, on_select_scan=lambda _scan: _refresh_inspector(state))
+
+
+def _refresh_inspector(state: AppState) -> None:
+    """Refresh the Inspect tab body after a dataset-tree selection change.
+
+    The Inspect tab's body is wrapped in ``@ui.refreshable`` and stashes its
+    refresh callable on ``state._inspect_refresh`` at render time. Calling
+    that re-runs the body against the latest ``state.selected_scan`` without
+    rebuilding the whole workspace.
+    """
+    refresh = getattr(state, "_inspect_refresh", None)
+    if refresh is not None:
+        refresh()
+
+
+# ---------------------------------------------------------------------------
+# Center pane — tabs
+# ---------------------------------------------------------------------------
+
+
+def _render_center_pane(state: AppState) -> None:
+    with ui.column().classes("w-full h-full"):
+        with ui.tabs().classes("w-full") as tabs:
+            for name in TAB_NAMES:
+                ui.tab(name)
+        with ui.tab_panels(tabs, value=TAB_NAMES[0]).classes(
+            "w-full flex-1 overflow-auto"
+        ):
+            for name in TAB_NAMES:
+                with ui.tab_panel(name):
+                    _render_tab_panel(name, state)
+
+
+def _render_tab_panel(name: str, state: AppState) -> None:
+    """Render one tab's body.
+
+    ``Inspect`` is real and shows the selected scan's metadata. Every other
+    tab is a "Coming in Sprint N" placeholder for now — Sprint 3+ replaces
+    them.
+    """
+    if name == "Inspect":
+        _render_inspect_tab(state)
+        return
+
+    # Map each placeholder tab to the sprint that fills it in.
+    next_sprint = {
+        "Quality": "Sprint 4 (lens-module wrapper)",
+        "Preprocess": "Sprint 3 (preprocess panel)",
+        "HRFs": "Sprint 3 (estimate panel + HRF gallery)",
+        "Activity": "Sprint 3 (estimate-activity panel)",
+        "HRtree": "Sprint 4 (plotly 3D explorer)",
+        "Export": "Sprint 5 (export panel)",
+    }.get(name, "a future sprint")
+
+    with ui.column().classes("p-6 gap-2"):
+        ui.label(name).classes("text-2xl font-semibold")
+        ui.label(f"Coming in {next_sprint}.").classes(
+            "text-sm opacity-60"
+        )
+
+
+def _render_inspect_tab(state: AppState) -> None:
+    """Inspect tab content — selected scan's basic metadata.
+
+    Renders against ``state.selected_scan``. When no scan is selected, shows
+    a prompt to pick one. The render is wrapped in ``ui.refreshable`` so
+    dataset-tree clicks update this panel without a full page rebuild.
+    """
+
+    @ui.refreshable
+    def _body() -> None:
+        scan = state.selected_scan
+        if scan is None:
+            with ui.column().classes("p-6 gap-2"):
+                ui.label("Inspect").classes("text-2xl font-semibold")
+                ui.label("Select a scan from the dataset tree.").classes(
+                    "text-sm opacity-60"
+                )
+            return
+        with ui.column().classes("p-6 gap-3"):
+            ui.label(scan.display_name or scan.path.name).classes(
+                "text-2xl font-semibold"
+            )
+            _kv_row("Format", scan.format)
+            _kv_row("Path", str(scan.path))
+            if scan.n_channels is not None:
+                _kv_row("Channels", str(scan.n_channels))
+            if scan.sfreq is not None:
+                _kv_row("Sampling rate", f"{scan.sfreq:.4g} Hz")
+            if scan.bids_subject:
+                _kv_row("BIDS subject", scan.bids_subject)
+            if scan.bids_session:
+                _kv_row("BIDS session", scan.bids_session)
+            if scan.bids_task:
+                _kv_row("BIDS task", scan.bids_task)
+            if scan.bids_run:
+                _kv_row("BIDS run", scan.bids_run)
+
+    _body()
+    # Stash the refresher on the state so dataset_tree.render's on_select
+    # can call it after updating state.selected_scan. Sprint 3+ panels will
+    # subscribe to the same channel via a more structured event bus, but
+    # the direct ref keeps Sprint 2.3 scope tight.
+    state._inspect_refresh = _body.refresh  # type: ignore[attr-defined]
+
+
+def _kv_row(key: str, value: str) -> None:
+    with ui.row().classes("w-full gap-4"):
+        ui.label(key).classes("text-xs uppercase opacity-60 w-32")
+        ui.label(value).classes("text-sm break-all")
+
+
+# ---------------------------------------------------------------------------
+# Right pane — minimal scan inspector for Sprint 2.3
+# ---------------------------------------------------------------------------
+
+
+def _render_right_pane(state: AppState) -> None:
+    """Right-pane inspector.
+
+    Sprint 2.3 shows manifest-level summary (root, scan count, scan-by-
+    format histogram). Sprint 3 replaces this with parameter controls
+    (preprocess toggles, estimate sliders) when an estimation tab is
+    active, and falls back to this summary otherwise.
+    """
+    with ui.column().classes("w-full h-full p-4 gap-3 overflow-auto"):
+        ui.label("Manifest").classes(
+            "text-xs uppercase opacity-60 tracking-wide"
+        )
+        if state.manifest is None:
+            ui.label("No manifest").classes("text-sm opacity-60")
+            return
+
+        manifest = state.manifest
+        format_counts = _count_by_format(manifest.scans)
+
+        _kv_row("Scans", str(len(manifest.scans)))
+        _kv_row("Scanned", manifest.scanned_at.strftime("%Y-%m-%d %H:%M UTC"))
+        if manifest.errors:
+            _kv_row("Errors", str(len(manifest.errors)))
+
+        if format_counts:
+            ui.separator()
+            ui.label("By format").classes(
+                "text-xs uppercase opacity-60 tracking-wide"
+            )
+            for fmt, count in sorted(format_counts.items()):
+                _kv_row(fmt, str(count))
+
+
+def _count_by_format(scans) -> dict:
+    counts: dict = {}
+    for scan in scans:
+        counts[scan.format] = counts.get(scan.format, 0) + 1
+    return counts

--- a/tests/test_gui_foundation.py
+++ b/tests/test_gui_foundation.py
@@ -49,14 +49,25 @@ class TestPackageImports:
     def test_importing_core_does_not_import_gui(self):
         """`import hrfunc` must NOT pull in NiceGUI. Users without [gui] extras
         should be able to use the library headlessly. Tested via sys.modules
-        after a fresh hrfunc import."""
+        after a fresh hrfunc import.
+
+        Saves and restores gui module entries so this test doesn't poison
+        subsequent tests in the gate (which import-bind to the same module
+        objects we'd otherwise replace)."""
         import sys
-        # Drop any cached gui modules
-        for key in list(sys.modules):
-            if key.startswith("hrfunc.gui"):
-                del sys.modules[key]
-        import hrfunc  # noqa: F401
-        assert "hrfunc.gui" not in sys.modules
+        saved_gui_modules = {
+            k: v for k, v in sys.modules.items() if k.startswith("hrfunc.gui")
+        }
+        try:
+            for key in list(sys.modules):
+                if key.startswith("hrfunc.gui"):
+                    del sys.modules[key]
+            import hrfunc  # noqa: F401
+            assert "hrfunc.gui" not in sys.modules
+        finally:
+            # Restore so test_gui_welcome and test_gui_workspace bind to
+            # the same state/page-registration objects they imported.
+            sys.modules.update(saved_gui_modules)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_gui_welcome.py
+++ b/tests/test_gui_welcome.py
@@ -183,22 +183,6 @@ async def test_welcome_page_shows_version_in_footer(user: User):
 
 
 @pytest.mark.asyncio
-async def test_workspace_stub_renders(user: User):
-    await user.open("/workspace")
-    await user.should_see("Workspace")
-    await user.should_see("Full workspace UI lands in Sprint 2.3")
-
-
-@pytest.mark.asyncio
-async def test_workspace_stub_shows_no_dataset_message(user: User):
-    # state.manifest defaults to None — stub should report that.
-    from hrfunc.gui.state import state
-    state.manifest = None
-    await user.open("/workspace")
-    await user.should_see("No dataset loaded")
-
-
-@pytest.mark.asyncio
 async def test_library_stub_renders(user: User):
     await user.open("/library")
     await user.should_see("HRF Library")

--- a/tests/test_gui_workspace.py
+++ b/tests/test_gui_workspace.py
@@ -1,0 +1,299 @@
+"""Targeted unit tests for feat/gui-workspace-shell (v1.3.0 Sprint 2.3).
+
+Covers:
+
+- ``hrfunc.gui.components.dataset_tree`` — Manifest → tree-node conversion,
+  BIDS vs non-BIDS grouping, stable ordering, find_scan lookup helper.
+- ``hrfunc.gui.pages.workspace`` — page registration, three-pane shell,
+  empty-state handling, tab table.
+
+Rendering tests use NiceGUI's User fixture (same setup as the welcome
+tests — `tests/gui_main.py` is the main_file). All tests gated by
+``pytest.importorskip("nicegui")``.
+"""
+
+from __future__ import annotations
+
+import inspect
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("nicegui")
+
+from nicegui.testing import User  # noqa: E402
+
+pytest_plugins = ["nicegui.testing.user_plugin"]
+
+from hrfunc.gui import app as gui_app  # noqa: E402
+from hrfunc.gui.components import dataset_tree  # noqa: E402
+from hrfunc.gui.pages import workspace  # noqa: E402
+from hrfunc.gui.state import state as global_state  # noqa: E402
+from hrfunc.io.manifest import Manifest, ScanEntry  # noqa: E402
+
+gui_app._register_pages()
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — synthetic manifests for tree-building tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def empty_manifest(tmp_path):
+    return Manifest(root=tmp_path)
+
+
+@pytest.fixture
+def bids_manifest(tmp_path):
+    """A manifest with two subjects, one with two sessions, fully BIDS."""
+    scans = (
+        ScanEntry(
+            format="snirf",
+            path=tmp_path / "sub-01" / "ses-01" / "sub-01_task-flanker_nirs.snirf",
+            bids_subject="01",
+            bids_session="01",
+            bids_task="flanker",
+            display_name="sub-01 / ses-01 / task-flanker",
+        ),
+        ScanEntry(
+            format="snirf",
+            path=tmp_path / "sub-01" / "ses-02" / "sub-01_task-rest_nirs.snirf",
+            bids_subject="01",
+            bids_session="02",
+            bids_task="rest",
+            display_name="sub-01 / ses-02 / task-rest",
+        ),
+        ScanEntry(
+            format="snirf",
+            path=tmp_path / "sub-02" / "ses-01" / "sub-02_task-flanker_nirs.snirf",
+            bids_subject="02",
+            bids_session="01",
+            bids_task="flanker",
+            display_name="sub-02 / ses-01 / task-flanker",
+        ),
+    )
+    return Manifest(root=tmp_path, scans=scans)
+
+
+@pytest.fixture
+def non_bids_manifest(tmp_path):
+    """A manifest with no BIDS metadata — uses parent-dir grouping."""
+    lab = tmp_path / "lab_data"
+    scans = (
+        ScanEntry(format="snirf", path=lab / "subj_A.snirf", display_name="lab_data/subj_A.snirf"),
+        ScanEntry(format="snirf", path=lab / "subj_B.snirf", display_name="lab_data/subj_B.snirf"),
+    )
+    return Manifest(root=tmp_path, scans=scans)
+
+
+# ---------------------------------------------------------------------------
+# dataset_tree.build_nodes — grouping and ordering contracts
+# ---------------------------------------------------------------------------
+
+
+class TestBuildNodes:
+    def test_empty_manifest_returns_empty_list(self, empty_manifest):
+        assert dataset_tree.build_nodes(empty_manifest) == []
+
+    def test_bids_manifest_groups_by_subject(self, bids_manifest):
+        nodes = dataset_tree.build_nodes(bids_manifest)
+        labels = [n["label"] for n in nodes]
+        assert labels == ["sub-01", "sub-02"]
+
+    def test_bids_manifest_groups_sessions_under_subject(self, bids_manifest):
+        nodes = dataset_tree.build_nodes(bids_manifest)
+        sub01 = next(n for n in nodes if n["label"] == "sub-01")
+        session_labels = [s["label"] for s in sub01["children"]]
+        assert session_labels == ["ses-01", "ses-02"]
+
+    def test_scan_leaves_use_display_name(self, bids_manifest):
+        nodes = dataset_tree.build_nodes(bids_manifest)
+        sub01 = next(n for n in nodes if n["label"] == "sub-01")
+        ses01 = next(s for s in sub01["children"] if s["label"] == "ses-01")
+        leaf_labels = [c["label"] for c in ses01["children"]]
+        assert leaf_labels == ["sub-01 / ses-01 / task-flanker"]
+
+    def test_scan_leaf_id_is_stringified_path(self, bids_manifest):
+        nodes = dataset_tree.build_nodes(bids_manifest)
+        sub01 = next(n for n in nodes if n["label"] == "sub-01")
+        ses01 = next(s for s in sub01["children"] if s["label"] == "ses-01")
+        leaf = ses01["children"][0]
+        scan = bids_manifest.scans[0]
+        assert leaf["id"] == str(scan.path)
+
+    def test_non_bids_groups_by_parent_dir(self, non_bids_manifest):
+        nodes = dataset_tree.build_nodes(non_bids_manifest)
+        assert len(nodes) == 1
+        # Parent dir is "lab_data"; the label uses the folder-emoji prefix.
+        assert nodes[0]["label"].endswith("lab_data")
+
+    def test_non_bids_has_single_no_session_group(self, non_bids_manifest):
+        nodes = dataset_tree.build_nodes(non_bids_manifest)
+        sessions = nodes[0]["children"]
+        assert len(sessions) == 1
+        assert sessions[0]["label"] == "(no session)"
+
+    def test_subjects_are_alphabetically_sorted(self, tmp_path):
+        # Manually feed subjects out of order to verify the sort.
+        scans = (
+            ScanEntry(format="snirf", path=tmp_path / "x.snirf",
+                      bids_subject="zebra"),
+            ScanEntry(format="snirf", path=tmp_path / "y.snirf",
+                      bids_subject="alpha"),
+            ScanEntry(format="snirf", path=tmp_path / "z.snirf",
+                      bids_subject="mike"),
+        )
+        m = Manifest(root=tmp_path, scans=scans)
+        labels = [n["label"] for n in dataset_tree.build_nodes(m)]
+        assert labels == ["sub-alpha", "sub-mike", "sub-zebra"]
+
+
+# ---------------------------------------------------------------------------
+# dataset_tree.find_scan — id → ScanEntry lookup
+# ---------------------------------------------------------------------------
+
+
+class TestFindScan:
+    def test_returns_scan_for_known_path(self, bids_manifest):
+        scan = bids_manifest.scans[0]
+        found = dataset_tree.find_scan(bids_manifest, str(scan.path))
+        assert found is scan
+
+    def test_returns_none_for_unknown_path(self, bids_manifest):
+        assert dataset_tree.find_scan(bids_manifest, "/nonexistent") is None
+
+    def test_returns_none_for_none_manifest(self):
+        assert dataset_tree.find_scan(None, "/anything") is None
+
+
+# ---------------------------------------------------------------------------
+# workspace module contracts — registration + tab table
+# ---------------------------------------------------------------------------
+
+
+class TestWorkspaceModule:
+    def test_register_is_callable(self):
+        assert callable(workspace.register)
+
+    def test_tab_names_match_planned_set(self):
+        """Sprint 2.3 ships the canonical tab order. Subsequent sprints add
+        content to each tab but should NOT change the order — this test is
+        the regression guard."""
+        assert workspace.TAB_NAMES == (
+            "Inspect",
+            "Quality",
+            "Preprocess",
+            "HRFs",
+            "Activity",
+            "HRtree",
+            "Export",
+        )
+
+    def test_register_pages_invokes_workspace_register(self):
+        source = inspect.getsource(gui_app._register_pages)
+        assert "workspace.register()" in source
+
+    def test_app_no_longer_contains_workspace_stub_text(self):
+        """Sprint 2.2 inline stub said 'Full workspace UI lands in Sprint 2.3'.
+        Confirm Sprint 2.3 removed that string from app.py so future readers
+        don't see contradictory placeholder messaging."""
+        source = inspect.getsource(gui_app)
+        assert "Full workspace UI lands in Sprint 2.3" not in source
+
+
+# ---------------------------------------------------------------------------
+# workspace rendering — User fixture
+# ---------------------------------------------------------------------------
+
+
+async def test_workspace_empty_state_when_no_manifest(user: User):
+    global_state.reset()
+    await user.open("/workspace")
+    await user.should_see("No dataset loaded")
+    await user.should_see("Open a folder from the welcome screen")
+
+
+async def test_workspace_renders_toolbar(user: User):
+    global_state.reset()
+    await user.open("/workspace")
+    await user.should_see("HRFunc")
+    await user.should_see("Back to welcome")
+
+
+async def test_workspace_renders_three_pane_with_manifest(
+    user: User, tmp_path
+):
+    scan = ScanEntry(
+        format="snirf",
+        path=tmp_path / "sub-01" / "sub-01_task-flanker_nirs.snirf",
+        bids_subject="01",
+        bids_task="flanker",
+        display_name="sub-01 / task-flanker",
+    )
+    global_state.reset()
+    global_state.manifest = Manifest(
+        root=tmp_path,
+        scans=(scan,),
+        scanned_at=datetime(2026, 5, 11, 12, 0, tzinfo=timezone.utc),
+    )
+
+    await user.open("/workspace")
+    # Dataset header label appears in left pane
+    await user.should_see("Dataset")
+    # Subject node visible in tree
+    await user.should_see("sub-01")
+    # Tab labels visible
+    await user.should_see("Inspect")
+    await user.should_see("Quality")
+    await user.should_see("HRtree")
+    # Manifest summary in right pane
+    await user.should_see("Manifest")
+
+
+async def test_workspace_inspector_prompts_when_no_scan_selected(
+    user: User, tmp_path
+):
+    global_state.reset()
+    global_state.manifest = Manifest(
+        root=tmp_path,
+        scans=(ScanEntry(format="snirf", path=tmp_path / "x.snirf",
+                         display_name="x.snirf"),),
+    )
+    await user.open("/workspace")
+    # Inspect tab is the default; should prompt to select a scan
+    await user.should_see("Select a scan from the dataset tree")
+
+
+async def test_workspace_right_pane_shows_scan_count(user: User, tmp_path):
+    global_state.reset()
+    global_state.manifest = Manifest(
+        root=tmp_path,
+        scans=(
+            ScanEntry(format="snirf", path=tmp_path / "a.snirf"),
+            ScanEntry(format="snirf", path=tmp_path / "b.snirf"),
+            ScanEntry(format="fif", path=tmp_path / "c.fif"),
+        ),
+    )
+    await user.open("/workspace")
+    await user.should_see("3")  # scan count in right pane
+
+
+async def test_workspace_placeholder_tabs_show_sprint_label(
+    user: User, tmp_path
+):
+    """Tabs beyond Inspect should announce when their content lands."""
+    global_state.reset()
+    global_state.manifest = Manifest(
+        root=tmp_path,
+        scans=(ScanEntry(format="snirf", path=tmp_path / "a.snirf"),),
+    )
+    await user.open("/workspace")
+    # Open the Preprocess tab — exact assertion of text is brittle for
+    # tab content (it's not visible until clicked), so instead verify
+    # the tab label itself is on the page.
+    await user.should_see("Preprocess")
+    await user.should_see("HRFs")
+    await user.should_see("Activity")
+    await user.should_see("Export")


### PR DESCRIPTION
## Summary

**Final branch of Sprint 2 (GUI shell).** Replaces the Sprint 2.2 `/workspace` stub with the real three-pane workspace: dataset tree on the left, tabs in the center, manifest inspector on the right. Sprint 3+ fills the tab content; this branch ships the **navigation surface and the Inspect tab end-to-end**.

## What lands

**New component** `src/hrfunc/gui/components/dataset_tree.py`:
- `build_nodes(manifest) → list[dict]` groups `ScanEntry`s into a tree structure (BIDS subject/session → scan; non-BIDS falls back to `📁 <parent>` / `(no session)`)
- Stable ordering — subjects alphabetical, sessions alphabetical, scans by `display_name` (no jitter on filesystem walk order)
- `render(state, on_select_scan=None)` — places the tree, wires click handler to update `state.selected_scan` AND fire the optional callback
- `find_scan(manifest, path_id)` — helper for any component receiving a node id

**New page** `src/hrfunc/gui/pages/workspace.py`:
- Three-pane via nested `ui.splitter` (outer 20/80, inner 72/28) — both **user-draggable** for layout customization
- Toolbar with HRFunc title and back-to-welcome button
- Empty state when `state.manifest` is `None` or empty — friendly "open a folder" prompt with a button to navigate back
- Left pane: dataset header + manifest root + dataset tree wired to refresh the inspector on selection
- Center pane: 7 tabs (`Inspect | Quality | Preprocess | HRFs | Activity | HRtree | Export`). **Inspect is real** and renders the selected `ScanEntry`'s metadata; the other six announce their target sprint
- Right pane: manifest summary (scan count, scanned_at, error count, by-format histogram)
- Inspect tab body wrapped in `@ui.refreshable` and refreshed reactively when the user clicks a scan

**Modified** `src/hrfunc/gui/app.py`:
- `_register_pages` imports `pages.workspace` and calls `workspace.register()` — drops the Sprint 2.2 inline stub

**`pyproject.toml`**: packages list expanded to include `hrfunc.gui.components` and `hrfunc.gui.pages`.

## Tests

`tests/test_gui_workspace.py` — **21 new tests**:

- **build_nodes** (8): empty manifest, BIDS subject grouping, BIDS session grouping, scan leaves use display_name, leaf ids are absolute path strings, non-BIDS parent-dir grouping, non-BIDS `(no session)` placeholder, subjects alphabetically sorted
- **find_scan** (3): returns ScanEntry for known path, None for unknown, None for None manifest
- **Workspace module contracts** (4): `register` callable, `TAB_NAMES` matches planned order (regression guard), `_register_pages` invokes `workspace.register()`, Sprint 2.2 stub text is gone from `app.py`
- **Rendering via NiceGUI User fixture** (6): empty state when no manifest, toolbar visible, three-pane renders with manifest (subject in tree + tabs + manifest header), Inspect prompts to select a scan when none selected, right pane shows scan count, all placeholder tab labels present

## Also fixes two test-isolation issues caught by the full gate

1. **`test_gui_foundation.py::test_importing_core_does_not_import_gui`** was deleting `hrfunc.gui.*` from `sys.modules` without restoring, leaving downstream tests with stale module references. Fixed with save/restore around the test.
2. **`test_gui_welcome.py`**: removed two obsolete workspace-stub tests (`test_workspace_stub_renders` and `test_workspace_stub_shows_no_dataset_message`) that checked Sprint 2.2 stub text. The new workspace tests cover the equivalent assertions.

## Gate

```
pytest tests/test_phase1a.py tests/test_phase1bc.py tests/test_phase2.py \
       tests/test_threading.py tests/test_input_validation.py \
       tests/test_state_lifecycle.py tests/test_oxygenation_guard.py \
       tests/test_tree_delete_filter.py tests/test_hasher_branch.py \
       tests/test_tree_hrf.py tests/test_canonical_hrf.py \
       tests/test_tree_edge_cases.py tests/test_observer_and_typos.py \
       tests/test_progress_callbacks.py tests/test_io_detect.py \
       tests/test_io_scan.py tests/test_io_raw_cache.py \
       tests/test_gui_foundation.py tests/test_gui_welcome.py \
       tests/test_gui_workspace.py -q
→ 383 passed in 5.81s (364 prior − 2 removed welcome stub tests + 21 new workspace tests, zero regressions)
```

**Manual smoke**:
```
$ hrfunc /path/to/study
# Opens window, scans folder, navigates to /workspace.
# Left pane: subjects in tree. Inspect tab: "Select a scan from the dataset tree."
# Click a scan: Inspect tab populates with format/path/channels/sfreq/BIDS metadata.
```

## Reviews

- **Architecture & Execution Flow**: `workspace.py` and `dataset_tree.py` import only downstream modules — no cycles. The `on_select_scan` callback pattern keeps `dataset_tree` decoupled from `workspace` (component knows about `state.selected_scan` but nothing about specific consumers). **Architecture review caught one bug** in the initial draft: I stashed `_inspect_refresh` on `state` but never called it from the on-select handler. Fixed by passing a callback through `dataset_tree.render` and routing the refresh through `workspace._refresh_inspector`.
- **API Surface & Usability**: `TAB_NAMES` is a module-level constant with a regression test guarding order. `dataset_tree.render` accepts an optional callback so consumers can react to selection without monkey-patching state. Empty workspace state surfaces clearly with a path back to welcome rather than a blank three-pane shell. BIDS vs non-BIDS grouping is visibly distinct (`sub-XX` vs `📁 <name>`) so the source of grouping is never ambiguous.

## Gotchas

- **`state._inspect_refresh`** is a private attribute, not a declared `AppState` field. Sprint 3+ should formalize this as an event bus or use NiceGUI's binding system when more panels need to subscribe. For Sprint 2.3 (one publisher, one consumer) the direct attribute keeps scope tight.
- **Splitter limits** clamp the dataset tree between 10–40% width and the right inspector between 10–50%. Without limits, users could collapse a pane to zero width and lose access.

## Test plan

- [x] `pytest tests/test_gui_workspace.py -v` passes (21/21)
- [x] Full v1.3.0 gate passes (383 total)
- [x] Test isolation issues resolved (sys.modules pollution + obsolete stub tests)
- [ ] Manual launch — `hrfunc <path>` opens window, scan completes, workspace shell renders, clicking a scan populates the Inspect tab

## Sprint 2 status

**All three Sprint 2 branches landed:**
- ✅ `feat/gui-foundation` (PR #24)
- ✅ `feat/gui-welcome-page` (PR #25)
- 🟡 `feat/gui-workspace-shell` (THIS)

**Sprint 3** begins next: dataset-tree search filter, scan inspector enrichment (channel list, 2D probe layout), preprocess panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)