### PR TITLE
feat: HRFs tab with toeplitz + canonical modes (GUI Sprint 3.3)

### DIFF
--- a/src/hrfunc/gui/components/hrf_panel.py
+++ b/src/hrfunc/gui/components/hrf_panel.py
@@ -1,0 +1,642 @@
+"""HRFs tab content — estimate HRFs from the preprocessed scan + events.
+
+Sprint 3.3 ships:
+- A "Toeplitz" mode wired to ``montage.estimate_hrf``: user picks one or more
+  annotation descriptions (e.g. ``"stim_a"``, ``"task-flanker"``) from the
+  scan, the panel builds an impulse-series array, dispatches estimation
+  via ``workers.run_in_background``, and renders a progress bar driven by
+  the ``progress_callback``.
+- A "Canonical" mode that bypasses estimation entirely and renders the
+  SPM-style double-gamma HRF (the same shape the library uses as a
+  reference in ``correlate_canonical``). No events needed.
+- Controls: model radio (toeplitz/canonical), event picker (multi-select
+  toggles), lambda slider on log scale (1e-5..1e-1, default 1e-3),
+  duration field (default 30.0 s).
+- Result preview: matplotlib base64 PNG showing all estimated HRF traces
+  overlaid by channel (toeplitz mode) or the canonical HRF (canonical mode).
+
+The panel reads from ``state.processed_cache`` for toeplitz mode (per
+Sprint 3.2 contract: preprocess in 3.2, estimate in 3.3). Canonical mode
+needs only ``state.raw_cache`` (no preprocessing required to generate the
+canonical shape).
+
+The panel subscribes to ``scan_selected``, ``scan_loaded``,
+``preprocess_done``, and ``hrf_estimated`` so it re-renders when any
+upstream tab changes state.
+
+Scientific notes
+----------------
+
+- ``estimate_hrf`` runs with ``preprocess=False`` here because the Raw
+  comes from ``processed_cache`` (already preprocessed in 3.2). Passing
+  ``preprocess=True`` would silently re-run the canonical preprocess on
+  preprocessed data, which is wrong.
+- The canonical double-gamma uses ``scipy.stats.gamma.pdf`` at peaks 6 s
+  and 16 s (with a 1/6 undershoot weight) — identical to the library's
+  ``correlate_canonical`` implementation at hrfunc.py:756-761.
+- The lambda slider is log-scale: the displayed value is ``10 ** raw``
+  where ``raw`` is the slider's actual ``-5..-1`` integer. The library's
+  default is ``1e-3``.
+"""
+
+from __future__ import annotations
+
+import base64
+import io
+import logging
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, List, Optional, Tuple
+
+import numpy as np
+from nicegui import background_tasks, ui
+
+from ..state import AppState
+from ..workers import make_progress_callback, run_in_background
+from ...io.manifest import ScanEntry
+
+if TYPE_CHECKING:
+    import mne
+
+logger = logging.getLogger(__name__)
+
+
+MODEL_TOEPLITZ = "toeplitz"
+MODEL_CANONICAL = "canonical"
+DEFAULT_DURATION = 30.0
+DEFAULT_LMBDA = 1e-3
+LOG_LMBDA_MIN = -5
+LOG_LMBDA_MAX = -1
+
+
+@dataclass
+class EstimationOptions:
+    """User-controlled options for the HRFs tab.
+
+    Snapshotted at Estimate-click time so the background task sees a stable
+    view. Defaults mirror ``montage.estimate_hrf`` library defaults.
+    """
+
+    model: str = MODEL_TOEPLITZ
+    lmbda: float = DEFAULT_LMBDA
+    duration: float = DEFAULT_DURATION
+    selected_events: Tuple[str, ...] = field(default_factory=tuple)
+
+
+def render(state: AppState) -> None:
+    """Render the HRFs tab body inside the current NiceGUI context.
+
+    Subscribes a refreshable body to scan/preprocess/HRF-result events so
+    the panel reacts to upstream tab changes without rebuilding the whole
+    workspace.
+    """
+    opts = EstimationOptions()
+
+    @ui.refreshable
+    def _body() -> None:
+        _render_body(state, opts)
+
+    _body()
+
+    def _refresh(_payload=None) -> None:
+        _body.refresh()
+
+    state.subscribe("scan_selected", _refresh)
+    state.subscribe("scan_loaded", _refresh)
+    state.subscribe("preprocess_done", _refresh)
+    state.subscribe("hrf_estimated", _refresh)
+
+    # Progress polling timer — refreshes the body every 0.5 s WHILE an
+    # estimation is in flight, so the progress bar advances. The
+    # progress_callback fires from a worker thread (run_in_executor) and
+    # cannot safely refresh NiceGUI elements from there, so we poll from
+    # the main loop instead. Cheap no-op when state.busy is False.
+    def _poll_progress() -> None:
+        if state.busy and state.estimation_progress is not None:
+            _body.refresh()
+
+    ui.timer(0.5, _poll_progress)
+
+
+def _render_body(state: AppState, opts: EstimationOptions) -> None:
+    """Render the HRFs body against the current state.
+
+    Module-level so tests can call it directly inside a synthetic NiceGUI
+    context without going through the refreshable wrapper.
+    """
+    scan = state.selected_scan
+    with ui.column().classes("p-6 gap-4 w-full"):
+        ui.label("HRFs").classes("text-2xl font-semibold")
+
+        if scan is None:
+            ui.label("Select a scan from the dataset tree.").classes(
+                "text-sm opacity-60"
+            )
+            return
+
+        ui.label(scan.display_name or scan.path.name).classes(
+            "text-sm font-mono opacity-70"
+        )
+
+        # ── Model selector + controls
+        with ui.card().classes("w-full"):
+            ui.label("Estimation").classes(
+                "text-xs uppercase opacity-60 tracking-wide"
+            )
+            _render_model_radio(opts, _refresh_body_for(state))
+            if opts.model == MODEL_TOEPLITZ:
+                _render_toeplitz_controls(state, opts, scan)
+            else:
+                _render_canonical_note()
+
+        # ── Run button + progress / error display
+        _render_run_row(state, scan, opts)
+
+        # ── Result preview
+        if state.montage is not None:
+            ui.separator()
+            ui.label("HRF preview").classes(
+                "text-xs uppercase opacity-60 tracking-wide"
+            )
+            _render_hrf_preview(state, scan, opts)
+
+
+def _refresh_body_for(state: AppState):
+    """Return a callable that re-publishes scan_selected to refresh subscribers.
+
+    Used by the model-radio change handler to trigger a re-render of the
+    panel body when the user flips between toeplitz and canonical (the
+    rendered controls differ between modes).
+    """
+    def _trigger() -> None:
+        state.publish("scan_selected", state.selected_scan)
+    return _trigger
+
+
+def _render_model_radio(
+    opts: EstimationOptions, on_change_refresh
+) -> None:
+    def _set(value: str) -> None:
+        opts.model = value
+        on_change_refresh()
+
+    ui.radio(
+        [MODEL_TOEPLITZ, MODEL_CANONICAL],
+        value=opts.model,
+        on_change=lambda e: _set(e.value),
+    ).props("inline")
+
+
+def _render_toeplitz_controls(
+    state: AppState, opts: EstimationOptions, scan: ScanEntry
+) -> None:
+    """Event picker + lmbda slider + duration field for toeplitz mode."""
+    raw = state.processed_cache.get(scan) if scan in state.processed_cache else None
+
+    # ── Event picker
+    ui.label("Events").classes("text-xs uppercase opacity-60 tracking-wide")
+    if raw is None:
+        ui.label(
+            "Preprocess the scan first (Preprocess tab) before estimating."
+        ).classes("text-sm opacity-60")
+        return
+
+    event_names = sorted_unique_annotation_descriptions(raw)
+    if not event_names:
+        ui.label(
+            "No events found in the preprocessed scan."
+        ).classes("text-sm opacity-60")
+    else:
+        # Seed selection on first render — default to all events so users
+        # don't need to tick anything in the common case.
+        if not opts.selected_events:
+            opts.selected_events = tuple(event_names)
+
+        selected_set = set(opts.selected_events)
+
+        def _toggle(name: str, checked: bool) -> None:
+            new_selection = set(opts.selected_events)
+            if checked:
+                new_selection.add(name)
+            else:
+                new_selection.discard(name)
+            opts.selected_events = tuple(sorted(new_selection))
+
+        with ui.row().classes("gap-2 flex-wrap"):
+            for name in event_names:
+                ui.checkbox(
+                    name,
+                    value=name in selected_set,
+                    on_change=(lambda e, n=name: _toggle(n, bool(e.value))),
+                )
+
+    # ── Lambda slider (log scale)
+    ui.label("Regularization (lambda)").classes(
+        "text-xs uppercase opacity-60 tracking-wide"
+    )
+    initial_log = int(round(np.log10(opts.lmbda))) if opts.lmbda > 0 else -3
+    initial_log = max(LOG_LMBDA_MIN, min(LOG_LMBDA_MAX, initial_log))
+
+    lmbda_display = ui.label(f"lambda = {opts.lmbda:.0e}").classes(
+        "text-sm font-mono opacity-80"
+    )
+
+    def _on_lmbda_change(event) -> None:
+        log_val = int(event.value)
+        opts.lmbda = float(10 ** log_val)
+        lmbda_display.set_text(f"lambda = {opts.lmbda:.0e}")
+
+    ui.slider(
+        min=LOG_LMBDA_MIN,
+        max=LOG_LMBDA_MAX,
+        step=1,
+        value=initial_log,
+        on_change=_on_lmbda_change,
+    )
+
+    # ── Duration
+    ui.label("Duration (seconds)").classes(
+        "text-xs uppercase opacity-60 tracking-wide"
+    )
+    ui.number(
+        value=opts.duration,
+        min=1.0,
+        max=120.0,
+        step=1.0,
+        format="%.1f",
+        on_change=lambda e: setattr(opts, "duration", float(e.value or DEFAULT_DURATION)),
+    )
+
+    # ── Edge-expansion advisory (library default 0.15 of duration)
+    # estimate_hrf shifts every event onset back by edge_expansion*duration
+    # seconds and silently drops events that would fall before t=0. With
+    # the library default (0.15) and the user's current duration, that
+    # means events in the first ``edge_seconds`` of the scan are lost.
+    edge_seconds = 0.15 * opts.duration
+    ui.label(
+        f"Note: events in the first ~{edge_seconds:.1f} s of the scan are "
+        f"dropped by the toeplitz edge-expansion window (library default "
+        f"0.15 × duration). Consider this when designing trial-onset timing."
+    ).classes("text-xs opacity-60 italic")
+
+
+def _render_canonical_note() -> None:
+    ui.label(
+        "Canonical mode renders the SPM-style double-gamma HRF (peak at "
+        "~6 s, undershoot at ~16 s) — a fixed reference shape, not "
+        "data-driven. Click Generate to display."
+    ).classes("text-sm opacity-70")
+
+
+def _render_run_row(
+    state: AppState, scan: ScanEntry, opts: EstimationOptions
+) -> None:
+    """Render the Run button row + progress / error display."""
+    if opts.model == MODEL_TOEPLITZ:
+        can_run = (
+            scan in state.processed_cache
+            and bool(opts.selected_events)
+            and not state.busy
+        )
+        run_label = "Estimate HRFs"
+    else:
+        can_run = not state.busy
+        run_label = "Generate canonical HRF"
+
+    with ui.row().classes("items-center gap-3"):
+        ui.button(
+            run_label,
+            on_click=lambda: _run(state, scan, opts),
+        ).props(f"color=primary {'disable' if not can_run else ''}")
+        if state.busy:
+            prog = state.estimation_progress
+            if prog is not None:
+                current, total, name = prog
+                fraction = (current + 1) / max(total, 1)
+                with ui.column().classes("gap-1 flex-grow"):
+                    ui.label(
+                        f"Channel {current + 1}/{total}: {name}"
+                    ).classes("text-xs opacity-70")
+                    ui.linear_progress(value=fraction).classes("w-64")
+            else:
+                with ui.row().classes("items-center gap-2"):
+                    ui.spinner(size="sm")
+                    ui.label("Working…").classes("text-sm opacity-70")
+        elif opts.model == MODEL_TOEPLITZ and scan not in state.processed_cache:
+            ui.label("Waiting for preprocess output…").classes(
+                "text-sm opacity-60"
+            )
+        elif opts.model == MODEL_TOEPLITZ and not opts.selected_events:
+            ui.label("Pick at least one event to estimate.").classes(
+                "text-sm opacity-60"
+            )
+
+    if state.last_error and not state.busy:
+        with ui.row().classes("items-center gap-2"):
+            ui.icon("error_outline").classes("text-red-400")
+            ui.label(state.last_error).classes("text-sm text-red-400")
+
+
+def _run(
+    state: AppState, scan: ScanEntry, opts: EstimationOptions
+) -> None:
+    """Click handler for Estimate / Generate.
+
+    Snapshots options, dispatches the appropriate sync worker through
+    ``workers.run_in_background``. On success, stashes the resulting
+    Montage on ``state.montage`` and publishes ``hrf_estimated``.
+    """
+    if state.busy:
+        return
+
+    snapshot = EstimationOptions(
+        model=opts.model,
+        lmbda=opts.lmbda,
+        duration=opts.duration,
+        selected_events=opts.selected_events,
+    )
+
+    if snapshot.model == MODEL_TOEPLITZ:
+        if scan not in state.processed_cache:
+            state.last_error = "Preprocess the scan first."
+            return
+        if not snapshot.selected_events:
+            state.last_error = "Pick at least one event."
+            return
+        raw = state.processed_cache.get(scan)
+        progress_cb = make_progress_callback(state)
+        sync_call = (
+            run_toeplitz_sync, raw, snapshot, progress_cb
+        )
+    else:
+        # Canonical mode doesn't need a processed Raw — only the raw_cache
+        # entry to get sfreq/channel count for shaping the output.
+        if scan not in state.raw_cache and scan not in state.processed_cache:
+            state.last_error = "Load the scan first."
+            return
+        source_raw = (
+            state.processed_cache.get(scan)
+            if scan in state.processed_cache
+            else state.raw_cache.get(scan)
+        )
+        sync_call = (
+            run_canonical_sync, source_raw, snapshot
+        )
+
+    async def _on_done(result) -> None:
+        if result is None:
+            return
+        state.montage = result
+        state.publish("hrf_estimated", scan)
+
+    background_tasks.create(
+        run_in_background(state, *sync_call, on_done=_on_done)
+    )
+
+
+def run_toeplitz_sync(
+    raw: "mne.io.BaseRaw",
+    opts: EstimationOptions,
+    progress_callback=None,
+):
+    """Run montage.estimate_hrf against a preprocessed Raw and return Montage.
+
+    Returns None if the events array can't be built (no annotation samples
+    match the selection). The library's ``estimate_hrf`` is called with
+    ``preprocess=False`` because the input is already preprocessed.
+
+    Module-level so tests can call without dispatching through workers.
+    """
+    from ...hrfunc import montage as Montage
+
+    events = build_events_array(raw, opts.selected_events)
+    if events is None or not events.any():
+        logger.warning(
+            "run_toeplitz_sync: no event samples matched the selected "
+            "descriptions; refusing to estimate on empty events."
+        )
+        return None
+
+    m = Montage(nirx_obj=raw)
+    m.estimate_hrf(
+        raw,
+        events=events.tolist(),
+        duration=opts.duration,
+        lmbda=opts.lmbda,
+        preprocess=False,
+        progress_callback=progress_callback,
+    )
+    # estimate_hrf only appends to optode.estimates; it does NOT populate
+    # optode.trace (which is what the preview reads). generate_distribution
+    # computes trace = mean(estimates) per channel. Without this call, the
+    # HRF preview would render an empty plot after a successful estimation.
+    m.generate_distribution()
+    return m
+
+
+def run_canonical_sync(
+    raw: "mne.io.BaseRaw",
+    opts: EstimationOptions,
+):
+    """Build a canonical SPM-style double-gamma HRF.
+
+    Returns a lightweight object with a ``.canonical_trace`` numpy array
+    and ``.duration`` / ``.sfreq`` fields. Not a real Montage — canonical
+    mode doesn't go through estimate_hrf, so the per-channel structure
+    isn't relevant. Sprint 3.4 (Activity) will not consume this; it has
+    its own canonical path via estimate_activity(hrf_model='canonical').
+    """
+    sfreq = float(raw.info["sfreq"])
+    trace = canonical_double_gamma(opts.duration, sfreq)
+    return _CanonicalResult(
+        canonical_trace=trace, duration=opts.duration, sfreq=sfreq
+    )
+
+
+@dataclass
+class _CanonicalResult:
+    """Holder for canonical-mode output.
+
+    Deliberately not a Montage — canonical mode skips estimation entirely
+    and returns a single reference HRF shape. Stored on ``state.montage``
+    via duck-typing; the HRFs tab is the only consumer.
+    """
+
+    canonical_trace: np.ndarray
+    duration: float
+    sfreq: float
+
+
+def canonical_double_gamma(duration: float, sfreq: float) -> np.ndarray:
+    """SPM-style double-gamma canonical HRF.
+
+    Standard SPM canonical: a gamma with peak at ~6 s minus a smaller
+    gamma with peak at ~16 s, normalized so the positive peak is 1.0.
+
+    The argument to ``gamma.pdf`` is in seconds, not sample indices.
+    This deliberately differs from the library's ``correlate_canonical``
+    (hrfunc.py:756-761) which passes raw sample indices — fine when the
+    correlation is point-wise but produces an sfreq-dependent peak
+    location for visualization. The GUI's canonical preview is meant to
+    be the "true" SPM canonical, so it operates in seconds.
+    """
+    import scipy.stats
+
+    n_samples = max(int(round(duration * sfreq)), 2)
+    t_seconds = np.arange(n_samples) / sfreq
+    peak1 = scipy.stats.gamma.pdf(t_seconds, 6)
+    peak2 = scipy.stats.gamma.pdf(t_seconds, 16) / 6.0
+    hrf = peak1 - peak2
+    peak = np.max(hrf)
+    if peak > 0:
+        hrf = hrf / peak
+    return hrf
+
+
+def build_events_array(
+    raw: "mne.io.BaseRaw",
+    selected_descriptions: Tuple[str, ...],
+) -> Optional[np.ndarray]:
+    """Convert MNE annotations to a 0/1 impulse series of length n_samples.
+
+    ``estimate_hrf`` consumes a flat list where each sample is 0 or 1; an
+    event onset at time ``t`` becomes ``1`` at sample index
+    ``round(t * sfreq)``. Annotations whose description is not in
+    ``selected_descriptions`` are ignored. Out-of-range onsets are
+    dropped silently with a logger.warning so a corrupt annotations table
+    doesn't crash the estimation.
+
+    Returns None if there are no annotations to convert at all (so the
+    caller can distinguish "nothing selected" from "selection matched but
+    fell outside the scan window").
+    """
+    annotations = raw.annotations
+    if annotations is None or len(annotations) == 0:
+        return None
+
+    sfreq = float(raw.info["sfreq"])
+    n_samples = raw.n_times
+    selected_set = set(selected_descriptions)
+
+    out = np.zeros(n_samples, dtype=np.int64)
+    for ann in annotations:
+        if str(ann["description"]) not in selected_set:
+            continue
+        sample = int(round(float(ann["onset"]) * sfreq))
+        if 0 <= sample < n_samples:
+            out[sample] = 1
+        else:
+            logger.warning(
+                "build_events_array: dropping annotation at onset %.3fs "
+                "(sample %d) — outside scan window 0..%d",
+                float(ann["onset"]), sample, n_samples,
+            )
+    return out
+
+
+def sorted_unique_annotation_descriptions(raw: "mne.io.BaseRaw") -> List[str]:
+    """Distinct annotation description strings, sorted alphabetically.
+
+    Empty list if the Raw has no annotations or all descriptions are empty.
+    """
+    annotations = raw.annotations
+    if annotations is None or len(annotations) == 0:
+        return []
+    seen = sorted({str(ann["description"]) for ann in annotations})
+    return [s for s in seen if s]
+
+
+# ---------------------------------------------------------------------------
+# Result preview rendering
+# ---------------------------------------------------------------------------
+
+
+def _render_hrf_preview(
+    state: AppState, scan: ScanEntry, opts: EstimationOptions
+) -> None:
+    """Render the matplotlib preview of the most-recent estimation result."""
+    result = state.montage
+    if result is None:
+        return
+    if isinstance(result, _CanonicalResult):
+        png = _render_canonical_preview_png(result)
+    else:
+        png = _render_toeplitz_preview_png(result)
+    if png is None:
+        ui.label("Preview unavailable.").classes("text-sm opacity-60")
+        return
+    ui.image(png).classes("max-w-3xl")
+
+
+def _render_toeplitz_preview_png(montage) -> Optional[str]:
+    """Overlay all channel HRF traces on a single matplotlib axes."""
+    try:
+        import matplotlib
+        matplotlib.use("Agg", force=False)
+        import matplotlib.pyplot as plt
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("matplotlib unavailable: %s", exc)
+        return None
+
+    fig = None
+    try:
+        fig, ax = plt.subplots(1, 1, figsize=(8, 4))
+        channels = getattr(montage, "channels", {})
+        plotted = 0
+        for ch_name, node in channels.items():
+            trace = getattr(node, "trace", None)
+            if trace is None or len(trace) == 0:
+                continue
+            ax.plot(trace, lw=0.6, alpha=0.7, label=ch_name)
+            plotted += 1
+        if plotted == 0:
+            ax.text(
+                0.5, 0.5, "No channel HRFs available.",
+                ha="center", va="center", transform=ax.transAxes,
+            )
+        ax.set_title("Estimated HRFs (toeplitz deconvolution)")
+        ax.set_xlabel("samples")
+        ax.set_ylabel("amplitude (a.u.)")
+        if plotted <= 24:
+            ax.legend(fontsize=6, loc="upper right")
+        fig.tight_layout()
+        buf = io.BytesIO()
+        fig.savefig(buf, format="png", dpi=100, bbox_inches="tight")
+        encoded = base64.b64encode(buf.getvalue()).decode("ascii")
+        return f"data:image/png;base64,{encoded}"
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("toeplitz preview render failed: %s", exc)
+        return None
+    finally:
+        if fig is not None:
+            plt.close(fig)
+
+
+def _render_canonical_preview_png(result: "_CanonicalResult") -> Optional[str]:
+    """Render the canonical HRF as a single line plot."""
+    try:
+        import matplotlib
+        matplotlib.use("Agg", force=False)
+        import matplotlib.pyplot as plt
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("matplotlib unavailable: %s", exc)
+        return None
+
+    fig = None
+    try:
+        fig, ax = plt.subplots(1, 1, figsize=(6, 3))
+        t = np.arange(len(result.canonical_trace)) / result.sfreq
+        ax.plot(t, result.canonical_trace, lw=1.5)
+        ax.set_title("Canonical HRF (double-gamma)")
+        ax.set_xlabel("time (s)")
+        ax.set_ylabel("amplitude (peak = 1.0)")
+        fig.tight_layout()
+        buf = io.BytesIO()
+        fig.savefig(buf, format="png", dpi=100, bbox_inches="tight")
+        encoded = base64.b64encode(buf.getvalue()).decode("ascii")
+        return f"data:image/png;base64,{encoded}"
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("canonical preview render failed: %s", exc)
+        return None
+    finally:
+        if fig is not None:
+            plt.close(fig)

--- a/src/hrfunc/gui/pages/workspace.py
+++ b/src/hrfunc/gui/pages/workspace.py
@@ -41,7 +41,7 @@ from typing import TYPE_CHECKING, Optional
 
 from nicegui import background_tasks, ui
 
-from ..components import dataset_tree, preprocess_panel
+from ..components import dataset_tree, hrf_panel, preprocess_panel
 from ..state import AppState, state as global_state
 from ..theme import apply_theme
 from ...io.manifest import ScanEntry
@@ -262,11 +262,13 @@ def _render_tab_panel(name: str, state: AppState) -> None:
     if name == "Preprocess":
         preprocess_panel.render(state)
         return
+    if name == "HRFs":
+        hrf_panel.render(state)
+        return
 
     # Map each placeholder tab to the sprint that fills it in.
     next_sprint = {
         "Quality": "Sprint 4 (lens-module wrapper)",
-        "HRFs": "Sprint 3 (estimate panel + HRF gallery)",
         "Activity": "Sprint 3 (estimate-activity panel)",
         "HRtree": "Sprint 4 (plotly 3D explorer)",
         "Export": "Sprint 5 (export panel)",

--- a/src/hrfunc/gui/state.py
+++ b/src/hrfunc/gui/state.py
@@ -27,8 +27,16 @@ What lives here:
 - `last_error`           - last error message surfaced to the user, or None
 - `subscribers`          - event-bus dispatch table (Sprint 3.2); see
                            ``subscribe`` / ``publish``
+- `montage`              - most recently estimated Montage from the HRFs tab
+                           (Sprint 3.3); None until estimate_hrf runs at least
+                           once. Cleared on dataset reset; switching the
+                           selected scan does NOT clear it, so users can
+                           switch tabs and come back without losing results
+                           — but a new estimation overwrites the field
+                           regardless of which scan it came from. Sprint 3.4
+                           may upgrade to per-scan storage.
 
-Event bus (Sprint 3.2):
+Event bus (Sprint 3.2, extended in 3.3):
 The bus replaces the Sprint 2.3-era ``_inspect_refresh`` private attribute.
 Panels subscribe to named events and are called when other parts of the GUI
 publish. The bus is dict-of-lists, deliberately minimal — no priorities, no
@@ -42,6 +50,9 @@ async dispatch, no payload schemas. Defined events:
 - ``"preprocess_done"`` — payload: ``ScanEntry``. Published after a successful
   preprocess run; subscribers can read the processed Raw from
   ``state.processed_cache``.
+- ``"hrf_estimated"``   — payload: ``ScanEntry``. Published after a successful
+  ``estimate_hrf`` (or canonical HRF generation); subscribers can read the
+  resulting Montage from ``state.montage``.
 
 Subscribers are sync callables. Async handlers can dispatch via
 ``nicegui.background_tasks.create`` from inside their callback.
@@ -83,6 +94,10 @@ class AppState:
     estimation_progress: Optional[Tuple[int, int, str]] = None
     last_error: Optional[str] = None
     subscribers: Dict[str, List[EventCallback]] = field(default_factory=dict)
+    # Montage from the most recent HRF estimation (Sprint 3.3). Typed as Any to
+    # avoid pulling hrfunc.hrfunc into the GUI import graph at module load —
+    # the GUI must stay importable without MNE for tests that disable it.
+    montage: Optional[Any] = None
 
     def subscribe(self, event: str, callback: EventCallback) -> None:
         """Register ``callback`` to be called on ``publish(event, ...)``.
@@ -135,9 +150,8 @@ class AppState:
         Used when the user closes the current project / switches datasets.
         Drops cached Raws (both source and processed) so memory is released.
         The RawCache instances are kept (not reassigned) so any references
-        held elsewhere stay valid. Event subscribers are also cleared —
-        a fresh dataset is a clean slate and old subscribers may point at
-        widgets that no longer exist.
+        held elsewhere stay valid. Event subscribers and the estimated
+        Montage are also cleared — a fresh dataset is a clean slate.
         """
         self.manifest = None
         self.selected_scan = None
@@ -148,6 +162,7 @@ class AppState:
         self.estimation_progress = None
         self.last_error = None
         self.subscribers.clear()
+        self.montage = None
 
 
 # Module-level singleton. Page handlers and components import this directly.

--- a/tests/test_gui_estimate_panel.py
+++ b/tests/test_gui_estimate_panel.py
@@ -1,0 +1,421 @@
+"""Targeted unit tests for feat/gui-estimate-panel (v1.3.0 Sprint 3.3).
+
+Covers:
+
+- ``EstimationOptions`` defaults and dataclass behavior.
+- ``canonical_double_gamma`` — SPM-style shape, normalization, sfreq-
+  independent peak time.
+- ``build_events_array`` — annotation descriptions to impulse series,
+  description filtering, out-of-range onset dropping, empty-annotation
+  handling.
+- ``sorted_unique_annotation_descriptions`` — sort + dedupe, empty handling.
+- ``hrf_panel.render`` rendering states: no scan, scan + no preprocess
+  (toeplitz), scan + preprocess + events (toeplitz), canonical mode.
+- ``run_canonical_sync`` returns a result with the expected trace shape.
+- ``hrf_estimated`` event published on success.
+- ``state.montage`` cleared by reset.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+pytest.importorskip("nicegui")
+
+from nicegui.testing import User  # noqa: E402
+
+pytest_plugins = ["nicegui.testing.user_plugin"]
+
+from hrfunc.gui import app as gui_app  # noqa: E402
+from hrfunc.gui.components import hrf_panel  # noqa: E402
+from hrfunc.gui.state import AppState, state as global_state  # noqa: E402
+from hrfunc.io.manifest import Manifest, ScanEntry  # noqa: E402
+
+gui_app._register_pages()
+
+
+def _make_fake_raw(
+    ch_names=None,
+    sfreq=10.0,
+    duration_s=30.0,
+    annotations_data=None,
+):
+    """Build a minimal in-memory MNE RawArray for testing.
+
+    By default produces 30 s of zeros at 10 Hz across 4 channels — enough
+    to exercise event-array length and probe layout without needing real
+    fNIRS metadata.
+    """
+    import mne
+
+    if ch_names is None:
+        ch_names = ["S1_D1 hbo", "S1_D1 hbr", "S2_D1 hbo", "S2_D1 hbr"]
+    n_ch = len(ch_names)
+    n_samples = int(round(duration_s * sfreq))
+    data = np.zeros((n_ch, n_samples))
+    info = mne.create_info(ch_names=ch_names, sfreq=sfreq, ch_types="misc")
+    raw = mne.io.RawArray(data, info, verbose="ERROR")
+    if annotations_data is not None:
+        onsets, durations, descriptions = zip(*annotations_data)
+        raw.set_annotations(
+            mne.Annotations(
+                onset=list(onsets),
+                duration=list(durations),
+                description=list(descriptions),
+            )
+        )
+    return raw
+
+
+# ---------------------------------------------------------------------------
+# EstimationOptions
+# ---------------------------------------------------------------------------
+
+
+class TestEstimationOptions:
+    def test_defaults_match_library(self):
+        opts = hrf_panel.EstimationOptions()
+        assert opts.model == hrf_panel.MODEL_TOEPLITZ
+        assert opts.lmbda == 1e-3
+        assert opts.duration == 30.0
+        assert opts.selected_events == ()
+
+    def test_is_dataclass(self):
+        import dataclasses
+        assert dataclasses.is_dataclass(hrf_panel.EstimationOptions)
+
+
+# ---------------------------------------------------------------------------
+# canonical_double_gamma
+# ---------------------------------------------------------------------------
+
+
+class TestCanonicalDoubleGamma:
+    def test_length_matches_duration_times_sfreq(self):
+        trace = hrf_panel.canonical_double_gamma(duration=30.0, sfreq=10.0)
+        assert len(trace) == 300
+
+    def test_normalized_to_unit_peak(self):
+        trace = hrf_panel.canonical_double_gamma(duration=30.0, sfreq=10.0)
+        assert np.isclose(np.max(trace), 1.0)
+
+    def test_peak_time_sfreq_independent(self):
+        """Peak should be at the same time-in-seconds regardless of sfreq —
+        verifies the time-indexed (vs sample-indexed) gamma argument."""
+        trace_10hz = hrf_panel.canonical_double_gamma(duration=30.0, sfreq=10.0)
+        trace_4hz = hrf_panel.canonical_double_gamma(duration=30.0, sfreq=4.0)
+
+        peak_t_10 = np.argmax(trace_10hz) / 10.0
+        peak_t_4 = np.argmax(trace_4hz) / 4.0
+        # Both should be near 5 s (SPM canonical gamma(a=6, b=1) peaks at a-1=5)
+        assert abs(peak_t_10 - peak_t_4) < 0.5
+        assert 4.5 < peak_t_10 < 6.0
+
+    def test_has_undershoot_after_peak(self):
+        """SPM canonical has a small negative undershoot ~12-18 s after onset."""
+        trace = hrf_panel.canonical_double_gamma(duration=30.0, sfreq=10.0)
+        # Within the 12-18 s window
+        undershoot_region = trace[120:180]
+        assert undershoot_region.min() < 0
+
+    def test_short_duration_still_returns_array(self):
+        trace = hrf_panel.canonical_double_gamma(duration=0.1, sfreq=10.0)
+        assert len(trace) >= 2
+
+
+# ---------------------------------------------------------------------------
+# build_events_array
+# ---------------------------------------------------------------------------
+
+
+class TestBuildEventsArray:
+    def test_returns_none_when_no_annotations(self):
+        raw = _make_fake_raw()
+        result = hrf_panel.build_events_array(raw, ("stim_a",))
+        assert result is None
+
+    def test_impulse_at_correct_sample(self):
+        raw = _make_fake_raw(
+            sfreq=10.0,
+            duration_s=10.0,
+            annotations_data=[(2.5, 0.5, "stim_a")],
+        )
+        result = hrf_panel.build_events_array(raw, ("stim_a",))
+        assert result is not None
+        # 2.5s * 10Hz = sample 25
+        assert result[25] == 1
+        assert result.sum() == 1
+
+    def test_filters_to_selected_descriptions(self):
+        raw = _make_fake_raw(
+            sfreq=10.0,
+            duration_s=10.0,
+            annotations_data=[
+                (1.0, 0.5, "stim_a"),
+                (3.0, 0.5, "stim_b"),
+                (5.0, 0.5, "stim_a"),
+            ],
+        )
+        result = hrf_panel.build_events_array(raw, ("stim_a",))
+        assert result is not None
+        assert result[10] == 1
+        assert result[30] == 0  # stim_b filtered out
+        assert result[50] == 1
+        assert result.sum() == 2
+
+    def test_drops_out_of_range_onsets(self, caplog):
+        raw = _make_fake_raw(
+            sfreq=10.0,
+            duration_s=5.0,  # 50 samples
+            annotations_data=[
+                (2.0, 0.5, "stim_a"),
+                (100.0, 0.5, "stim_a"),  # way out of range
+            ],
+        )
+        result = hrf_panel.build_events_array(raw, ("stim_a",))
+        assert result is not None
+        assert result[20] == 1
+        assert result.sum() == 1  # the out-of-range onset dropped
+
+    def test_length_matches_n_times(self):
+        raw = _make_fake_raw(sfreq=10.0, duration_s=12.0)
+        # Even with no events selected, the returned array (if any) should
+        # have length = n_times when annotations exist.
+        raw.set_annotations(
+            __import__("mne").Annotations(
+                onset=[1.0], duration=[0.5], description=["x"]
+            )
+        )
+        result = hrf_panel.build_events_array(raw, ("not_x",))
+        assert result is not None
+        assert len(result) == raw.n_times
+        # Nothing matched → all zeros
+        assert result.sum() == 0
+
+
+# ---------------------------------------------------------------------------
+# sorted_unique_annotation_descriptions
+# ---------------------------------------------------------------------------
+
+
+class TestSortedUniqueDescriptions:
+    def test_empty_when_no_annotations(self):
+        raw = _make_fake_raw()
+        assert hrf_panel.sorted_unique_annotation_descriptions(raw) == []
+
+    def test_dedupe_and_sort(self):
+        raw = _make_fake_raw(
+            duration_s=10.0,
+            annotations_data=[
+                (1.0, 0, "stim_b"),
+                (2.0, 0, "stim_a"),
+                (3.0, 0, "stim_b"),
+                (4.0, 0, "stim_a"),
+            ],
+        )
+        descs = hrf_panel.sorted_unique_annotation_descriptions(raw)
+        assert descs == ["stim_a", "stim_b"]
+
+    def test_drops_empty_descriptions(self):
+        raw = _make_fake_raw(
+            duration_s=10.0,
+            annotations_data=[
+                (1.0, 0, "stim_a"),
+                (2.0, 0, ""),
+            ],
+        )
+        descs = hrf_panel.sorted_unique_annotation_descriptions(raw)
+        assert descs == ["stim_a"]
+
+
+# ---------------------------------------------------------------------------
+# run_canonical_sync
+# ---------------------------------------------------------------------------
+
+
+class TestRunCanonicalSync:
+    def test_returns_canonical_result_with_trace(self):
+        raw = _make_fake_raw(sfreq=10.0, duration_s=30.0)
+        opts = hrf_panel.EstimationOptions(
+            model=hrf_panel.MODEL_CANONICAL, duration=30.0
+        )
+        result = hrf_panel.run_canonical_sync(raw, opts)
+        assert isinstance(result, hrf_panel._CanonicalResult)
+        assert result.duration == 30.0
+        assert result.sfreq == 10.0
+        assert len(result.canonical_trace) == 300
+
+
+class TestRunToeplitzSyncContract:
+    """Sprint 3.3 review caught that estimate_hrf only populates
+    optode.estimates; optode.trace is set by generate_distribution. The
+    GUI's run_toeplitz_sync must call both so the preview can read .trace."""
+
+    def test_calls_generate_distribution_after_estimate(self, monkeypatch):
+        """Verify the sync wrapper calls generate_distribution post-estimate
+        so .trace fields are populated."""
+        from hrfunc import hrfunc as hrf_module
+
+        events_arr = np.zeros(50, dtype=np.int64)
+        events_arr[10] = 1
+
+        # Mock build_events_array to return a non-zero array
+        monkeypatch.setattr(
+            hrf_panel, "build_events_array", lambda raw, events: events_arr
+        )
+
+        calls = []
+
+        class _FakeMontage:
+            def __init__(self, nirx_obj=None):
+                self.channels = {}
+                calls.append(("init",))
+
+            def estimate_hrf(self, *args, **kwargs):
+                calls.append(("estimate_hrf", kwargs.get("preprocess")))
+
+            def generate_distribution(self, plot_dir=None):
+                calls.append(("generate_distribution",))
+
+        monkeypatch.setattr(hrf_module, "montage", _FakeMontage)
+
+        raw = _make_fake_raw()
+        opts = hrf_panel.EstimationOptions(
+            model=hrf_panel.MODEL_TOEPLITZ,
+            selected_events=("stim_a",),
+        )
+        result = hrf_panel.run_toeplitz_sync(raw, opts)
+
+        # Ordering must be: init → estimate_hrf → generate_distribution
+        method_names = [c[0] for c in calls]
+        assert method_names == ["init", "estimate_hrf", "generate_distribution"]
+        # estimate_hrf called with preprocess=False (raw is from processed_cache)
+        assert calls[1][1] is False
+        assert result is not None
+
+
+# ---------------------------------------------------------------------------
+# state.montage cleared by reset
+# ---------------------------------------------------------------------------
+
+
+class TestStateMontage:
+    def test_montage_field_defaults_none(self):
+        s = AppState()
+        assert s.montage is None
+
+    def test_reset_clears_montage(self):
+        s = AppState()
+        s.montage = "anything"
+        s.reset()
+        assert s.montage is None
+
+
+# ---------------------------------------------------------------------------
+# Panel render states — User fixture
+# ---------------------------------------------------------------------------
+
+
+async def test_panel_prompts_when_no_scan(user: User, tmp_path):
+    global_state.reset()
+    global_state.manifest = Manifest(
+        root=tmp_path,
+        scans=(ScanEntry(format="snirf", path=tmp_path / "a.snirf",
+                         display_name="a"),),
+    )
+    await user.open("/workspace")
+    await user.should_see("HRFs")
+    await user.should_see("Select a scan from the dataset tree")
+
+
+async def test_panel_shows_waiting_when_no_processed_raw(user: User, tmp_path):
+    """Toeplitz mode requires the preprocessed Raw — the panel should
+    nudge the user toward the Preprocess tab when none is cached."""
+    scan = ScanEntry(
+        format="snirf",
+        path=tmp_path / "sub-01" / "sub-01_task-flanker_nirs.snirf",
+        bids_subject="01",
+        display_name="sub-01 / task-flanker",
+    )
+    global_state.reset()
+    global_state.manifest = Manifest(root=tmp_path, scans=(scan,))
+    global_state.selected_scan = scan
+    # Neither raw_cache nor processed_cache has the scan
+    await user.open("/workspace")
+    await user.should_see("Preprocess the scan first")
+
+
+async def test_panel_shows_event_picker_when_preprocessed(user: User, tmp_path):
+    scan = ScanEntry(
+        format="snirf",
+        path=tmp_path / "sub-01" / "sub-01_task-flanker_nirs.snirf",
+        bids_subject="01",
+        display_name="sub-01 / task-flanker",
+    )
+    raw = _make_fake_raw(
+        sfreq=10.0,
+        duration_s=10.0,
+        annotations_data=[(1.0, 0.5, "stim_a"), (3.0, 0.5, "stim_b")],
+    )
+    global_state.reset()
+    global_state.manifest = Manifest(root=tmp_path, scans=(scan,))
+    global_state.selected_scan = scan
+    global_state.processed_cache._cache[scan.path.resolve()] = raw
+    global_state.raw_cache._cache[scan.path.resolve()] = raw
+
+    await user.open("/workspace")
+    # Event names should appear as checkbox labels.
+    await user.should_see("stim_a")
+    await user.should_see("stim_b")
+    await user.should_see("Regularization")
+    await user.should_see("Duration")
+
+
+async def test_panel_canonical_note_when_canonical_mode(user: User, tmp_path):
+    """Switching to canonical mode shows the SPM-canonical note, not the
+    event picker."""
+    scan = ScanEntry(
+        format="snirf",
+        path=tmp_path / "a.snirf",
+        display_name="a",
+    )
+    raw = _make_fake_raw()
+    global_state.reset()
+    global_state.manifest = Manifest(root=tmp_path, scans=(scan,))
+    global_state.selected_scan = scan
+    global_state.raw_cache._cache[scan.path.resolve()] = raw
+
+    await user.open("/workspace")
+    # Default is toeplitz; canonical-only label not visible yet.
+    # Just verify the toeplitz/canonical radio is rendered.
+    await user.should_see("toeplitz")
+    await user.should_see("canonical")
+
+
+# ---------------------------------------------------------------------------
+# Event-bus wiring
+# ---------------------------------------------------------------------------
+
+
+async def test_workspace_subscribes_hrf_panel_to_events(user: User, tmp_path):
+    """After workspace renders, the HRFs panel has subscribed to the
+    scan/preprocess/hrf_estimated events."""
+    global_state.reset()
+    global_state.manifest = Manifest(
+        root=tmp_path,
+        scans=(ScanEntry(format="snirf", path=tmp_path / "a.snirf",
+                         display_name="a"),),
+    )
+    await user.open("/workspace")
+    # All three events the panel subscribes to should be present in the
+    # bus. Each event has at least one subscriber (Inspect + Preprocess +
+    # HRFs).
+    assert "scan_selected" in global_state.subscribers
+    assert "scan_loaded" in global_state.subscribers
+    assert "preprocess_done" in global_state.subscribers
+    assert "hrf_estimated" in global_state.subscribers


### PR DESCRIPTION
## Summary

Sprint 3.3 of v1.3.0 GUI work — the HRFs tab lights up. Users can estimate channel-wise HRFs from preprocessed scans (toeplitz deconvolution) or generate a reference SPM-style canonical HRF without estimation.

## What changed

### `state.py`
| Surface | Change |
|---|---|
| `montage: Optional[Any] = None` | New field. Holds the most recent estimation result (`Montage` or `_CanonicalResult`). Cleared by `reset()`. |
| `"hrf_estimated"` event | New event, payload is `ScanEntry`. Published after a successful estimation. |

### `components/hrf_panel.py` (new)
| Surface | Change |
|---|---|
| `EstimationOptions` dataclass | `model` (toeplitz/canonical), `lmbda`, `duration`, `selected_events`. Defaults match library. |
| `render(state)` | Subscribes refreshable to scan/preprocess/HRF events, starts a `ui.timer(0.5)` for progress-bar polling. |
| Toeplitz controls | Event-picker checkboxes (multi-select from `raw.annotations`), log-scale lambda slider, duration field, edge-expansion advisory. |
| Canonical mode | No event picker; Generate produces the SPM double-gamma (time-indexed, peak ~5 s, peak-normalized). |
| `run_toeplitz_sync` | Builds events array, configures Montage, calls `estimate_hrf(preprocess=False, progress_callback=cb)`, then `generate_distribution()` to populate `optode.trace`. |
| `run_canonical_sync` | Returns `_CanonicalResult(canonical_trace, duration, sfreq)`. |
| `build_events_array` | Annotation → 0/1 impulse series of length `n_samples`. |
| Preview | Matplotlib base64 PNG; toeplitz overlays all channels, canonical shows a single line plot in seconds. |

### `pages/workspace.py`
- Dispatches the "HRFs" tab to `hrf_panel.render`.

## Dual review findings + fixes

Post-implementation review caught two real bugs; both fixed before push:

| Issue | Severity | Fix |
|---|---|---|
| `estimate_hrf` only populates `optode.estimates`, NOT `optode.trace` (verified by reading hrfunc.py:436 vs hrfunc.py:630). Preview would render blank after a successful estimation. | Bug | Call `montage.generate_distribution()` inside `run_toeplitz_sync` after `estimate_hrf`. Regression test `TestRunToeplitzSyncContract::test_calls_generate_distribution_after_estimate` asserts the call order. |
| `progress_callback` fires from a worker thread and can't safely refresh NiceGUI elements. Progress bar would never advance during an estimation. | Bug | Add `ui.timer(0.5)` at panel-render time that polls `state.busy` and refreshes the body from the main loop. Cheap no-op when not busy. |

Also added a scientific-integrity advisory: the library's `estimate_hrf` silently drops events in the first `edge_expansion * duration` seconds (default 0.15 × 30.0 = 4.5 s). The panel now renders a static "Note: events in the first ~Xs are dropped…" label below the duration field so users understand the constraint.

## Out of scope, flagged for later

- **Edge-expansion as a user control.** Library default 0.15 hardcoded for 3.3. Future sprint may add a slider.
- **Lambda slider granularity.** Current step=1 on log scale gives 5 discrete values (1e-5..1e-1). Researchers may want intermediate values like 5e-4.
- **Duck-typing `_CanonicalResult` on `state.montage`.** Sprint 3.4 (Activity) may need to discriminate. Currently the panel uses `isinstance`.

## Test plan

Full Sprint 3.3 gate (23 test files): **446 passed, zero regressions** (was 422 at end of 3.2; +24 new).

```
pytest tests/test_phase1a.py tests/test_phase1bc.py tests/test_phase2.py \
       tests/test_threading.py tests/test_input_validation.py \
       tests/test_state_lifecycle.py tests/test_oxygenation_guard.py \
       tests/test_tree_delete_filter.py tests/test_hasher_branch.py \
       tests/test_tree_hrf.py tests/test_canonical_hrf.py \
       tests/test_tree_edge_cases.py tests/test_observer_and_typos.py \
       tests/test_progress_callbacks.py tests/test_io_detect.py \
       tests/test_io_scan.py tests/test_io_raw_cache.py \
       tests/test_gui_foundation.py tests/test_gui_welcome.py \
       tests/test_gui_workspace.py tests/test_gui_scan_inspector.py \
       tests/test_gui_preprocess.py tests/test_gui_estimate_panel.py -q
```

New test classes:
- `TestEstimationOptions` (2) — defaults, dataclass-ness.
- `TestCanonicalDoubleGamma` (5) — length, normalization, peak time, undershoot, edge case.
- `TestBuildEventsArray` (5) — None on no annotations, impulse at correct sample, description filtering, out-of-range drop, length match.
- `TestSortedUniqueDescriptions` (3) — empty, dedupe+sort, empty-string filter.
- `TestRunCanonicalSync` (1) — returns `_CanonicalResult`.
- `TestRunToeplitzSyncContract` (1) — verifies `generate_distribution` called after `estimate_hrf`.
- `TestStateMontage` (2) — defaults None, reset clears.
- Panel rendering (4) — no-scan, no-preprocess, event picker, model radio.
- Event-bus wiring (1) — subscribers registered for all 4 events.

- [x] All tests pass on macOS Darwin / Python 3.12
- [x] Editable install verified
- [ ] Manual smoke test against `tests/data/sNIRF_formatted/` to click through Preprocess → HRFs end-to-end and see a populated HRF preview (recommended before merge — none of the automated tests run real `estimate_hrf` due to fNIRS-channel-type requirements)

🤖 Generated with [Claude Code](https://claude.com/claude-code)