### PR TITLE
feat: HRF Library page with filter + plotly 3D viz (GUI Sprint 4.2-4.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,9 +21,16 @@
 - New: Activity tab — toeplitz (reuses estimated HRFs) and canonical
   (uses bundled HRF library) modes; lens.plot_nirx-style overlay
   preview with event markers
+- New: Quality tab — per-scan SNR / skewness / kurtosis / SCI metrics
+  across raw / preprocessed / deconvolved stages plus a dataset-wide
+  aggregate that walks every scan in the manifest
+- New: HRF Library page at `/library` — three-pane Browser-persona
+  flow with Context Filter sidebar, plotly 3D HRtree viz, and per-HRF
+  detail pane with trace preview
 - New: Cross-component event bus (`scan_selected`, `scan_loaded`,
-  `preprocess_done`, `hrf_estimated`, `activity_estimated`) for panel
-  reactivity
+  `preprocess_done`, `hrf_estimated`, `activity_estimated`,
+  `quality_computed`, `library_filter_changed`,
+  `library_selection_changed`) for panel reactivity
 - New: Folder-scan I/O subsystem (`hrfunc.io.scan_folder`,
   `classify_path`, `RawCache`) reusable from the Python API
 - New: `progress_callback` kwarg added to `montage.estimate_hrf` and

--- a/README.md
+++ b/README.md
@@ -73,8 +73,13 @@ The workspace exposes seven tabs that mirror the analysis pipeline:
 4. **Activity** — deconvolve neural-activity time series from the
    preprocessed scan using either your estimated HRFs or the bundled
    canonical library.
-5. **Quality / HRtree / Export** — placeholders, landing in Sprints 4
-   and 5.
+5. **Quality** — per-scan SNR / skewness / kurtosis / SCI metrics plus
+   a dataset-wide aggregate that walks the full manifest.
+6. **HRtree (`/library`)** — plotly 3D scatter of the bundled
+   literature HRF database, with a context filter sidebar (task, doi,
+   study, demographics, stimulus, conditions) and a per-HRF detail
+   pane with trace preview.
+7. **Export** — placeholder, landing in Sprint 5.
 
 A 3-pane workspace with a BIDS-aware dataset tree on the left, tabbed
 analysis surface in the middle, and a manifest summary on the right.

--- a/docs/external/gui_guide.md
+++ b/docs/external/gui_guide.md
@@ -52,7 +52,8 @@ When the GUI opens with no folder pre-loaded, you see three paths:
    completes.
 2. **Browse HRF library** — explore the bundled literature-derived HRF
    databases (`hbo_hrfs.json` / `hbr_hrfs.json`) without any of your own
-   data. *Coming in Sprint 4.*
+   data. Opens the `/library` page directly. See [HRF
+   Library](#hrf-library) below for the full walkthrough.
 3. **Recent projects** — re-open a folder you scanned previously. The
    scan manifest is cached on disk per the XDG cache convention
    (`~/Library/Caches/hrfunc/` on macOS, `~/.cache/hrfunc/` on Linux,
@@ -217,6 +218,91 @@ orange vertical lines.
 
 ---
 
+## HRF Library
+
+The `/library` page is the **Browser** persona's entry point — a
+researcher who wants to explore HRFunc's bundled literature HRFs without
+opening their own data. Reach it via the welcome screen's "Browse HRF
+library" card, or by navigating directly.
+
+Three resizable panes:
+
+```
+┌──────────────┬──────────────────────────────┬──────────────┐
+│  Filter      │  HRtree (plotly 3D)          │  Detail      │
+│  (context    │   - Points = HRF location    │  (selected   │
+│   form)      │   - Color = HbO / HbR        │   HRF info,  │
+│              │   - Hover for context        │   trace plot)│
+│              │   - Click to select          │              │
+└──────────────┴──────────────────────────────┴──────────────┘
+```
+
+The library loads two bundled databases on first visit — `hbo_hrfs.json`
+and `hbr_hrfs.json`, both shipped inside the `hrfunc` package — into
+their k-d tree containers. The trees stay in memory for the rest of the
+session.
+
+### Filter pane
+
+The left sidebar exposes six common context fields as text inputs:
+
+- **task** — e.g. `flanker`, `nback`, `rest`
+- **doi** — paper identifier or `temp` for not-yet-published entries
+- **study** — internal study name
+- **demographics** — e.g. `children`, `adults`, `women`
+- **stimulus** — visual / auditory / etc.
+- **conditions** — experiment condition names
+
+Matching is **case-insensitive substring**. Leave a field blank to
+ignore it. Click **Apply** to refresh the viz; **Reset** clears all
+fields. A live count below the buttons shows `N / M HRFs match` where M
+is the total bundled count.
+
+For context fields whose values in the database are lists (e.g.
+`conditions: ["congruent", "incongruent"]`), the filter matches if any
+list entry contains the needle.
+
+### HRtree viz pane (center)
+
+Plotly 3D scatter of HRFs positioned by their `(x, y, z)` optode
+coordinates. Two traces: HbO (red) and HbR (blue), so you can toggle
+oxygenation visibility from the plotly legend.
+
+- **Hover** — shows the HRF key plus its task / doi / study /
+  demographics for quick scanning.
+- **Click** — sets the selected HRF; the right pane updates with the
+  full context dict and a trace preview.
+- **Rotate / zoom / pan** — standard plotly 3D controls (drag to
+  rotate, scroll to zoom, shift-drag to pan).
+
+HRFs without a recorded 3D location are excluded from the viz rather
+than clustered at the origin (the spatial display only makes sense for
+HRFs with measured coordinates).
+
+### Detail pane (right)
+
+Empty until you click an HRF in the viz. Once selected, shows:
+
+- The HRF key (e.g. `s1_d1_hbo-doi/10.1234/abcd`)
+- Oxygenation (HbO / HbR), sampling rate, location, trace length
+- Full context dict — every non-None field from the database entry
+- A trace preview plot in seconds (with ±1 standard-deviation shading
+  when `hrf_std` is available)
+
+### Library limitations to know about
+
+- **Read-only** — v1.3.0 does not let you delete, insert, or merge
+  HRFs from the GUI. Use the `hrfunc.tree` Python API for those
+  operations.
+- **Filter is view-only** — applying a filter does not modify the
+  underlying tree on disk. Re-opening the page resets to "all HRFs
+  visible".
+- **No cross-reference with the workspace** — you cannot drag an HRF
+  from the library into your workspace's montage yet. Use
+  `hrfunc.localize_hrfs` in Python for that flow.
+
+---
+
 ## Caching behavior
 
 The GUI uses two LRU caches of size 3 (so up to 3 scans stay in memory
@@ -324,12 +410,11 @@ The matplotlib render failed (most often: the channel you picked was
 dropped during estimation and the deconvolved Raw has fewer channels
 than the processed Raw). Pick a different channel from the dropdown.
 
-### Library Browser / HRtree / Export / Quality tabs say "Coming in Sprint N"
+### Export tab says "Coming in Sprint 5"
 
-Those tabs are placeholders in v1.3.0. The Quality, HRtree, Context
-Filter, and Library Browser land in Sprint 4; HRF gallery and Export
-land in Sprint 5. Tracking issues on the [HRFunc
-repository](https://github.com/dennys246/HRFunc).
+The Export panel (and HRF gallery, scheduled to merge alongside it) is
+the only remaining placeholder in v1.3.0. Tracking issues on the
+[HRFunc repository](https://github.com/dennys246/HRFunc).
 
 ### GUI crashes on launch with a port-binding error
 

--- a/src/hrfunc/gui/app.py
+++ b/src/hrfunc/gui/app.py
@@ -95,31 +95,16 @@ def _build_argument_parser() -> argparse.ArgumentParser:
 def _register_pages() -> None:
     """Register all `@ui.page` handlers.
 
-    Sprint 2.2 ships the real welcome page at ``/`` plus minimal stubs for
-    ``/workspace`` (Sprint 2.3 replaces) and ``/library`` (Sprint 4 replaces).
-    Page modules are imported lazily so dev-mode reloading picks up changes
-    without restarting the NiceGUI server.
+    Welcome at ``/`` (Sprint 2.2), workspace at ``/workspace`` (Sprint 2.3+),
+    library at ``/library`` (Sprint 4.2-4.4). Page modules are imported
+    lazily so dev-mode reloading picks up changes without restarting the
+    NiceGUI server.
     """
-    from nicegui import ui
-
-    from .pages import welcome, workspace
-    from .theme import apply_theme, page_container
+    from .pages import library, welcome, workspace
 
     welcome.register()
     workspace.register()
-
-    @ui.page("/library")
-    def _library_stub() -> None:
-        apply_theme()
-        with page_container():
-            ui.label("HRF Library").classes("text-4xl font-bold")
-            ui.label(
-                "Browse the bundled literature-derived HRF databases. "
-                "Full library browser lands in Sprint 4."
-            ).classes("text-lg opacity-80")
-            ui.button("Back to welcome", on_click=lambda: ui.navigate.to("/")).props(
-                "flat color=primary"
-            )
+    library.register()
 
 
 def _find_free_port() -> int:

--- a/src/hrfunc/gui/pages/library.py
+++ b/src/hrfunc/gui/pages/library.py
@@ -1,0 +1,609 @@
+"""HRF Library page — browse the bundled literature-derived HRF databases.
+
+The /library route is the entry path for the **Browser** persona — a
+researcher who has no scan of their own but wants to explore the
+literature HRFs HRFunc bundles (``hbo_hrfs.json`` / ``hbr_hrfs.json``)
+and the community-contributed entries that get merged in over time.
+
+Sprint 4.2 + 4.3 + 4.4 ship together as one combined branch because the
+three pieces are tightly coupled on shared state:
+
+- **Library Browser (4.4)** — the three-pane ``/library`` page scaffold:
+  Context Filter on the left, plotly 3D HRtree explorer in the center,
+  HRF detail card on the right.
+- **HRtree explorer (4.2)** — the plotly 3D scatter showing HRF nodes
+  positioned by their (x, y, z) location, colored by oxygenation,
+  hoverable for context preview, clickable to select an HRF.
+- **Context Filter (4.3)** — the left-sidebar form for filtering the
+  visible HRFs by context fields (task, doi, demographics, etc.).
+
+Loading: both trees are read from disk once on the first /library
+visit and stashed on ``state.library_hbo`` / ``state.library_hbr``.
+Subsequent visits reuse the cached trees. The trees themselves never
+change (the bundled files are read-only data), so we don't bother
+with cache invalidation.
+
+Filtering: applied non-destructively in ``_apply_filter`` rather than
+via ``tree.branch()`` — the GUI's filter is a view, not a permanent
+sub-tree, and we want users to be able to toggle filters freely.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
+
+from nicegui import ui
+
+from ..state import AppState, state as global_state
+from ..theme import apply_theme, page_container
+
+if TYPE_CHECKING:
+    from ...hrtree import tree as TreeType
+
+logger = logging.getLogger(__name__)
+
+
+# Subset of context fields exposed as filter controls. The library tree
+# context has ~10 fields; researchers most commonly filter on the first
+# few (task, doi, study, demographics). Less-used fields (intensity,
+# protocol) stay accessible via the data but don't get a control.
+FILTER_FIELDS = (
+    "task",
+    "doi",
+    "study",
+    "demographics",
+    "stimulus",
+    "conditions",
+)
+
+
+def register() -> None:
+    """Register the /library page handler.
+
+    Called by ``app._register_pages()``. Replaces the Sprint 2.2 inline
+    stub.
+    """
+
+    @ui.page("/library")
+    def library_page() -> None:
+        _render(global_state)
+
+
+def _render(state: AppState) -> None:
+    """Render the Library page against the given AppState.
+
+    Split from the page handler so tests can call it with a synthetic
+    state without going through NiceGUI's routing layer.
+
+    Event-bus subscriptions are page-scoped (see ``workspace._render`` for
+    the same pattern): clear the subscriber list at the top so repeat
+    visits don't accumulate dead refreshable handles from prior page
+    DOMs. Each pane's render function re-subscribes during this render.
+    """
+    apply_theme()
+    state.subscribers.clear()
+    _render_toolbar()
+
+    if state.library_hbo is None or state.library_hbr is None:
+        _load_trees(state)
+
+    _render_three_pane(state)
+
+
+def _load_trees(state: AppState) -> None:
+    """Read the bundled HRF databases into memory once.
+
+    The trees stay on state for the lifetime of the process. Failures are
+    surfaced to ``state.last_error`` but the page still renders so users
+    can see what went wrong rather than getting a blank screen.
+    """
+    try:
+        # Lazy-import to keep the GUI import graph minimal at module load.
+        from ...hrtree import tree as Tree
+        from ... import __file__ as hrfunc_file
+
+        import os
+        lib_dir = os.path.join(os.path.dirname(hrfunc_file), "hrfs")
+        hbo_path = os.path.join(lib_dir, "hbo_hrfs.json")
+        hbr_path = os.path.join(lib_dir, "hbr_hrfs.json")
+        state.library_hbo = Tree(hbo_path)
+        state.library_hbr = Tree(hbr_path)
+        logger.info(
+            "Loaded library trees: HbO=%d nodes, HbR=%d nodes",
+            len(state.library_hbo.gather(state.library_hbo.root)),
+            len(state.library_hbr.gather(state.library_hbr.root)),
+        )
+    except Exception as exc:  # noqa: BLE001
+        state.last_error = (
+            f"Failed to load bundled HRF library: {type(exc).__name__}: {exc}"
+        )
+        logger.exception("library load failed: %s", exc)
+
+
+# ---------------------------------------------------------------------------
+# Toolbar + empty state
+# ---------------------------------------------------------------------------
+
+
+def _render_toolbar() -> None:
+    with ui.row().classes(
+        "w-full items-center justify-between px-6 py-3 border-b border-slate-800"
+    ):
+        with ui.row().classes("items-center gap-3"):
+            ui.icon("library_books", size="2rem").classes("text-primary")
+            ui.label("HRF Library").classes("text-2xl font-semibold")
+        with ui.row().classes("items-center gap-2"):
+            ui.button(
+                "Back to welcome",
+                on_click=lambda: ui.navigate.to("/"),
+            ).props("flat color=primary")
+
+
+# ---------------------------------------------------------------------------
+# Three-pane layout — splitters for left | (center | right)
+# ---------------------------------------------------------------------------
+
+
+def _render_three_pane(state: AppState) -> None:
+    """Render filter | viz | detail with two splitters, matching workspace."""
+    with ui.splitter(value=20, limits=(10, 35)).classes(
+        "w-full h-screen"
+    ) as outer:
+        with outer.before:
+            _render_filter_pane(state)
+        with outer.after:
+            with ui.splitter(value=70, limits=(40, 90)).classes(
+                "w-full h-full"
+            ) as inner:
+                with inner.before:
+                    _render_viz_pane(state)
+                with inner.after:
+                    _render_detail_pane(state)
+
+
+# ---------------------------------------------------------------------------
+# Left pane: Context Filter
+# ---------------------------------------------------------------------------
+
+
+def _render_filter_pane(state: AppState) -> None:
+    """The Context Filter sidebar.
+
+    Each FILTER_FIELDS entry becomes a text input bound to
+    ``state.library_filter[field]``. Empty string = field not filtered
+    (the entry is removed from the dict). An "Apply" button refreshes
+    the dependent viz + detail panes.
+    """
+    with ui.column().classes("w-full h-full p-3 gap-3 overflow-auto"):
+        ui.label("Filter").classes(
+            "text-xs uppercase opacity-60 tracking-wide"
+        )
+        ui.label(
+            "Narrow the visible HRFs by context. Case-insensitive substring "
+            "match against each field; leave blank to ignore."
+        ).classes("text-xs opacity-60")
+
+        # One ui.input per filter field.
+        inputs: Dict[str, Any] = {}
+        for field in FILTER_FIELDS:
+            initial = str(state.library_filter.get(field, ""))
+            inputs[field] = ui.input(
+                label=field,
+                value=initial,
+            ).props("dense clearable").classes("w-full")
+
+        def _apply() -> None:
+            new_filter: Dict[str, Any] = {}
+            for field, widget in inputs.items():
+                value = (widget.value or "").strip()
+                if value:
+                    new_filter[field] = value
+            state.library_filter = new_filter
+            # Trigger a re-render of dependent panes via the event bus.
+            state.publish("library_filter_changed", new_filter)
+
+        def _reset() -> None:
+            for widget in inputs.values():
+                widget.value = ""
+            state.library_filter = {}
+            state.publish("library_filter_changed", {})
+
+        with ui.row().classes("w-full gap-2"):
+            ui.button("Apply", on_click=_apply).props("color=primary")
+            ui.button("Reset", on_click=_reset).props("flat")
+
+        # Live count of matching HRFs, refreshable so Apply / Reset
+        # updates it. The count also annotates how many filtered HRFs
+        # are NOT visualizable in the 3D viz because they lack a
+        # location — without this, a user can see "5 / 22 match" while
+        # the viz shows only 3 points and be confused.
+        @ui.refreshable
+        def _count_label() -> None:
+            all_hrfs = gather_library_hrfs(state)
+            matched = apply_filter(all_hrfs, state.library_filter)
+            visualizable = sum(
+                1
+                for hrf in matched.values()
+                if hrf.get("location") is not None
+                and len(hrf.get("location") or []) >= 3
+            )
+            text = f"{len(matched)} / {len(all_hrfs)} HRFs match"
+            if visualizable < len(matched):
+                missing = len(matched) - visualizable
+                text += f" ({missing} not visualizable: missing location)"
+            ui.label(text).classes("text-xs opacity-70")
+
+        _count_label()
+        state.subscribe(
+            "library_filter_changed", lambda _p=None: _count_label.refresh()
+        )
+
+
+# ---------------------------------------------------------------------------
+# Center pane: HRtree 3D viz
+# ---------------------------------------------------------------------------
+
+
+def _render_viz_pane(state: AppState) -> None:
+    """The plotly 3D scatter of HRF locations.
+
+    Refreshable so the Apply button can re-render against the filter.
+    """
+
+    @ui.refreshable
+    def _viz_body() -> None:
+        all_hrfs = gather_library_hrfs(state)
+        matched = apply_filter(all_hrfs, state.library_filter)
+
+        if not all_hrfs:
+            with ui.column().classes("p-6 gap-2"):
+                ui.label("HRtree").classes("text-2xl font-semibold")
+                if state.last_error:
+                    ui.label(state.last_error).classes(
+                        "text-sm text-red-400"
+                    )
+                else:
+                    ui.label(
+                        "Library trees not loaded. Returning to the welcome "
+                        "screen and re-opening /library may help."
+                    ).classes("text-sm opacity-60")
+            return
+
+        with ui.column().classes("w-full h-full p-3 gap-2"):
+            ui.label(
+                f"HRtree — {len(matched)} HRFs shown"
+            ).classes("text-sm opacity-70")
+            fig = build_plotly_figure(matched)
+            plot = ui.plotly(fig).classes("w-full h-full")
+
+            def _on_click(event) -> None:
+                # NiceGUI's plotly click event delivers an args dict with a
+                # 'points' list. Each point has a 'customdata' field if we
+                # set it on the trace, which we use to store the HRF key.
+                hrf_key = _extract_clicked_hrf_key(event)
+                if hrf_key is None:
+                    return
+                hrf = matched.get(hrf_key) or all_hrfs.get(hrf_key)
+                if hrf is None:
+                    return
+                # Stash the key on the dict so the detail pane can show it.
+                state.library_selected_hrf = {**hrf, "_key": hrf_key}
+                state.publish("library_selection_changed", hrf_key)
+
+            plot.on("plotly_click", _on_click)
+
+    _viz_body()
+
+    # Re-render the viz on filter change.
+    def _refresh_viz(_payload=None) -> None:
+        _viz_body.refresh()
+    state.subscribe("library_filter_changed", _refresh_viz)
+
+
+def _extract_clicked_hrf_key(event) -> Optional[str]:
+    """Pull the clicked HRF's key from a plotly click event payload.
+
+    NiceGUI delivers ``event.args`` as the raw plotly JSON; the clicked
+    point has a ``customdata`` field which we populated with the HRF key
+    when building the figure. Returns None on any malformed payload,
+    logging at warning level so a future plotly-API change surfaces
+    instead of leaving clicks mysteriously silent.
+    """
+    try:
+        args = getattr(event, "args", None) or {}
+        points = args.get("points") or []
+        if not points:
+            return None
+        first = points[0]
+        return first.get("customdata")
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "library: failed to extract HRF key from click event: %s", exc
+        )
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Right pane: HRF detail
+# ---------------------------------------------------------------------------
+
+
+def _render_detail_pane(state: AppState) -> None:
+    """The selected-HRF detail card.
+
+    Shows context metadata + a matplotlib trace plot for the picked HRF.
+    """
+
+    @ui.refreshable
+    def _detail_body() -> None:
+        hrf = state.library_selected_hrf
+        with ui.column().classes("w-full h-full p-4 gap-3 overflow-auto"):
+            ui.label("Detail").classes(
+                "text-xs uppercase opacity-60 tracking-wide"
+            )
+            if hrf is None:
+                ui.label("Click an HRF in the viz to inspect.").classes(
+                    "text-sm opacity-60"
+                )
+                return
+
+            key = hrf.get("_key", "")
+            ui.label(key or "(no key)").classes(
+                "text-lg font-mono break-all"
+            )
+
+            _kv("oxygenation", "HbO" if hrf.get("oxygenation") else "HbR")
+            _kv("sfreq", f"{float(hrf.get('sfreq', 0)):.4g} Hz")
+            loc = hrf.get("location") or [0, 0, 0]
+            _kv(
+                "location",
+                f"x={loc[0]:.3f}  y={loc[1]:.3f}  z={loc[2]:.3f}",
+            )
+            trace = hrf.get("hrf_mean") or []
+            _kv("trace length", str(len(trace)))
+
+            context = hrf.get("context") or {}
+            if context:
+                ui.separator()
+                ui.label("Context").classes(
+                    "text-xs uppercase opacity-60 tracking-wide"
+                )
+                for ctx_key, value in context.items():
+                    if value is None:
+                        continue
+                    _kv(ctx_key, str(value))
+
+            if trace:
+                ui.separator()
+                ui.label("Trace").classes(
+                    "text-xs uppercase opacity-60 tracking-wide"
+                )
+                png = _render_trace_png(hrf)
+                if png is not None:
+                    ui.image(png).classes("max-w-md")
+
+    _detail_body()
+
+    def _refresh_detail(_payload=None) -> None:
+        _detail_body.refresh()
+    state.subscribe("library_selection_changed", _refresh_detail)
+
+
+def _kv(key: str, value: str) -> None:
+    with ui.row().classes("w-full gap-4"):
+        ui.label(key).classes("text-xs uppercase opacity-60 w-32")
+        ui.label(value).classes("text-sm break-all")
+
+
+# ---------------------------------------------------------------------------
+# Data helpers (module-level so tests can call them)
+# ---------------------------------------------------------------------------
+
+
+def gather_library_hrfs(state: AppState) -> Dict[str, Dict[str, Any]]:
+    """Combine the HbO + HbR trees into a single name → HRF-dict map.
+
+    Returns empty dict if the trees aren't loaded. Each value is the
+    gathered-form dict produced by ``tree.gather``.
+    """
+    out: Dict[str, Dict[str, Any]] = {}
+    for tree_obj in (state.library_hbo, state.library_hbr):
+        if tree_obj is None:
+            continue
+        hrfs = tree_obj.gather(tree_obj.root)
+        if hrfs:
+            out.update(hrfs)
+    return out
+
+
+def apply_filter(
+    hrfs: Dict[str, Dict[str, Any]],
+    filter_kwargs: Dict[str, Any],
+) -> Dict[str, Dict[str, Any]]:
+    """Filter an HRF dict by case-insensitive substring match on context.
+
+    Each key in ``filter_kwargs`` must appear in the HRF's context with
+    a value whose string representation contains the filter value (case-
+    insensitive). HRFs missing a filtered key are excluded. Empty filter
+    returns the input unchanged.
+    """
+    if not filter_kwargs:
+        return dict(hrfs)
+
+    out: Dict[str, Dict[str, Any]] = {}
+    for key, hrf in hrfs.items():
+        context = hrf.get("context") or {}
+        if _hrf_matches_filter(context, filter_kwargs):
+            out[key] = hrf
+    return out
+
+
+def _hrf_matches_filter(
+    context: Dict[str, Any],
+    filter_kwargs: Dict[str, Any],
+) -> bool:
+    """True if every (key, value) in the filter is reflected in context."""
+    for field, needle in filter_kwargs.items():
+        if needle is None or needle == "":
+            continue
+        haystack = context.get(field)
+        if haystack is None:
+            return False
+        # Stringify and substring-match case-insensitively for primitive
+        # context values. For list/tuple values, match if any entry matches.
+        if isinstance(haystack, (list, tuple)):
+            if not any(_str_match(item, needle) for item in haystack):
+                return False
+        else:
+            if not _str_match(haystack, needle):
+                return False
+    return True
+
+
+def _str_match(value: Any, needle: str) -> bool:
+    if value is None:
+        return False
+    return str(needle).lower() in str(value).lower()
+
+
+# ---------------------------------------------------------------------------
+# Plotly figure builder
+# ---------------------------------------------------------------------------
+
+
+def build_plotly_figure(hrfs: Dict[str, Dict[str, Any]]):
+    """Build the 3D scatter figure for the given HRF dict.
+
+    Two traces: HbO (red) and HbR (blue). Each point's ``customdata`` is
+    the HRF key so click handlers can look it up. ``hovertext`` carries a
+    short context summary.
+    """
+    import plotly.graph_objects as go
+
+    hbo_x, hbo_y, hbo_z, hbo_keys, hbo_hover = [], [], [], [], []
+    hbr_x, hbr_y, hbr_z, hbr_keys, hbr_hover = [], [], [], [], []
+
+    for key, hrf in hrfs.items():
+        loc = hrf.get("location")
+        # Skip HRFs without a real 3D location rather than fabricating
+        # (0,0,0) — clustering location-less nodes at the origin would be
+        # visually misleading and the GUI's spatial story (kd-tree) only
+        # makes sense for HRFs with measured coordinates.
+        if loc is None or len(loc) < 3:
+            continue
+        is_hbo = bool(hrf.get("oxygenation"))
+        hover = _hover_text_for(key, hrf)
+        if is_hbo:
+            hbo_x.append(loc[0])
+            hbo_y.append(loc[1])
+            hbo_z.append(loc[2])
+            hbo_keys.append(key)
+            hbo_hover.append(hover)
+        else:
+            hbr_x.append(loc[0])
+            hbr_y.append(loc[1])
+            hbr_z.append(loc[2])
+            hbr_keys.append(key)
+            hbr_hover.append(hover)
+
+    traces = []
+    if hbo_x:
+        traces.append(
+            go.Scatter3d(
+                x=hbo_x, y=hbo_y, z=hbo_z,
+                mode="markers",
+                marker=dict(size=4, color="#fb7185", opacity=0.85),
+                name="HbO",
+                customdata=hbo_keys,
+                hovertext=hbo_hover,
+                hoverinfo="text",
+            )
+        )
+    if hbr_x:
+        traces.append(
+            go.Scatter3d(
+                x=hbr_x, y=hbr_y, z=hbr_z,
+                mode="markers",
+                marker=dict(size=4, color="#38bdf8", opacity=0.85),
+                name="HbR",
+                customdata=hbr_keys,
+                hovertext=hbr_hover,
+                hoverinfo="text",
+            )
+        )
+
+    fig = go.Figure(data=traces)
+    fig.update_layout(
+        margin=dict(l=0, r=0, t=20, b=0),
+        scene=dict(
+            xaxis_title="x (m)",
+            yaxis_title="y (m)",
+            zaxis_title="z (m)",
+            aspectmode="data",
+        ),
+        showlegend=True,
+        paper_bgcolor="rgba(0,0,0,0)",
+        plot_bgcolor="rgba(0,0,0,0)",
+    )
+    return fig
+
+
+def _hover_text_for(key: str, hrf: Dict[str, Any]) -> str:
+    """Short multi-line hover-text summary for one HRF."""
+    context = hrf.get("context") or {}
+    bits = [key]
+    for field in ("task", "doi", "study", "demographics"):
+        value = context.get(field)
+        if value:
+            bits.append(f"{field}: {value}")
+    return "<br>".join(bits)
+
+
+# ---------------------------------------------------------------------------
+# Trace plot PNG
+# ---------------------------------------------------------------------------
+
+
+def _render_trace_png(hrf: Dict[str, Any]) -> Optional[str]:
+    """Render the HRF trace as a base64 PNG line plot."""
+    try:
+        import base64
+        import io as _io
+        import matplotlib
+        matplotlib.use("Agg", force=False)
+        import matplotlib.pyplot as plt
+        import numpy as np
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("matplotlib unavailable for library trace: %s", exc)
+        return None
+
+    trace = hrf.get("hrf_mean") or []
+    if not trace:
+        return None
+    sfreq = float(hrf.get("sfreq") or 1.0)
+    if sfreq <= 0:
+        sfreq = 1.0
+
+    fig = None
+    try:
+        t = np.arange(len(trace)) / sfreq
+        std = hrf.get("hrf_std") or []
+        fig, ax = plt.subplots(1, 1, figsize=(5, 2.5))
+        ax.plot(t, trace, lw=1.2, color="#6366f1")
+        if std and len(std) == len(trace):
+            lower = np.asarray(trace) - np.asarray(std)
+            upper = np.asarray(trace) + np.asarray(std)
+            ax.fill_between(t, lower, upper, alpha=0.15, color="#6366f1")
+        ax.set_xlabel("time (s)")
+        ax.set_ylabel("amplitude (a.u.)")
+        fig.tight_layout()
+        buf = _io.BytesIO()
+        fig.savefig(buf, format="png", dpi=100, bbox_inches="tight")
+        return f"data:image/png;base64,{base64.b64encode(buf.getvalue()).decode('ascii')}"
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("library trace render failed: %s", exc)
+        return None
+    finally:
+        if fig is not None:
+            plt.close(fig)

--- a/src/hrfunc/gui/state.py
+++ b/src/hrfunc/gui/state.py
@@ -128,6 +128,22 @@ class AppState:
     # views Quality for the current scan, or in bulk during the dataset-wide
     # aggregate run.
     quality_metrics: Dict[Path, Dict[str, Any]] = field(default_factory=dict)
+    # Lazy-loaded bundled HRF databases for the /library page (Sprint 4.2-4.4).
+    # Tree objects from ``hrfunc.hrtree.tree``. Populated on first /library
+    # visit; never cleared (the data is read-only from disk so re-loading
+    # would just re-read the same files). Typed Any to keep the GUI import
+    # graph free of hrfunc.hrtree at module load.
+    library_hbo: Optional[Any] = None
+    library_hbr: Optional[Any] = None
+    # Current context filter state for the Library page. Keys are context
+    # field names ('task', 'doi', 'demographics', ...). Empty dict = no
+    # filter applied. The Library page rebuilds the visible HRF list from
+    # the filter every render.
+    library_filter: Dict[str, Any] = field(default_factory=dict)
+    # Currently-selected HRF on the Library page (from a click in the
+    # plotly viz or a manual list selection). Stored as the gathered-form
+    # dict (the value type produced by ``tree.gather``), or None.
+    library_selected_hrf: Optional[Dict[str, Any]] = None
 
     def subscribe(self, event: str, callback: EventCallback) -> None:
         """Register ``callback`` to be called on ``publish(event, ...)``.
@@ -196,6 +212,11 @@ class AppState:
         self.montage_source_scan = None
         self.activity_raw = None
         self.quality_metrics.clear()
+        # Note: library_hbo / library_hbr are deliberately NOT cleared by
+        # reset(). They hold immutable bundled data loaded once per process;
+        # re-loading on every dataset switch would burn ~100 ms unnecessarily.
+        self.library_filter.clear()
+        self.library_selected_hrf = None
 
 
 # Module-level singleton. Page handlers and components import this directly.

--- a/tests/test_gui_library.py
+++ b/tests/test_gui_library.py
@@ -1,0 +1,344 @@
+"""Targeted unit tests for feat/gui-library-browser (v1.3.0 Sprint 4.2-4.4).
+
+Covers:
+
+- AppState additions (library_hbo / library_hbr / library_filter /
+  library_selected_hrf) — defaults, reset behavior.
+- ``apply_filter`` — empty filter passes through, substring match,
+  case-insensitivity, list-valued context fields, missing-key exclusion.
+- ``gather_library_hrfs`` — combines HbO + HbR, handles None tree.
+- ``build_plotly_figure`` — produces HbO + HbR traces, customdata is
+  the HRF key (for click handling), missing/short locations are skipped.
+- ``_extract_clicked_hrf_key`` — pulls key from plotly event payload.
+- /library page render — toolbar visible, filter inputs present,
+  empty-data fallback (no library loaded).
+"""
+
+from __future__ import annotations
+
+import contextlib
+import io as _io
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("nicegui")
+
+from nicegui.testing import User  # noqa: E402
+
+pytest_plugins = ["nicegui.testing.user_plugin"]
+
+from hrfunc.gui import app as gui_app  # noqa: E402
+from hrfunc.gui.pages import library  # noqa: E402
+from hrfunc.gui.state import AppState, state as global_state  # noqa: E402
+
+gui_app._register_pages()
+
+
+def _silent(fn, *args, **kwargs):
+    """Run a callable while swallowing its stdout chatter (tree.gather is loud)."""
+    with contextlib.redirect_stdout(_io.StringIO()):
+        return fn(*args, **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# State lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestStateLibraryFields:
+    def test_defaults(self):
+        s = AppState()
+        assert s.library_hbo is None
+        assert s.library_hbr is None
+        assert s.library_filter == {}
+        assert s.library_selected_hrf is None
+
+    def test_reset_clears_filter_and_selection(self):
+        s = AppState()
+        s.library_filter["task"] = "flanker"
+        s.library_selected_hrf = {"_key": "x"}
+        s.reset()
+        assert s.library_filter == {}
+        assert s.library_selected_hrf is None
+
+    def test_reset_does_not_clear_loaded_trees(self):
+        """Bundled HRF trees are immutable on-disk data; re-loading on
+        every dataset switch would burn 100+ ms with no benefit."""
+        s = AppState()
+        sentinel = object()
+        s.library_hbo = sentinel
+        s.library_hbr = sentinel
+        s.reset()
+        assert s.library_hbo is sentinel
+        assert s.library_hbr is sentinel
+
+
+# ---------------------------------------------------------------------------
+# apply_filter — context substring matching
+# ---------------------------------------------------------------------------
+
+
+class TestApplyFilter:
+    def _fake_hrfs(self):
+        return {
+            "h1": {
+                "context": {"task": "flanker", "doi": "doi/A", "demographics": "children"},
+            },
+            "h2": {
+                "context": {"task": "rest", "doi": "doi/B", "demographics": "adults"},
+            },
+            "h3": {
+                "context": {"task": "flanker", "doi": "doi/C", "demographics": None},
+            },
+        }
+
+    def test_empty_filter_returns_all(self):
+        hrfs = self._fake_hrfs()
+        assert library.apply_filter(hrfs, {}) == hrfs
+
+    def test_match_one_field(self):
+        hrfs = self._fake_hrfs()
+        result = library.apply_filter(hrfs, {"task": "flanker"})
+        assert set(result.keys()) == {"h1", "h3"}
+
+    def test_case_insensitive(self):
+        hrfs = self._fake_hrfs()
+        assert (
+            set(library.apply_filter(hrfs, {"task": "FLANKER"}).keys())
+            == set(library.apply_filter(hrfs, {"task": "flanker"}).keys())
+        )
+
+    def test_substring_match(self):
+        hrfs = self._fake_hrfs()
+        # "doi/A" should be found by "doi/" but also by just "A"
+        result = library.apply_filter(hrfs, {"doi": "doi/A"})
+        assert set(result.keys()) == {"h1"}
+
+    def test_and_across_keys(self):
+        hrfs = self._fake_hrfs()
+        result = library.apply_filter(
+            hrfs, {"task": "flanker", "demographics": "children"}
+        )
+        # h1 matches both; h3 has flanker but demographics=None → excluded
+        assert set(result.keys()) == {"h1"}
+
+    def test_missing_context_key_excludes(self):
+        hrfs = {"h1": {"context": {"task": "flanker"}}}
+        result = library.apply_filter(hrfs, {"doi": "X"})
+        assert result == {}
+
+    def test_list_context_value_any_match(self):
+        hrfs = {
+            "h1": {"context": {"conditions": ["congruent", "incongruent"]}},
+            "h2": {"context": {"conditions": ["rest"]}},
+        }
+        result = library.apply_filter(hrfs, {"conditions": "congruent"})
+        assert set(result.keys()) == {"h1"}
+
+
+# ---------------------------------------------------------------------------
+# gather_library_hrfs
+# ---------------------------------------------------------------------------
+
+
+class TestGatherLibraryHrfs:
+    def test_empty_when_trees_none(self):
+        s = AppState()
+        assert library.gather_library_hrfs(s) == {}
+
+    def test_combines_real_bundled_trees(self):
+        s = AppState()
+        _silent(library._load_trees, s)
+        all_hrfs = _silent(library.gather_library_hrfs, s)
+        # Sanity: the bundled databases ship with HRFs; expect at least 1 HbO + 1 HbR
+        assert len(all_hrfs) > 0
+        # Confirm at least one HbO and one HbR
+        oxys = {hrf.get("oxygenation") for hrf in all_hrfs.values()}
+        assert True in oxys
+        assert False in oxys
+
+
+# ---------------------------------------------------------------------------
+# build_plotly_figure
+# ---------------------------------------------------------------------------
+
+
+class TestBuildPlotlyFigure:
+    def test_two_traces_for_mixed_oxygenation(self):
+        hrfs = {
+            "h1": {"location": [1, 2, 3], "oxygenation": True, "context": {}},
+            "h2": {"location": [4, 5, 6], "oxygenation": False, "context": {}},
+        }
+        fig = library.build_plotly_figure(hrfs)
+        assert len(fig.data) == 2
+        names = {trace.name for trace in fig.data}
+        assert names == {"HbO", "HbR"}
+
+    def test_customdata_carries_keys_for_click(self):
+        hrfs = {
+            "alpha": {"location": [0, 0, 0], "oxygenation": True, "context": {}},
+            "beta": {"location": [1, 1, 1], "oxygenation": True, "context": {}},
+        }
+        fig = library.build_plotly_figure(hrfs)
+        hbo_trace = next(t for t in fig.data if t.name == "HbO")
+        assert list(hbo_trace.customdata) == ["alpha", "beta"]
+
+    def test_skips_missing_location(self):
+        hrfs = {
+            "good": {"location": [0, 1, 2], "oxygenation": True, "context": {}},
+            "no_loc": {"oxygenation": True, "context": {}},
+            "short": {"location": [0, 1], "oxygenation": True, "context": {}},
+        }
+        fig = library.build_plotly_figure(hrfs)
+        hbo_trace = next(t for t in fig.data if t.name == "HbO")
+        assert list(hbo_trace.customdata) == ["good"]
+
+    def test_empty_input_produces_zero_traces(self):
+        fig = library.build_plotly_figure({})
+        assert len(fig.data) == 0
+
+
+# ---------------------------------------------------------------------------
+# Click extraction
+# ---------------------------------------------------------------------------
+
+
+class TestExtractClickedHrfKey:
+    def test_returns_customdata_from_first_point(self):
+        class _Event:
+            args = {"points": [{"customdata": "the_key"}]}
+        assert library._extract_clicked_hrf_key(_Event()) == "the_key"
+
+    def test_returns_none_for_empty_points(self):
+        class _Event:
+            args = {"points": []}
+        assert library._extract_clicked_hrf_key(_Event()) is None
+
+    def test_returns_none_for_malformed_event(self):
+        class _Event:
+            args = None
+        assert library._extract_clicked_hrf_key(_Event()) is None
+
+
+# ---------------------------------------------------------------------------
+# /library page render — User fixture
+# ---------------------------------------------------------------------------
+
+
+async def test_library_page_renders_toolbar(user: User):
+    global_state.reset()
+    # Force-empty trees so we don't load 22 HRFs in the test render
+    global_state.library_hbo = type("FakeTree", (), {
+        "root": None,
+        "gather": lambda self, root: {},
+    })()
+    global_state.library_hbr = global_state.library_hbo
+    await user.open("/library")
+    await user.should_see("HRF Library")
+    await user.should_see("Back to welcome")
+
+
+async def test_library_page_shows_filter_pane(user: User):
+    global_state.reset()
+    global_state.library_hbo = type("FakeTree", (), {
+        "root": None,
+        "gather": lambda self, root: {},
+    })()
+    global_state.library_hbr = global_state.library_hbo
+    await user.open("/library")
+    await user.should_see("Filter")
+    await user.should_see("Narrow the visible HRFs")
+
+
+async def test_library_page_shows_empty_state_when_no_data(user: User):
+    """If both trees yield zero HRFs (or load failed), the center pane
+    surfaces a graceful message rather than rendering an empty plot."""
+    global_state.reset()
+    global_state.library_hbo = type("FakeTree", (), {
+        "root": None,
+        "gather": lambda self, root: {},
+    })()
+    global_state.library_hbr = global_state.library_hbo
+    await user.open("/library")
+    await user.should_see("Library trees not loaded")
+
+
+async def test_library_page_renders_with_real_data(user: User):
+    """End-to-end: real bundled HRFs load + filter + viz."""
+    global_state.reset()
+    _silent(library._load_trees, global_state)
+    await user.open("/library")
+    # The match-count label below the filter form should report the totals
+    await user.should_see("HRFs match")
+    # And the HRtree header in the center pane
+    await user.should_see("HRtree")
+
+
+async def test_library_detail_pane_prompt_when_no_selection(user: User):
+    global_state.reset()
+    global_state.library_hbo = type("FakeTree", (), {
+        "root": None,
+        "gather": lambda self, root: {},
+    })()
+    global_state.library_hbr = global_state.library_hbo
+    await user.open("/library")
+    await user.should_see("Click an HRF in the viz to inspect")
+
+
+async def test_library_render_clears_subscribers(user: User):
+    """Repeated page renders should not accumulate dead refreshable
+    handles. _render clears state.subscribers at the top, matching
+    workspace's pattern."""
+    global_state.reset()
+    global_state.library_hbo = type("FakeTree", (), {
+        "root": None,
+        "gather": lambda self, root: {},
+    })()
+    global_state.library_hbr = global_state.library_hbo
+    # Pre-load a junk subscriber that would survive a non-clearing render
+    leaked_calls = []
+    global_state.subscribe(
+        "library_filter_changed", lambda _p: leaked_calls.append(1)
+    )
+    await user.open("/library")
+    # After render, the pre-render subscriber should be gone (replaced
+    # by the library page's own subscribers).
+    global_state.publish("library_filter_changed", {})
+    assert leaked_calls == []
+    # And the library page's own subscribers are present
+    assert "library_filter_changed" in global_state.subscribers
+    assert len(global_state.subscribers["library_filter_changed"]) >= 1
+
+
+async def test_filter_count_annotates_missing_location_hrfs(user: User):
+    """The match-count label should make it clear when some matched
+    HRFs are excluded from the viz for lacking a 3D location — so the
+    user isn't confused by '5 / 22 match' while seeing only 3 points."""
+    global_state.reset()
+
+    class _FakeTree:
+        root = "non_none"
+
+        def gather(self, root):
+            return {
+                "with_loc": {
+                    "location": [0, 0, 0],
+                    "oxygenation": True,
+                    "context": {"task": "flanker"},
+                },
+                "no_loc": {
+                    "location": None,
+                    "oxygenation": True,
+                    "context": {"task": "flanker"},
+                },
+            }
+
+    global_state.library_hbo = _FakeTree()
+    global_state.library_hbr = type("EmptyTree", (), {
+        "root": None,
+        "gather": lambda self, root: {},
+    })()
+    await user.open("/library")
+    # Both HRFs match the (empty) filter; one lacks location.
+    await user.should_see("not visualizable: missing location")

--- a/tests/test_gui_welcome.py
+++ b/tests/test_gui_welcome.py
@@ -183,10 +183,13 @@ async def test_welcome_page_shows_version_in_footer(user: User):
 
 
 @pytest.mark.asyncio
-async def test_library_stub_renders(user: User):
+async def test_library_page_renders(user: User):
+    """Sprint 4.4 replaced the inline /library stub with the real Library
+    page; this test asserts the toolbar + a filter-pane header so the
+    welcome-flow test file knows /library is reachable."""
     await user.open("/library")
     await user.should_see("HRF Library")
-    await user.should_see("Full library browser lands in Sprint 4")
+    await user.should_see("Filter")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Sprint 4.2 + 4.3 + 4.4 ship together as one combined branch. The `/library` route — Browser-persona entry point — now has a real three-pane page: Context Filter sidebar, plotly 3D HRtree explorer, and HRF detail card. With this PR, the only remaining v1.3.0 placeholder is the Export tab (Sprint 5).

## What changed

### `state.py`
| Surface | Change |
|---|---|
| `library_hbo` / `library_hbr` | Lazy-loaded bundled HRF trees. NOT cleared by `reset()` (immutable on-disk data). |
| `library_filter` | Current context filter kwargs. Cleared by `reset()`. |
| `library_selected_hrf` | Currently-picked HRF for the detail pane. Cleared by `reset()`. |
| `"library_filter_changed"` / `"library_selection_changed"` events | New event-bus events. |

### `pages/library.py` (new, ~480 lines)
| Pane | What it does |
|---|---|
| **Filter (left)** | Six `ui.input` fields (task / doi / study / demographics / stimulus / conditions). Apply + Reset buttons. Refreshable live count: "N / M HRFs match (K not visualizable: missing location)". |
| **HRtree viz (center)** | `ui.plotly` 3D scatter, HbO red / HbR blue. Customdata = HRF key. Click → updates `state.library_selected_hrf` + publishes `library_selection_changed`. HRFs without 3D location are skipped (not fabricated at origin). |
| **Detail (right)** | Selected HRF's context dict + matplotlib trace preview (base64 PNG, ±1 std shading when available). |

### `app.py`
- `_register_pages` calls `library.register()`; inline `/library` stub gone.

### Documentation
- `docs/external/gui_guide.md` — new **HRF Library** section with full walkthrough (filter, viz, detail, limitations). Welcome-screen + troubleshooting sections updated.
- `README.md` — tab walkthrough promotes Quality + HRtree from "placeholder" to first-class.
- `CHANGELOG.md` — v1.3.0 entry extended.

## Dual review findings + fixes

Architecture + correctness reviews both said GO conditional on four real bugs. All four fixed before push:

| Bug | Severity | Fix |
|---|---|---|
| `library._render` didn't clear `state.subscribers` — repeat visits leak refreshable handles. | Critical | Added `state.subscribers.clear()` at top of `_render`, matching workspace.py. Test `test_library_render_clears_subscribers` covers it. |
| Filter count label rendered once, never refreshed on Apply. | UX | Wrapped count in `@ui.refreshable` subscribed to `library_filter_changed`. |
| Filter count and viz disagreed: count showed all matched HRFs, viz silently dropped location-less ones. | Data integrity | Count now annotated: "(K not visualizable: missing location)". Test `test_filter_count_annotates_missing_location_hrfs` covers it. |
| `_extract_clicked_hrf_key` silently swallowed exceptions. | Maintenance | Added `logger.warning` so a future plotly-API change surfaces. |

## Out of scope, flagged for later

- **Sync tree load.** ~100ms on first visit. Acceptable for 22 bundled HRFs; wrap in `background_tasks.create` if community contributions grow the database.
- **Per-click PNG re-render.** ~50-100ms per detail-pane refresh; cache by HRF key in v1.4.
- **Filter form covers 6 of ~10 context fields.** `intensity` / `protocol` / `age_range` / `duration` / `method` aren't exposed. Add a "show more" toggle in v1.4 if researchers ask.
- **No "Back to workspace" link** on the Library page. v1.3.x polish.
- **Filter semantics differ from `tree.compare_context`** (substring vs weighted-similarity-with-threshold). Documented in the sidebar copy.
- **`tree.gather()` prints heavily** — out-of-scope library refactor.

## Test plan

Full Sprint 4.2-4.4 gate (26 test files): **507 passed, zero regressions** (was 481 at end of 4.1; +26 new).

```
pytest tests/test_phase1a.py tests/test_phase1bc.py tests/test_phase2.py \
       tests/test_threading.py tests/test_input_validation.py \
       tests/test_state_lifecycle.py tests/test_oxygenation_guard.py \
       tests/test_tree_delete_filter.py tests/test_hasher_branch.py \
       tests/test_tree_hrf.py tests/test_canonical_hrf.py \
       tests/test_tree_edge_cases.py tests/test_observer_and_typos.py \
       tests/test_progress_callbacks.py tests/test_io_detect.py \
       tests/test_io_scan.py tests/test_io_raw_cache.py \
       tests/test_gui_foundation.py tests/test_gui_welcome.py \
       tests/test_gui_workspace.py tests/test_gui_scan_inspector.py \
       tests/test_gui_preprocess.py tests/test_gui_estimate_panel.py \
       tests/test_gui_activity_panel.py tests/test_gui_quality_panel.py \
       tests/test_gui_library.py -q
```

New test classes:
- `TestStateLibraryFields` (3) — defaults, reset clears filter + selection but not loaded trees.
- `TestApplyFilter` (7) — empty filter, substring match, case insensitivity, AND across keys, missing-key exclusion, list-value OR.
- `TestGatherLibraryHrfs` (2) — empty when trees None, combines real bundled trees.
- `TestBuildPlotlyFigure` (4) — two traces, customdata, skip missing location, empty input.
- `TestExtractClickedHrfKey` (3) — customdata extraction, empty points, malformed event.
- Page rendering (6) — toolbar, filter pane, empty-state, real-data, detail prompt, subscriber clear guard, missing-location annotation.

Also renamed `test_library_stub_renders` to `test_library_page_renders` in `test_gui_welcome.py` since the stub copy is gone.

- [x] All tests pass on macOS Darwin / Python 3.12
- [x] Editable install verified
- [ ] Manual smoke test against the bundled HRF database — click into /library, apply filters (`doi=temp` and `task=flanker` are useful starters), rotate the 3D viz, click a point and inspect the detail card (recommended before merge — none of the automated tests exercise the plotly click round-trip in a browser)

🤖 Generated with [Claude Code](https://claude.com/claude-code)