### PR TITLE
feat: Raw-aware Inspect tab + dataset tree filter (GUI Sprint 3.1)

### DIFF
--- a/src/hrfunc/gui/components/dataset_tree.py
+++ b/src/hrfunc/gui/components/dataset_tree.py
@@ -16,9 +16,16 @@ combines BIDS components when available — see ``scan._make_display_name``).
 Node IDs are the absolute scan path stringified — this makes the click
 lookup O(1) given a dict from path → ScanEntry.
 
+Search filter (Sprint 3.1):
+``build_nodes`` accepts an optional ``filter_text``. When non-empty, scans
+are kept only if the filter (case-insensitive) appears in ``display_name``
+or the stringified path. Subjects and sessions with zero surviving scans
+are pruned, so the tree only shows the relevant subtree. ``render`` wires
+a ``ui.input`` above the tree that refreshes the body on change.
+
 Public API:
-    build_nodes(manifest) -> list[dict]   - tree node structure
-    render(state)                         - render the tree + wire selection
+    build_nodes(manifest, filter_text="") -> list[dict]   - tree node structure
+    render(state, on_select_scan=None)                    - render the tree + wire selection
 """
 
 from __future__ import annotations
@@ -38,13 +45,27 @@ _NO_SESSION_LABEL = "(no session)"
 OnScanSelect = Callable[[Optional[ScanEntry]], None]
 
 
-def build_nodes(manifest: Manifest) -> List[dict]:
+def _scan_matches_filter(scan: ScanEntry, filter_text: str) -> bool:
+    """Case-insensitive substring match against display_name + path."""
+    if not filter_text:
+        return True
+    needle = filter_text.lower()
+    if scan.display_name and needle in scan.display_name.lower():
+        return True
+    return needle in str(scan.path).lower()
+
+
+def build_nodes(manifest: Manifest, filter_text: str = "") -> List[dict]:
     """Convert a Manifest into the dict structure ``ui.tree`` expects.
 
     Returns a list of subject-level nodes. Each subject node has children
     (sessions); each session has children (scans). The scan-level nodes use
     the stringified absolute path as the ``id`` so click handlers can do a
     direct dict lookup back to the ScanEntry.
+
+    When ``filter_text`` is non-empty, scans are filtered by case-insensitive
+    substring match against their display_name and path. Subjects/sessions
+    with zero surviving scans are pruned.
 
     Stable ordering: subjects sorted alphabetically, sessions within a
     subject sorted alphabetically, scans within a session sorted by
@@ -55,6 +76,8 @@ def build_nodes(manifest: Manifest) -> List[dict]:
     subjects: Dict[str, Dict[str, List[ScanEntry]]] = {}
 
     for scan in manifest.scans:
+        if not _scan_matches_filter(scan, filter_text):
+            continue
         sub_key = (
             f"sub-{scan.bids_subject}"
             if scan.bids_subject
@@ -106,6 +129,10 @@ def render(
     ``None`` if the user clicked a group node) — typically used by the
     workspace to refresh the inspector panel.
 
+    A search input above the tree filters scans by case-insensitive
+    substring match against display_name or path. Filter state lives in a
+    closure dict so the refreshable body always reads the latest value.
+
     Caller is responsible for placing this inside the desired layout
     (typically the left pane of a splitter).
     """
@@ -113,9 +140,13 @@ def render(
         ui.label("No dataset loaded.").classes("opacity-60 text-sm p-4")
         return
 
-    nodes = build_nodes(state.manifest)
+    # Closure-held filter state. A mutable dict (rather than a nonlocal
+    # string) lets the on_change handler write without scope gymnastics.
+    filter_state: Dict[str, str] = {"text": ""}
 
     # Path string -> ScanEntry, for O(1) lookup in the click handler.
+    # Built once over the full manifest — filtering only affects which
+    # nodes are *rendered*, not which paths can be resolved on click.
     path_to_scan: Dict[str, ScanEntry] = {
         str(s.path): s for s in state.manifest.scans
     }
@@ -131,7 +162,25 @@ def render(
         if on_select_scan is not None:
             on_select_scan(scan)
 
-    ui.tree(nodes, on_select=_on_select).classes("w-full")
+    @ui.refreshable
+    def _tree_body() -> None:
+        nodes = build_nodes(state.manifest, filter_state["text"])
+        if not nodes:
+            ui.label("No scans match filter.").classes(
+                "opacity-60 text-xs p-2"
+            )
+            return
+        ui.tree(nodes, on_select=_on_select).classes("w-full")
+
+    def _on_filter_change(event) -> None:
+        filter_state["text"] = event.value or ""
+        _tree_body.refresh()
+
+    ui.input(
+        placeholder="Filter scans…",
+        on_change=_on_filter_change,
+    ).props("dense clearable").classes("w-full")
+    _tree_body()
 
 
 def find_scan(manifest: Optional[Manifest], path_id: str) -> Optional[ScanEntry]:

--- a/src/hrfunc/gui/pages/workspace.py
+++ b/src/hrfunc/gui/pages/workspace.py
@@ -11,10 +11,11 @@ the available real estate:
   │   scans)    │                                │              │
   └─────────────┴──────────────────────────────┴──────────────┘
 
-Sprint 2.3 ships the shell: dataset tree (real), tab structure (real), and
-inspector showing selected ScanEntry metadata (real). Tab content beyond
-``Inspect`` is placeholder — Sprint 3+ replaces it with the estimation,
-quality, and visualization panels.
+Sprint 2.3 shipped the shell: dataset tree (real), tab structure (real), and
+inspector showing selected ScanEntry metadata (real). Sprint 3.1 enriches
+the Inspect tab to be Raw-aware: when a scan is selected, the underlying
+MNE Raw is loaded in the background and the channel list, 2D probe layout,
+and event annotations appear in the Inspect tab.
 
 Routing:
 - Welcome → workspace via ``ui.navigate.to("/workspace")`` after a
@@ -24,20 +25,29 @@ Routing:
 State:
 - Reads ``state.manifest`` (set by the welcome page's open-folder flow).
 - Reads/writes ``state.selected_scan`` (driven by dataset-tree clicks).
+- Reads/writes ``state.raw_cache`` (Sprint 3.1 — populated by background
+  Raw loads kicked off when a scan is selected).
 - Tab change does not modify state — the visible tab is local to the
   workspace render.
 """
 
 from __future__ import annotations
 
+import asyncio
+import base64
+import io
 import logging
+from typing import TYPE_CHECKING, Optional
 
-from nicegui import ui
+from nicegui import background_tasks, ui
 
 from ..components import dataset_tree
 from ..state import AppState, state as global_state
 from ..theme import apply_theme
 from ...io.manifest import ScanEntry
+
+if TYPE_CHECKING:
+    import mne
 
 logger = logging.getLogger(__name__)
 
@@ -155,20 +165,62 @@ def _render_left_pane(state: AppState) -> None:
             ui.label(str(state.manifest.root)).classes(
                 "text-xs font-mono opacity-70 break-all"
             )
-        dataset_tree.render(state, on_select_scan=lambda _scan: _refresh_inspector(state))
+        dataset_tree.render(
+            state, on_select_scan=lambda _scan: _refresh_inspector(state)
+        )
 
 
 def _refresh_inspector(state: AppState) -> None:
-    """Refresh the Inspect tab body after a dataset-tree selection change.
+    """Refresh the Inspect tab body and kick off a background Raw load if needed.
 
-    The Inspect tab's body is wrapped in ``@ui.refreshable`` and stashes its
-    refresh callable on ``state._inspect_refresh`` at render time. Calling
-    that re-runs the body against the latest ``state.selected_scan`` without
-    rebuilding the whole workspace.
+    Two paths:
+    - Always re-runs the Inspect body so the metadata section reflects the
+      newly-selected scan immediately.
+    - If a scan is selected and its Raw is not yet cached, dispatches a
+      background load via ``nicegui.background_tasks.create``. When that
+      load finishes, ``_load_scan_raw`` re-refreshes the body — but only
+      if the user is still on the same scan (path-equality check, since
+      a new Manifest scan can produce a new ScanEntry object for the same
+      file).
     """
     refresh = getattr(state, "_inspect_refresh", None)
     if refresh is not None:
         refresh()
+
+    scan = state.selected_scan
+    if scan is None:
+        return
+    if scan in state.raw_cache:
+        return
+    background_tasks.create(_load_scan_raw(state, scan))
+
+
+async def _load_scan_raw(state: AppState, scan: ScanEntry) -> None:
+    """Load ``scan`` into ``state.raw_cache`` off the event loop.
+
+    Bypasses ``workers.run_in_background`` deliberately: that helper gates on
+    ``state.busy`` (reserved for the long estimation tasks Sprint 3.3/3.4
+    wire up), and rapid scan navigation should not be blocked by that gate
+    or affect the estimation progress indicator.
+
+    After the load completes (or fails), the Inspect body is refreshed only
+    if the user is still inspecting the same scan — compared by path, not
+    object identity, so a fresh ScanEntry from a re-scan still matches.
+    """
+    loop = asyncio.get_event_loop()
+    try:
+        await loop.run_in_executor(None, state.raw_cache.get, scan)
+    except Exception as exc:  # noqa: BLE001 — surface to UI via last_error
+        state.last_error = (
+            f"Failed to load scan: {type(exc).__name__}: {exc}"
+        )
+        logger.exception("Failed to load scan %s", scan.path)
+
+    current = state.selected_scan
+    if current is not None and current.path == scan.path:
+        refresh = getattr(state, "_inspect_refresh", None)
+        if refresh is not None:
+            refresh()
 
 
 # ---------------------------------------------------------------------------
@@ -192,9 +244,9 @@ def _render_center_pane(state: AppState) -> None:
 def _render_tab_panel(name: str, state: AppState) -> None:
     """Render one tab's body.
 
-    ``Inspect`` is real and shows the selected scan's metadata. Every other
-    tab is a "Coming in Sprint N" placeholder for now — Sprint 3+ replaces
-    them.
+    ``Inspect`` is real and shows the selected scan's metadata plus
+    Raw-derived recording info (Sprint 3.1). Every other tab is a "Coming
+    in Sprint N" placeholder — Sprint 3.2+ replaces them.
     """
     if name == "Inspect":
         _render_inspect_tab(state)
@@ -218,48 +270,209 @@ def _render_tab_panel(name: str, state: AppState) -> None:
 
 
 def _render_inspect_tab(state: AppState) -> None:
-    """Inspect tab content — selected scan's basic metadata.
+    """Inspect tab — Metadata + Recording sections, refreshable on scan change.
 
-    Renders against ``state.selected_scan``. When no scan is selected, shows
-    a prompt to pick one. The render is wrapped in ``ui.refreshable`` so
-    dataset-tree clicks update this panel without a full page rebuild.
+    Wraps ``_render_inspect_body`` in ``ui.refreshable`` and stashes the
+    resulting refresher on ``state._inspect_refresh`` so dataset-tree
+    clicks and background-load completions can drive a re-render without
+    rebuilding the whole workspace.
     """
 
     @ui.refreshable
     def _body() -> None:
-        scan = state.selected_scan
-        if scan is None:
-            with ui.column().classes("p-6 gap-2"):
-                ui.label("Inspect").classes("text-2xl font-semibold")
-                ui.label("Select a scan from the dataset tree.").classes(
-                    "text-sm opacity-60"
-                )
-            return
-        with ui.column().classes("p-6 gap-3"):
-            ui.label(scan.display_name or scan.path.name).classes(
-                "text-2xl font-semibold"
-            )
-            _kv_row("Format", scan.format)
-            _kv_row("Path", str(scan.path))
-            if scan.n_channels is not None:
-                _kv_row("Channels", str(scan.n_channels))
-            if scan.sfreq is not None:
-                _kv_row("Sampling rate", f"{scan.sfreq:.4g} Hz")
-            if scan.bids_subject:
-                _kv_row("BIDS subject", scan.bids_subject)
-            if scan.bids_session:
-                _kv_row("BIDS session", scan.bids_session)
-            if scan.bids_task:
-                _kv_row("BIDS task", scan.bids_task)
-            if scan.bids_run:
-                _kv_row("BIDS run", scan.bids_run)
+        _render_inspect_body(state)
 
     _body()
-    # Stash the refresher on the state so dataset_tree.render's on_select
-    # can call it after updating state.selected_scan. Sprint 3+ panels will
-    # subscribe to the same channel via a more structured event bus, but
-    # the direct ref keeps Sprint 2.3 scope tight.
+    # Stash the refresher on the state so external callers (the dataset-tree
+    # click handler and the async Raw loader) can trigger a re-render. Sprint
+    # 3.2 should formalize this as an event bus once a second subscriber
+    # (the Preprocess tab) joins.
     state._inspect_refresh = _body.refresh  # type: ignore[attr-defined]
+
+
+def _render_inspect_body(state: AppState) -> None:
+    """Render the Inspect tab body against the current ``state.selected_scan``.
+
+    Two sections: Metadata (always available from ScanEntry) and Recording
+    (renders once the MNE Raw is in ``state.raw_cache``). If no scan is
+    selected, shows a prompt; if a scan is selected but not yet cached,
+    shows a "Loading recording…" skeleton so users see the load is in
+    flight.
+
+    Extracted as a top-level function so tests can call it inside a
+    synthetic NiceGUI context without going through the refreshable wrapper.
+    """
+    scan = state.selected_scan
+    if scan is None:
+        with ui.column().classes("p-6 gap-2"):
+            ui.label("Inspect").classes("text-2xl font-semibold")
+            ui.label("Select a scan from the dataset tree.").classes(
+                "text-sm opacity-60"
+            )
+        return
+
+    with ui.column().classes("p-6 gap-4 w-full"):
+        ui.label(scan.display_name or scan.path.name).classes(
+            "text-2xl font-semibold"
+        )
+
+        # ── Metadata section (always renders from ScanEntry)
+        ui.label("Metadata").classes(
+            "text-xs uppercase opacity-60 tracking-wide"
+        )
+        _kv_row("Format", scan.format)
+        _kv_row("Path", str(scan.path))
+        if scan.n_channels is not None:
+            _kv_row("Channels", str(scan.n_channels))
+        if scan.sfreq is not None:
+            _kv_row("Sampling rate", f"{scan.sfreq:.4g} Hz")
+        if scan.bids_subject:
+            _kv_row("BIDS subject", scan.bids_subject)
+        if scan.bids_session:
+            _kv_row("BIDS session", scan.bids_session)
+        if scan.bids_task:
+            _kv_row("BIDS task", scan.bids_task)
+        if scan.bids_run:
+            _kv_row("BIDS run", scan.bids_run)
+
+        ui.separator()
+
+        # ── Recording section (loaded MNE Raw)
+        ui.label("Recording").classes(
+            "text-xs uppercase opacity-60 tracking-wide"
+        )
+        if scan in state.raw_cache:
+            try:
+                raw = state.raw_cache.get(scan)
+            except Exception as exc:  # noqa: BLE001
+                # Cache hit but reload failed (defensive — get() shouldn't
+                # error on hit, but the cache could be cleared between the
+                # __contains__ check and the get call by another callback).
+                logger.warning("Inspect: cache.get raised: %s", exc)
+                ui.label(
+                    "Recording unavailable — cache entry was cleared."
+                ).classes("text-sm opacity-60")
+                return
+            _render_recording_sections(raw)
+        else:
+            with ui.row().classes("items-center gap-3"):
+                ui.spinner(size="sm")
+                ui.label("Loading recording…").classes(
+                    "text-sm opacity-70"
+                )
+
+
+def _render_recording_sections(raw: "mne.io.BaseRaw") -> None:
+    """Render channel list + probe layout + events for a loaded Raw."""
+    ch_names = list(raw.ch_names)
+    annotations = raw.annotations if raw.annotations is not None else []
+
+    # ── Channel list (collapsed by default; channel counts dominate the
+    # vertical real estate on dense montages otherwise).
+    with ui.expansion(
+        f"Channels ({len(ch_names)})",
+        icon="sensors",
+    ).classes("w-full"):
+        with ui.column().classes(
+            "max-h-64 overflow-auto gap-1 text-xs font-mono"
+        ):
+            for name in ch_names:
+                ui.label(name).classes("opacity-80")
+
+    # ── 2D probe layout — matplotlib via base64 PNG. ui.matplotlib would
+    # also work, but PNG keeps the snapshot purely declarative and avoids
+    # holding a Figure across the NiceGUI re-render cycle.
+    with ui.expansion("Probe layout", icon="scatter_plot").classes(
+        "w-full"
+    ):
+        probe_html = _render_probe_png(raw)
+        if probe_html is None:
+            ui.label("Probe layout unavailable for this scan.").classes(
+                "text-sm opacity-60"
+            )
+        else:
+            ui.image(probe_html).classes("max-w-md")
+
+    # ── Events / annotations
+    n_events = len(annotations)
+    with ui.expansion(
+        f"Events ({n_events})", icon="event"
+    ).classes("w-full"):
+        if n_events == 0:
+            ui.label("No events recorded in this scan.").classes(
+                "text-sm opacity-60"
+            )
+        else:
+            rows = [
+                {
+                    "description": str(ann["description"]),
+                    "onset": f"{float(ann['onset']):.3f}",
+                    "duration": f"{float(ann['duration']):.3f}",
+                }
+                for ann in annotations
+            ]
+            ui.table(
+                columns=[
+                    {
+                        "name": "description",
+                        "label": "Description",
+                        "field": "description",
+                        "align": "left",
+                    },
+                    {
+                        "name": "onset",
+                        "label": "Onset (s)",
+                        "field": "onset",
+                        "align": "right",
+                    },
+                    {
+                        "name": "duration",
+                        "label": "Duration (s)",
+                        "field": "duration",
+                        "align": "right",
+                    },
+                ],
+                rows=rows,
+                row_key="onset",
+            ).classes("w-full")
+
+
+def _render_probe_png(raw: "mne.io.BaseRaw") -> Optional[str]:
+    """Render the probe layout to a base64-encoded PNG data URL.
+
+    Returns None if MNE refuses to plot (no montage, no sensor positions,
+    or any matplotlib failure). The caller is expected to fall back to a
+    placeholder label in that case.
+    """
+    try:
+        # Lazy imports — matplotlib import time is noticeable at GUI startup,
+        # and this function is only called on a successful Raw load.
+        import matplotlib
+        matplotlib.use("Agg", force=False)
+        import matplotlib.pyplot as plt
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("matplotlib unavailable for probe layout: %s", exc)
+        return None
+
+    fig = None
+    try:
+        fig = raw.plot_sensors(show=False)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("raw.plot_sensors failed: %s", exc)
+        if fig is not None:
+            plt.close(fig)
+        return None
+
+    try:
+        buf = io.BytesIO()
+        fig.savefig(buf, format="png", bbox_inches="tight", dpi=100)
+        encoded = base64.b64encode(buf.getvalue()).decode("ascii")
+        return f"data:image/png;base64,{encoded}"
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("probe layout encode failed: %s", exc)
+        return None
+    finally:
+        plt.close(fig)
 
 
 def _kv_row(key: str, value: str) -> None:
@@ -277,7 +490,7 @@ def _render_right_pane(state: AppState) -> None:
     """Right-pane inspector.
 
     Sprint 2.3 shows manifest-level summary (root, scan count, scan-by-
-    format histogram). Sprint 3 replaces this with parameter controls
+    format histogram). Sprint 3+ replaces this with parameter controls
     (preprocess toggles, estimate sliders) when an estimation tab is
     active, and falls back to this summary otherwise.
     """

--- a/tests/test_gui_scan_inspector.py
+++ b/tests/test_gui_scan_inspector.py
@@ -1,0 +1,401 @@
+"""Targeted unit tests for feat/gui-scan-inspector (v1.3.0 Sprint 3.1).
+
+Covers:
+
+- ``dataset_tree.build_nodes`` filter — case-insensitive substring match
+  against display_name + path; subjects/sessions with zero matching scans
+  pruned.
+- ``dataset_tree.render`` — search input renders above the tree, empty-
+  match shows "No scans match filter" rather than blank.
+- ``workspace._render_inspect_body`` — three rendering states: no scan,
+  scan selected but Raw not yet cached (loading), scan selected and Raw
+  cached (channels/probe/events visible).
+- ``workspace._load_scan_raw`` — async helper inserts loaded Raw into
+  state.raw_cache and refreshes only if the user is still on the same
+  scan (compared by path, not identity).
+
+Rendering tests use NiceGUI's User fixture; state-isolation tests don't
+need NiceGUI bootstrap.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+pytest.importorskip("nicegui")
+
+from nicegui.testing import User  # noqa: E402
+
+pytest_plugins = ["nicegui.testing.user_plugin"]
+
+from hrfunc.gui import app as gui_app  # noqa: E402
+from hrfunc.gui.components import dataset_tree  # noqa: E402
+from hrfunc.gui.pages import workspace  # noqa: E402
+from hrfunc.gui.state import state as global_state  # noqa: E402
+from hrfunc.io.manifest import Manifest, ScanEntry  # noqa: E402
+
+gui_app._register_pages()
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def filterable_manifest(tmp_path):
+    """A manifest with two BIDS subjects and varied display names — good for
+    exercising substring filtering at the leaf level and group pruning."""
+    scans = (
+        ScanEntry(
+            format="snirf",
+            path=tmp_path / "sub-01" / "ses-01" / "sub-01_task-flanker_nirs.snirf",
+            bids_subject="01",
+            bids_session="01",
+            bids_task="flanker",
+            display_name="sub-01 / ses-01 / task-flanker",
+        ),
+        ScanEntry(
+            format="snirf",
+            path=tmp_path / "sub-01" / "ses-01" / "sub-01_task-rest_nirs.snirf",
+            bids_subject="01",
+            bids_session="01",
+            bids_task="rest",
+            display_name="sub-01 / ses-01 / task-rest",
+        ),
+        ScanEntry(
+            format="snirf",
+            path=tmp_path / "sub-02" / "ses-01" / "sub-02_task-flanker_nirs.snirf",
+            bids_subject="02",
+            bids_session="01",
+            bids_task="flanker",
+            display_name="sub-02 / ses-01 / task-flanker",
+        ),
+    )
+    return Manifest(root=tmp_path, scans=scans)
+
+
+def _make_fake_raw(ch_names=None, annotations_data=None):
+    """Build a minimal in-memory MNE RawArray for inspector tests.
+
+    Avoids touching disk; the cache is keyed by path so we can stash this
+    under any path string we choose for the cache lookup to succeed.
+    """
+    import numpy as np
+    import mne
+
+    if ch_names is None:
+        ch_names = ["S1_D1 hbo", "S1_D1 hbr", "S1_D2 hbo", "S1_D2 hbr"]
+    n_ch = len(ch_names)
+    sfreq = 10.0
+    data = np.zeros((n_ch, 50))
+    info = mne.create_info(ch_names=ch_names, sfreq=sfreq, ch_types="misc")
+    raw = mne.io.RawArray(data, info, verbose="ERROR")
+    if annotations_data is not None:
+        onsets, durations, descriptions = zip(*annotations_data)
+        raw.set_annotations(
+            mne.Annotations(onset=list(onsets), duration=list(durations),
+                            description=list(descriptions))
+        )
+    return raw
+
+
+# ---------------------------------------------------------------------------
+# dataset_tree.build_nodes filter — leaf filtering + group pruning
+# ---------------------------------------------------------------------------
+
+
+class TestBuildNodesFilter:
+    def test_empty_filter_returns_all(self, filterable_manifest):
+        nodes_all = dataset_tree.build_nodes(filterable_manifest)
+        nodes_default = dataset_tree.build_nodes(
+            filterable_manifest, filter_text=""
+        )
+        assert nodes_all == nodes_default
+
+    def test_filter_matches_display_name(self, filterable_manifest):
+        nodes = dataset_tree.build_nodes(filterable_manifest, "rest")
+        # Only the rest scan survives — that's under sub-01/ses-01
+        assert len(nodes) == 1
+        assert nodes[0]["label"] == "sub-01"
+        session = nodes[0]["children"][0]
+        leaves = [leaf["label"] for leaf in session["children"]]
+        assert leaves == ["sub-01 / ses-01 / task-rest"]
+
+    def test_filter_is_case_insensitive(self, filterable_manifest):
+        lower = dataset_tree.build_nodes(filterable_manifest, "rest")
+        upper = dataset_tree.build_nodes(filterable_manifest, "REST")
+        mixed = dataset_tree.build_nodes(filterable_manifest, "ReSt")
+        assert lower == upper == mixed
+
+    def test_filter_matches_path(self, filterable_manifest):
+        # The substring 'sub-02' appears in the path of the third scan only.
+        nodes = dataset_tree.build_nodes(filterable_manifest, "sub-02")
+        assert len(nodes) == 1
+        assert nodes[0]["label"] == "sub-02"
+
+    def test_filter_prunes_subject_with_zero_matches(self, filterable_manifest):
+        # 'rest' only matches scans under sub-01 → sub-02 should be pruned.
+        nodes = dataset_tree.build_nodes(filterable_manifest, "rest")
+        labels = [n["label"] for n in nodes]
+        assert "sub-02" not in labels
+
+    def test_filter_prunes_session_with_zero_matches(self, tmp_path):
+        scans = (
+            ScanEntry(
+                format="snirf",
+                path=tmp_path / "sub-01" / "ses-01" / "rest.snirf",
+                bids_subject="01", bids_session="01",
+                display_name="ses-01 rest",
+            ),
+            ScanEntry(
+                format="snirf",
+                path=tmp_path / "sub-01" / "ses-02" / "flanker.snirf",
+                bids_subject="01", bids_session="02",
+                display_name="ses-02 flanker",
+            ),
+        )
+        m = Manifest(root=tmp_path, scans=scans)
+        nodes = dataset_tree.build_nodes(m, "rest")
+        sub01 = nodes[0]
+        session_labels = [s["label"] for s in sub01["children"]]
+        # ses-02 has no rest scan → pruned
+        assert session_labels == ["ses-01"]
+
+    def test_filter_no_matches_returns_empty(self, filterable_manifest):
+        nodes = dataset_tree.build_nodes(filterable_manifest, "zzz_unmatchable")
+        assert nodes == []
+
+
+# ---------------------------------------------------------------------------
+# dataset_tree.render — search input wiring + empty filter message
+# ---------------------------------------------------------------------------
+
+
+async def test_dataset_tree_renders_filter_input(user: User, tmp_path):
+    """The filter input should render above the tree when scans exist."""
+    global_state.reset()
+    global_state.manifest = Manifest(
+        root=tmp_path,
+        scans=(
+            ScanEntry(format="snirf", path=tmp_path / "a.snirf",
+                      display_name="alpha"),
+        ),
+    )
+    await user.open("/workspace")
+    # Filter input is a placeholder — NiceGUI's User fixture matches it via
+    # the placeholder text. The trailing ellipsis is a Unicode character;
+    # match the prefix to stay robust.
+    await user.should_see("Filter scans")
+
+
+async def test_workspace_recording_section_shows_loading_when_uncached(
+    user: User, tmp_path
+):
+    """Selecting a scan before its Raw is cached should show a loading hint."""
+    scan = ScanEntry(
+        format="snirf",
+        path=tmp_path / "sub-01" / "sub-01_task-flanker_nirs.snirf",
+        bids_subject="01",
+        bids_task="flanker",
+        display_name="sub-01 / task-flanker",
+    )
+    global_state.reset()
+    global_state.manifest = Manifest(
+        root=tmp_path,
+        scans=(scan,),
+        scanned_at=datetime(2026, 5, 11, 12, 0, tzinfo=timezone.utc),
+    )
+    global_state.selected_scan = scan
+
+    await user.open("/workspace")
+    # The "Recording" header always renders when a scan is selected;
+    # combined with "Loading recording…" it confirms the uncached branch.
+    await user.should_see("Recording")
+    await user.should_see("Loading recording")
+
+
+async def test_workspace_recording_section_shows_channels_when_cached(
+    user: User, tmp_path
+):
+    """When the Raw is in state.raw_cache, channel/probe/events sections render."""
+    scan = ScanEntry(
+        format="snirf",
+        path=tmp_path / "sub-01" / "sub-01_task-flanker_nirs.snirf",
+        bids_subject="01",
+        bids_task="flanker",
+        display_name="sub-01 / task-flanker",
+    )
+    global_state.reset()
+    global_state.manifest = Manifest(
+        root=tmp_path,
+        scans=(scan,),
+    )
+    global_state.selected_scan = scan
+
+    # Pre-populate the cache with a synthetic Raw so the rendering path that
+    # depends on cache hit is exercised without disk I/O.
+    raw = _make_fake_raw(
+        ch_names=["S1_D1 hbo", "S1_D1 hbr"],
+        annotations_data=[(1.0, 0.5, "stim_a"), (3.0, 0.5, "stim_b")],
+    )
+    global_state.raw_cache._cache[scan.path.resolve()] = raw
+
+    await user.open("/workspace")
+    await user.should_see("Recording")
+    # Channels expansion label includes the channel count
+    await user.should_see("Channels (2)")
+    # Events expansion label includes the annotation count
+    await user.should_see("Events (2)")
+    # Probe layout label is rendered regardless of whether MNE can plot
+    await user.should_see("Probe layout")
+
+
+# ---------------------------------------------------------------------------
+# workspace._load_scan_raw — async load + post-load refresh gating
+# ---------------------------------------------------------------------------
+
+
+class TestLoadScanRaw:
+    def test_refresh_fires_when_scan_unchanged(self, tmp_path, monkeypatch):
+        """After load, refresh fires only if state.selected_scan still matches by path."""
+        scan = ScanEntry(
+            format="snirf",
+            path=tmp_path / "x.snirf",
+            display_name="x",
+        )
+        from hrfunc.gui.state import AppState
+        from hrfunc.io.raw_cache import RawCache
+
+        state = AppState()
+        state.raw_cache = RawCache(maxsize=3)
+        state.selected_scan = scan
+
+        fake_raw = _make_fake_raw()
+
+        # Stub raw_cache.get so we don't hit disk; insert directly into cache.
+        def fake_get(scan_or_path):
+            state.raw_cache._cache[scan.path.resolve()] = fake_raw
+            return fake_raw
+
+        monkeypatch.setattr(state.raw_cache, "get", fake_get)
+
+        refresh_calls = []
+        state._inspect_refresh = lambda: refresh_calls.append(1)  # type: ignore
+
+        asyncio.run(workspace._load_scan_raw(state, scan))
+
+        assert scan in state.raw_cache
+        # Refresh fires because state.selected_scan path still matches.
+        assert refresh_calls == [1]
+
+    def test_refresh_skipped_when_scan_changed(self, tmp_path, monkeypatch):
+        """User navigated away mid-load → no stale refresh."""
+        scan_a = ScanEntry(
+            format="snirf",
+            path=tmp_path / "a.snirf",
+            display_name="a",
+        )
+        scan_b = ScanEntry(
+            format="snirf",
+            path=tmp_path / "b.snirf",
+            display_name="b",
+        )
+        from hrfunc.gui.state import AppState
+        from hrfunc.io.raw_cache import RawCache
+
+        state = AppState()
+        state.raw_cache = RawCache(maxsize=3)
+        state.selected_scan = scan_a
+
+        fake_raw = _make_fake_raw()
+
+        def fake_get(scan_or_path):
+            # Simulate the user clicking a different scan while load is in
+            # flight by mutating state.selected_scan inside the executor work.
+            state.selected_scan = scan_b
+            state.raw_cache._cache[scan_a.path.resolve()] = fake_raw
+            return fake_raw
+
+        monkeypatch.setattr(state.raw_cache, "get", fake_get)
+
+        refresh_calls = []
+        state._inspect_refresh = lambda: refresh_calls.append(1)  # type: ignore
+
+        asyncio.run(workspace._load_scan_raw(state, scan_a))
+
+        # Load completed but user is on scan_b now → no stale refresh.
+        assert refresh_calls == []
+
+    def test_path_equality_match_when_object_changed(self, tmp_path, monkeypatch):
+        """A re-scan can produce a new ScanEntry object for the same path —
+        the path-equality check should still recognize it as 'still the same scan'."""
+        scan = ScanEntry(format="snirf", path=tmp_path / "x.snirf", display_name="x")
+        scan_reloaded = ScanEntry(format="snirf", path=tmp_path / "x.snirf",
+                                  display_name="x")
+        assert scan is not scan_reloaded  # different object, same path
+
+        from hrfunc.gui.state import AppState
+        from hrfunc.io.raw_cache import RawCache
+
+        state = AppState()
+        state.raw_cache = RawCache(maxsize=3)
+        state.selected_scan = scan_reloaded  # fresh instance, e.g. after re-scan
+
+        fake_raw = _make_fake_raw()
+
+        def fake_get(scan_or_path):
+            state.raw_cache._cache[scan.path.resolve()] = fake_raw
+            return fake_raw
+
+        monkeypatch.setattr(state.raw_cache, "get", fake_get)
+
+        refresh_calls = []
+        state._inspect_refresh = lambda: refresh_calls.append(1)  # type: ignore
+
+        asyncio.run(workspace._load_scan_raw(state, scan))
+
+        # Path matches even though objects differ → refresh fires.
+        assert refresh_calls == [1]
+
+    def test_load_failure_sets_last_error(self, tmp_path, monkeypatch):
+        scan = ScanEntry(format="snirf", path=tmp_path / "x.snirf", display_name="x")
+        from hrfunc.gui.state import AppState
+        from hrfunc.io.raw_cache import RawCache
+
+        state = AppState()
+        state.raw_cache = RawCache(maxsize=3)
+        state.selected_scan = scan
+
+        def fake_get(scan_or_path):
+            raise FileNotFoundError("nope")
+
+        monkeypatch.setattr(state.raw_cache, "get", fake_get)
+        # No refresher attached — the helper should still tolerate the
+        # absence and just record the error.
+        asyncio.run(workspace._load_scan_raw(state, scan))
+
+        assert state.last_error is not None
+        assert "FileNotFoundError" in state.last_error
+        # Cache is untouched
+        assert scan not in state.raw_cache
+
+
+# ---------------------------------------------------------------------------
+# _render_inspect_body — exercised through the workspace render
+# ---------------------------------------------------------------------------
+
+
+class TestInspectBodyContracts:
+    def test_render_inspect_body_is_module_level(self):
+        """Sprint 3.1 extracted the body from inside _render_inspect_tab so
+        tests and future panels can call it directly. Regression guard."""
+        import inspect as inspect_mod
+        assert callable(workspace._render_inspect_body)
+        sig = inspect_mod.signature(workspace._render_inspect_body)
+        assert list(sig.parameters) == ["state"]


### PR DESCRIPTION
## Summary

Sprint 3.1 of v1.3.0 GUI work. Two user-visible changes plus the plumbing for both:

- **Inspect tab is now Raw-aware** — selecting a scan triggers a background MNE Raw load; once cached, the Inspect tab shows channel list, 2D probe layout, and event annotations alongside the ScanEntry metadata.
- **Dataset tree gets a search filter** — case-insensitive substring match across `display_name` and path, with subjects/sessions pruned when no scan inside them survives the filter.

## What changed

### `components/dataset_tree.py`
| Surface | Change |
|---|---|
| `build_nodes(manifest, filter_text="")` | New optional kwarg. Empty filter preserves Sprint 2.3 behavior. |
| `render()` | Adds a `ui.input` above the tree, wraps tree body in `@ui.refreshable`. Empty-match shows "No scans match filter". |

### `pages/workspace.py`
| Surface | Change |
|---|---|
| `_render_inspect_body(state)` | Extracted from `_render_inspect_tab` to module scope (testable). Splits content into Metadata + Recording sections. |
| Recording section | Three collapsible expansions: Channels (scrollable `ch_names`), Probe layout (matplotlib → base64 PNG into `ui.image`), Events (`ui.table` from `raw.annotations`). |
| `_refresh_inspector` | Now dispatches a background Raw load via `nicegui.background_tasks.create` when the selected scan is not yet cached. |
| `_load_scan_raw(state, scan)` | New async helper using `loop.run_in_executor` directly. Refresh fires post-load only if `state.selected_scan.path == scan.path` (handles both stale-load and re-scan cases). |

### `tests/test_gui_scan_inspector.py` (new, 15 tests)
- `TestBuildNodesFilter` (7) — leaf match by display_name, case-insensitive, path matching, subject/session pruning, no-match empty.
- 3 rendering tests using NiceGUI `User` fixture — filter input visible, "Loading recording…" when uncached, channels/probe/events when cached (synthetic `mne.io.RawArray` pre-inserted into `raw_cache._cache`).
- `TestLoadScanRaw` (4) — refresh-when-unchanged, refresh-skipped-when-stale, path-equality across fresh `ScanEntry` instances, load-failure populates `state.last_error`.
- `TestInspectBodyContracts` (1) — regression guard that `_render_inspect_body` stays a module-level callable.

## Dual review decisions

Pre-coding architecture + data-integrity reviews surfaced three real issues:

1. **Identity vs equality on `ScanEntry`** — `is` would fail across `Manifest` re-scans (frozen dataclass produces fresh objects for same path). Switched to `.path ==`. Covered by `test_path_equality_match_when_object_changed`.
2. **`asyncio.create_task` in NiceGUI sync handler** — replaced with the official `nicegui.background_tasks.create`.
3. **`raw_cache` not thread-safe** — kept the cache contract intact; sequential dispatch from event-loop callbacks means no true concurrent mutation. Empty-annotations path handled explicitly.

## Out of scope, flagged for 3.2

`preprocess_fnirs` mutates the Raw in place. When Sprint 3.2 wires up the Preprocess tab, the cached Raw could be mutated and leak changes into the Inspect view. 3.2's design must choose between copy-before-preprocess, cache-eviction-before-preprocess, or a separate processed-Raw cache. This is a 3.2 problem because 3.1 only reads.

The `state._inspect_refresh` private-attribute pattern stays for 3.1 (still one subscriber). 3.2 will be the right moment to formalize an event bus.

## Test plan

Full Sprint 3.1 gate (21 test files) — **398 passed, zero regressions** (was 383 at end of Sprint 2.3; +15 new in `test_gui_scan_inspector.py`).

```
pytest tests/test_phase1a.py tests/test_phase1bc.py tests/test_phase2.py \
       tests/test_threading.py tests/test_input_validation.py \
       tests/test_state_lifecycle.py tests/test_oxygenation_guard.py \
       tests/test_tree_delete_filter.py tests/test_hasher_branch.py \
       tests/test_tree_hrf.py tests/test_canonical_hrf.py \
       tests/test_tree_edge_cases.py tests/test_observer_and_typos.py \
       tests/test_progress_callbacks.py tests/test_io_detect.py \
       tests/test_io_scan.py tests/test_io_raw_cache.py \
       tests/test_gui_foundation.py tests/test_gui_welcome.py \
       tests/test_gui_workspace.py tests/test_gui_scan_inspector.py -q
```

- [x] All listed tests pass on macOS Darwin / Python 3.12
- [x] Editable install verified (`src/hrfunc/__init__.py`, not site-packages)
- [ ] Manual smoke test against `tests/data/sNIRF_formatted/` to confirm probe layout renders for the real scans (recommended before merge if you want to eyeball the new sections)

🤖 Generated with [Claude Code](https://claude.com/claude-code)