### PR TITLE
feat: HRF gallery + Export tab + v1.3.0 version bump (GUI Sprint 5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,13 @@
 - New: HRF Library page at `/library` — three-pane Browser-persona
   flow with Context Filter sidebar, plotly 3D HRtree viz, and per-HRF
   detail pane with trace preview
+- New: HRF gallery — HRFs-tab preview replaced by a clickable channel
+  grid (one mini-plot per channel) with a per-channel detail panel
+  showing full trace + ±1 std shading
+- New: Export tab — saves processed Raw (SNIRF/FIF), activity Raw
+  (SNIRF/FIF), montage HRFs (JSON via montage.save), per-channel HRF
+  plot PNGs to a folder, and quality metrics as a flat CSV (one row
+  per scan × stage)
 - New: Cross-component event bus (`scan_selected`, `scan_loaded`,
   `preprocess_done`, `hrf_estimated`, `activity_estimated`,
   `quality_computed`, `library_filter_changed`,

--- a/README.md
+++ b/README.md
@@ -79,7 +79,8 @@ The workspace exposes seven tabs that mirror the analysis pipeline:
    literature HRF database, with a context filter sidebar (task, doi,
    study, demographics, stimulus, conditions) and a per-HRF detail
    pane with trace preview.
-7. **Export** — placeholder, landing in Sprint 5.
+7. **Export** — saves preprocessed Raw, activity Raw, montage HRFs
+   JSON, per-channel HRF PNGs, and quality metrics CSV.
 
 A 3-pane workspace with a BIDS-aware dataset tree on the left, tabbed
 analysis surface in the middle, and a manifest summary on the right.

--- a/docs/external/gui_guide.md
+++ b/docs/external/gui_guide.md
@@ -185,8 +185,11 @@ regardless of scan sampling rate), which deliberately differs from
 the library's internal `correlate_canonical` (sample-indexed, scan-rate
 dependent).
 
-After a successful run, all estimated HRF traces are overlaid on a
-single line plot in the preview.
+After a successful run, the gallery renders a **clickable channel
+grid** — one mini-plot per channel — and a detail panel below showing
+the currently-focused channel's full trace with ±1 standard-deviation
+shading. Click any mini-plot to focus a different channel; the grid
+highlights the active selection.
 
 ---
 
@@ -410,11 +413,44 @@ The matplotlib render failed (most often: the channel you picked was
 dropped during estimation and the deconvolved Raw has fewer channels
 than the processed Raw). Pick a different channel from the dropdown.
 
-### Export tab says "Coming in Sprint 5"
+### Export tab is empty after I clicked Save
 
-The Export panel (and HRF gallery, scheduled to merge alongside it) is
-the only remaining placeholder in v1.3.0. Tracking issues on the
-[HRFunc repository](https://github.com/dennys246/HRFunc).
+Each exporter only enables when its source data is in state. If the
+button is greyed out, the row's "italic hint" line tells you what to
+do next (e.g. "Run the HRFs tab in toeplitz mode first" or "Compute
+metrics in the Quality tab first"). The Save button is disabled, not
+hidden — so you can see all five exporters at a glance even when only
+one is ready.
+
+### Save dialog doesn't appear
+
+The Export panel uses `pywebview`'s native save/folder dialogs. Same
+fallback as the welcome-screen folder picker — if no native window is
+attached (e.g. launching via `python -m hrfunc.gui.app` instead of the
+`hrfunc` console script), the panel shows a NiceGUI toast telling you
+to launch in native mode.
+
+### SNIRF export of haemoglobin / activity data
+
+The Export panel writes whatever's in the source Raw to the chosen
+SNIRF file. For round-trip workflows (export → re-load in MNE), prefer
+`.fif` over `.snirf` when exporting **preprocessed** or **activity**
+data — FIF preserves the full MNE channel-type metadata (`hbo`, `hbr`,
+plus user-added types), whereas SNIRF's data-type indices may not
+round-trip the haemoglobin / neural-activity unit information cleanly.
+If you only need the data values (e.g. for analysis in software that
+re-derives types from channel names), SNIRF is fine.
+
+### "N channels dropped during deconvolution" in the activity-save toast
+
+`estimate_activity` silently drops channels whose Tikhonov-regularized
+lstsq solve fails or times out (default 30 s ceiling per channel). The
+exported activity Raw has these channels removed. The save-toast now
+surfaces the count so you know if the output has fewer channels than
+the preprocessed source. If the count is non-zero, check
+`state.last_error` and the underlying console output for which
+channels failed — typically caused by pathological lstsq matrices on
+all-bad-channel inputs.
 
 ### GUI crashes on launch with a port-binding error
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hrfunc"
-version = "1.1.2"
+version = "1.3.0"
 description = "Tools for modeling HRFs and estimating neural activity from fNIRS brain signals"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/src/hrfunc/gui/components/export_panel.py
+++ b/src/hrfunc/gui/components/export_panel.py
@@ -1,0 +1,528 @@
+"""Export tab — save analysis artifacts to disk.
+
+Sprint 5 final piece. Each section of the panel corresponds to one
+artifact the workspace can produce and exposes a button that opens an
+OS save dialog (or directory picker for multi-file exports) and writes
+the data. Buttons disable themselves when the source artifact isn't
+in state (e.g. "Export montage HRFs" is dim until estimate_hrf has
+run).
+
+Exporters
+---------
+
+- **Processed Raw (SNIRF/FIF)** — `state.processed_cache[selected_scan]
+  .save(path)`. Output of the Preprocess tab.
+- **Activity Raw (SNIRF/FIF)** — `state.activity_raw.save(path)`. Output
+  of the Activity tab.
+- **Montage HRFs (JSON)** — `state.montage.save(path)`. The estimated
+  HRFs from the HRFs tab in their canonical on-disk form (the same
+  format that `tree.load_hrfs` consumes).
+- **HRF plot PNGs (folder)** — writes one PNG per channel to a chosen
+  directory. Re-uses the gallery's mini-plot renderer for consistency.
+- **Quality metrics (CSV)** — flattens `state.quality_metrics` to one
+  row per (scan, stage) with the SNR/skew/kurtosis/SCI columns.
+
+File dialogs use pywebview's SAVE_DIALOG / FOLDER_DIALOG via
+`app.native.main_window`. Tests can monkeypatch ``_pick_save_path`` /
+``_pick_folder_path`` so they don't try to open real dialogs.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import csv
+import io as _io
+import logging
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Iterable, List, Optional, Tuple
+
+from nicegui import app, ui
+
+from ..state import AppState
+from .hrf_panel import _CanonicalResult
+
+if TYPE_CHECKING:
+    import mne
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Panel render
+# ---------------------------------------------------------------------------
+
+
+def render(state: AppState) -> None:
+    """Render the Export tab inside the current NiceGUI context."""
+
+    @ui.refreshable
+    def _body() -> None:
+        _render_body(state)
+
+    _body()
+
+    def _refresh(_payload=None) -> None:
+        _body.refresh()
+
+    state.subscribe("scan_selected", _refresh)
+    state.subscribe("scan_loaded", _refresh)
+    state.subscribe("preprocess_done", _refresh)
+    state.subscribe("hrf_estimated", _refresh)
+    state.subscribe("activity_estimated", _refresh)
+    state.subscribe("quality_computed", _refresh)
+
+
+def _render_body(state: AppState) -> None:
+    """Render the Export tab body against current state."""
+    scan = state.selected_scan
+    with ui.column().classes("p-6 gap-4 w-full"):
+        ui.label("Export").classes("text-2xl font-semibold")
+        ui.label(
+            "Save analysis artifacts produced by the workspace. Each row "
+            "is enabled when its source data is available — preprocess "
+            "first, estimate HRFs, run Activity, or run Quality to unlock "
+            "the corresponding exports."
+        ).classes("text-sm opacity-70")
+
+        if scan is None:
+            ui.label("Select a scan from the dataset tree.").classes(
+                "text-sm opacity-60"
+            )
+            return
+
+        ui.label(scan.display_name or scan.path.name).classes(
+            "text-sm font-mono opacity-70"
+        )
+
+        # ── Processed Raw
+        _render_row(
+            "Processed Raw",
+            "Output of the Preprocess tab. Saves as SNIRF (.snirf) or FIF "
+            "(.fif) — extension on the chosen filename decides the format.",
+            available=(scan in state.processed_cache),
+            unavailable_hint="Run the Preprocess tab first.",
+            button_label="Save processed scan…",
+            on_click=lambda: _save_processed(state, scan),
+        )
+
+        # ── Activity Raw
+        _render_row(
+            "Activity Raw",
+            "Deconvolved neural-activity output of the Activity tab. Saves "
+            "as SNIRF or FIF.",
+            available=(state.activity_raw is not None),
+            unavailable_hint="Run the Activity tab first.",
+            button_label="Save activity scan…",
+            on_click=lambda: _save_activity(state, scan),
+        )
+
+        # ── Montage HRFs
+        toeplitz_montage_ready = (
+            state.montage is not None
+            and not isinstance(state.montage, _CanonicalResult)
+        )
+        _render_row(
+            "Montage HRFs (JSON)",
+            "Per-channel estimated HRFs and their context, in the same "
+            "JSON format that `hrfunc.tree.load_hrfs` consumes.",
+            available=toeplitz_montage_ready,
+            unavailable_hint=(
+                "Run the HRFs tab in toeplitz mode first (canonical mode "
+                "produces a reference shape, not estimated HRFs)."
+            ),
+            button_label="Save montage HRFs…",
+            on_click=lambda: _save_montage(state, scan),
+        )
+
+        # ── HRF plot PNGs
+        _render_row(
+            "HRF plots (PNG folder)",
+            "One PNG per channel — same renderer the HRFs-tab gallery "
+            "uses. Saved to a chosen directory.",
+            available=toeplitz_montage_ready,
+            unavailable_hint="Run the HRFs tab in toeplitz mode first.",
+            button_label="Save HRF plots…",
+            on_click=lambda: _save_hrf_plots(state, scan),
+        )
+
+        # ── Quality metrics CSV
+        quality_ready = bool(state.quality_metrics)
+        _render_row(
+            "Quality metrics (CSV)",
+            "Flat CSV of the metrics computed by the Quality tab — one "
+            "row per (scan, stage) with SNR / skewness / kurtosis / SCI "
+            "columns.",
+            available=quality_ready,
+            unavailable_hint="Compute metrics in the Quality tab first.",
+            button_label="Save quality CSV…",
+            on_click=lambda: _save_quality_csv(state),
+        )
+
+        if state.last_error:
+            with ui.row().classes("items-center gap-2"):
+                ui.icon("error_outline").classes("text-red-400")
+                ui.label(state.last_error).classes("text-sm text-red-400")
+
+
+def _render_row(
+    title: str,
+    description: str,
+    available: bool,
+    unavailable_hint: str,
+    button_label: str,
+    on_click,
+) -> None:
+    """Render one export-row card."""
+    with ui.card().classes("w-full"):
+        with ui.row().classes("w-full items-start justify-between gap-3"):
+            with ui.column().classes("flex-grow gap-1"):
+                ui.label(title).classes(
+                    "text-sm uppercase tracking-wide"
+                )
+                ui.label(description).classes("text-xs opacity-70")
+                if not available:
+                    ui.label(unavailable_hint).classes(
+                        "text-xs opacity-60 italic"
+                    )
+            with ui.column().classes("items-end gap-1"):
+                ui.button(
+                    button_label, on_click=on_click,
+                ).props(f"color=primary {'disable' if not available else ''}")
+
+
+# ---------------------------------------------------------------------------
+# Click handlers (async because they await the file dialog)
+# ---------------------------------------------------------------------------
+
+
+async def _save_processed(state: AppState, scan) -> None:
+    if scan not in state.processed_cache:
+        state.last_error = "No preprocessed scan available."
+        return
+    path = await _pick_save_path(
+        suggested=f"{scan.path.stem}_processed.snirf",
+        title="Save processed scan",
+    )
+    if path is None:
+        return
+    raw = state.processed_cache.get(scan)
+    try:
+        await asyncio.get_event_loop().run_in_executor(
+            None, _save_raw, raw, path
+        )
+        ui.notify(f"Saved processed scan: {path.name}", type="positive")
+    except Exception as exc:  # noqa: BLE001
+        state.last_error = f"Save failed: {type(exc).__name__}: {exc}"
+        logger.exception("processed save failed: %s", exc)
+        ui.notify(state.last_error, type="negative")
+
+
+async def _save_activity(state: AppState, scan) -> None:
+    if state.activity_raw is None:
+        state.last_error = "No activity scan available."
+        return
+    path = await _pick_save_path(
+        suggested=f"{scan.path.stem}_activity.snirf",
+        title="Save activity scan",
+    )
+    if path is None:
+        return
+    # estimate_activity drops channels whose lstsq solve failed
+    # (hrfunc.py:599 + 606-611). Surface the count so the user knows
+    # if the exported file has fewer channels than the source.
+    saved_count = len(state.activity_raw.ch_names)
+    source_count = (
+        len(state.processed_cache.get(scan).ch_names)
+        if scan in state.processed_cache
+        else saved_count
+    )
+    dropped = source_count - saved_count
+    try:
+        await asyncio.get_event_loop().run_in_executor(
+            None, _save_raw, state.activity_raw, path
+        )
+        notice = f"Saved activity scan: {path.name}"
+        if dropped > 0:
+            notice += f" ({dropped} channel(s) dropped during deconvolution)"
+        ui.notify(notice, type="positive")
+    except Exception as exc:  # noqa: BLE001
+        state.last_error = f"Save failed: {type(exc).__name__}: {exc}"
+        logger.exception("activity save failed: %s", exc)
+        ui.notify(state.last_error, type="negative")
+
+
+async def _save_montage(state: AppState, scan) -> None:
+    montage = state.montage
+    if montage is None or isinstance(montage, _CanonicalResult):
+        state.last_error = "No estimated montage to save."
+        return
+    path = await _pick_save_path(
+        suggested=f"{scan.path.stem}_hrfs.json",
+        title="Save montage HRFs",
+    )
+    if path is None:
+        return
+    try:
+        await asyncio.get_event_loop().run_in_executor(
+            None, save_montage_sync, montage, path
+        )
+        ui.notify(f"Saved montage: {path.name}", type="positive")
+    except Exception as exc:  # noqa: BLE001
+        state.last_error = f"Save failed: {type(exc).__name__}: {exc}"
+        logger.exception("montage save failed: %s", exc)
+        ui.notify(state.last_error, type="negative")
+
+
+async def _save_hrf_plots(state: AppState, scan) -> None:
+    montage = state.montage
+    if montage is None or isinstance(montage, _CanonicalResult):
+        state.last_error = "No estimated montage to save."
+        return
+    folder = await _pick_folder_path(title="Save HRF plots to folder")
+    if folder is None:
+        return
+    try:
+        count = await asyncio.get_event_loop().run_in_executor(
+            None, save_hrf_plots_sync, montage, folder, scan.path.stem
+        )
+        ui.notify(
+            f"Saved {count} HRF plots to {folder.name}/", type="positive"
+        )
+    except Exception as exc:  # noqa: BLE001
+        state.last_error = f"Save failed: {type(exc).__name__}: {exc}"
+        logger.exception("HRF plots save failed: %s", exc)
+        ui.notify(state.last_error, type="negative")
+
+
+async def _save_quality_csv(state: AppState) -> None:
+    if not state.quality_metrics:
+        state.last_error = "No quality metrics computed yet."
+        return
+    path = await _pick_save_path(
+        suggested="quality_metrics.csv",
+        title="Save quality metrics CSV",
+    )
+    if path is None:
+        return
+    try:
+        rows = await asyncio.get_event_loop().run_in_executor(
+            None, save_quality_csv_sync, state.quality_metrics, path
+        )
+        ui.notify(
+            f"Saved {rows} rows to {path.name}", type="positive"
+        )
+    except Exception as exc:  # noqa: BLE001
+        state.last_error = f"Save failed: {type(exc).__name__}: {exc}"
+        logger.exception("quality CSV save failed: %s", exc)
+        ui.notify(state.last_error, type="negative")
+
+
+# ---------------------------------------------------------------------------
+# Sync workers (module-level so tests can call without async dispatch)
+# ---------------------------------------------------------------------------
+
+
+def _save_raw(raw: "mne.io.BaseRaw", path: Path) -> None:
+    """Save an MNE Raw to SNIRF or FIF based on file extension.
+
+    MNE doesn't expose a single ``raw.save()`` that handles both formats;
+    ``mne.export.export_raw`` does SNIRF and the Raw's own ``.save()`` does
+    FIF. Dispatch on extension.
+    """
+    raw.load_data()
+    suffix = path.suffix.lower()
+    if suffix == ".snirf":
+        import mne
+        mne.export.export_raw(str(path), raw, fmt="snirf", overwrite=True)
+    elif suffix == ".fif":
+        raw.save(str(path), overwrite=True, verbose="ERROR")
+    else:
+        raise ValueError(
+            f"Unsupported extension {suffix!r}; use .snirf or .fif"
+        )
+
+
+def save_montage_sync(montage, path: Path) -> None:
+    """Save a Montage's estimated HRFs to JSON via montage.save()."""
+    montage.save(str(path))
+
+
+def save_hrf_plots_sync(montage, folder: Path, prefix: str) -> int:
+    """Write one PNG per channel into ``folder`` and return the count.
+
+    Uses the same matplotlib renderer as the HRFs-tab gallery detail
+    panel (full-size with std shading) so the saved plots match what the
+    user previewed in the GUI.
+    """
+    try:
+        import matplotlib
+        matplotlib.use("Agg", force=False)
+        import matplotlib.pyplot as plt
+        import numpy as np
+    except Exception as exc:  # noqa: BLE001
+        raise RuntimeError(f"matplotlib unavailable: {exc}") from exc
+
+    folder.mkdir(parents=True, exist_ok=True)
+    channels = getattr(montage, "channels", {})
+    count = 0
+    for ch_name, node in channels.items():
+        trace = getattr(node, "trace", None)
+        if trace is None or len(trace) == 0:
+            continue
+        sfreq = float(getattr(node, "sfreq", 1.0) or 1.0)
+        if sfreq <= 0:
+            sfreq = 1.0
+        t = np.arange(len(trace)) / sfreq
+        std = getattr(node, "trace_std", None)
+
+        fig, ax = plt.subplots(1, 1, figsize=(6, 3))
+        try:
+            ax.plot(t, trace, lw=1.3, color="#6366f1", label=ch_name)
+            if std is not None and len(std) == len(trace):
+                arr = np.asarray(trace)
+                std_arr = np.asarray(std)
+                ax.fill_between(
+                    t, arr - std_arr, arr + std_arr,
+                    alpha=0.18, color="#6366f1", label="±1 std",
+                )
+            ax.set_xlabel("time (s)")
+            ax.set_ylabel("amplitude (a.u.)")
+            ax.set_title(f"{prefix}: {ch_name}")
+            ax.legend(fontsize=8, loc="upper right")
+            fig.tight_layout()
+            safe_name = _safe_filename(ch_name)
+            out_path = folder / f"{prefix}_{safe_name}.png"
+            fig.savefig(out_path, dpi=110, bbox_inches="tight")
+            count += 1
+        finally:
+            plt.close(fig)
+    return count
+
+
+def save_quality_csv_sync(quality_metrics: dict, path: Path) -> int:
+    """Flatten ``state.quality_metrics`` to one row per (scan, stage).
+
+    Returns the number of rows written (header excluded).
+    """
+    columns = [
+        "scan_path",
+        "stage",
+        "n_channels",
+        "snr_mean",
+        "skew_mean",
+        "kurtosis_mean",
+        "sci_mean",
+    ]
+    rows: List[List[Any]] = []
+    for scan_path, stages in quality_metrics.items():
+        for stage_name, metrics in stages.items():
+            rows.append([
+                str(scan_path),
+                stage_name,
+                _attr(metrics, "n_channels", 0),
+                _attr(metrics, "snr_mean", ""),
+                _attr(metrics, "skew_mean", ""),
+                _attr(metrics, "kurtosis_mean", ""),
+                _attr(metrics, "sci_mean", ""),
+            ])
+
+    with open(path, "w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(columns)
+        writer.writerows(rows)
+    return len(rows)
+
+
+def _attr(obj, name: str, fallback: Any) -> Any:
+    """Pull a possibly-missing attribute from a QualityMetrics dataclass-or-dict."""
+    if obj is None:
+        return fallback
+    value = getattr(obj, name, None)
+    if value is None and isinstance(obj, dict):
+        value = obj.get(name)
+    return fallback if value is None else value
+
+
+def _safe_filename(name: str) -> str:
+    """Sanitize a string for use as a cross-platform filename.
+
+    Replaces any character that's not alphanumeric, dash, underscore, or
+    dot with an underscore. Windows forbids ``\\ / : * ? " < > |`` and
+    treats trailing dots/spaces specially; this conservative whitelist
+    handles all of those without per-platform branching. Also collapses
+    runs of underscores and strips leading/trailing dots so we don't
+    accidentally produce hidden files on Unix.
+    """
+    sanitized = "".join(
+        c if (c.isalnum() or c in "-_.") else "_" for c in name
+    )
+    while "__" in sanitized:
+        sanitized = sanitized.replace("__", "_")
+    return sanitized.strip("._") or "channel"
+
+
+# ---------------------------------------------------------------------------
+# File dialog helpers
+# ---------------------------------------------------------------------------
+
+
+async def _pick_save_path(suggested: str, title: str) -> Optional[Path]:
+    """Open the OS save-file dialog. Returns None on cancel."""
+    try:
+        import webview
+    except ImportError:
+        ui.notify("pywebview not installed", type="negative")
+        return None
+
+    window = getattr(app, "native", None) and app.native.main_window
+    if window is None:
+        ui.notify(
+            "Save dialog requires native window mode. "
+            "Launch with `hrfunc` (not via browser).",
+            type="warning",
+        )
+        return None
+
+    loop = asyncio.get_event_loop()
+    result = await loop.run_in_executor(
+        None,
+        lambda: window.create_file_dialog(
+            webview.SAVE_DIALOG,
+            save_filename=suggested,
+        ),
+    )
+    if not result:
+        return None
+    # pywebview returns a string for SAVE_DIALOG and a list for OPEN/FOLDER
+    if isinstance(result, (list, tuple)):
+        result = result[0]
+    return Path(result)
+
+
+async def _pick_folder_path(title: str) -> Optional[Path]:
+    """Open the OS folder picker. Returns None on cancel."""
+    try:
+        import webview
+    except ImportError:
+        ui.notify("pywebview not installed", type="negative")
+        return None
+
+    window = getattr(app, "native", None) and app.native.main_window
+    if window is None:
+        ui.notify(
+            "Folder picker requires native window mode.",
+            type="warning",
+        )
+        return None
+
+    loop = asyncio.get_event_loop()
+    paths = await loop.run_in_executor(
+        None,
+        lambda: window.create_file_dialog(webview.FOLDER_DIALOG),
+    )
+    if not paths:
+        return None
+    return Path(paths[0])

--- a/src/hrfunc/gui/components/hrf_panel.py
+++ b/src/hrfunc/gui/components/hrf_panel.py
@@ -104,6 +104,10 @@ def render(state: AppState) -> None:
     state.subscribe("scan_loaded", _refresh)
     state.subscribe("preprocess_done", _refresh)
     state.subscribe("hrf_estimated", _refresh)
+    # Dedicated event for gallery channel-pick refreshes — fires only the
+    # HRFs-tab body re-render, avoiding the 6-subscriber re-render
+    # cascade that republishing hrf_estimated would cause.
+    state.subscribe("hrf_selection_changed", _refresh)
 
     # Progress polling timer — refreshes the body every 0.5 s WHILE an
     # estimation is in flight, so the progress bar advances. The
@@ -556,22 +560,117 @@ def sorted_unique_annotation_descriptions(raw: "mne.io.BaseRaw") -> List[str]:
 def _render_hrf_preview(
     state: AppState, scan: ScanEntry, opts: EstimationOptions
 ) -> None:
-    """Render the matplotlib preview of the most-recent estimation result."""
+    """Render the most-recent estimation result.
+
+    Canonical mode: single SPM-style line plot.
+    Toeplitz mode (Sprint 5.1): clickable channel grid of mini-plots,
+    plus a per-channel detail panel below when the user picks a channel.
+    """
     result = state.montage
     if result is None:
         return
     if isinstance(result, _CanonicalResult):
         png = _render_canonical_preview_png(result)
-    else:
-        png = _render_toeplitz_preview_png(result)
-    if png is None:
-        ui.label("Preview unavailable.").classes("text-sm opacity-60")
+        if png is None:
+            ui.label("Preview unavailable.").classes("text-sm opacity-60")
+            return
+        ui.image(png).classes("max-w-3xl")
         return
-    ui.image(png).classes("max-w-3xl")
+
+    _render_toeplitz_gallery(state, result)
 
 
-def _render_toeplitz_preview_png(montage) -> Optional[str]:
-    """Overlay all channel HRF traces on a single matplotlib axes."""
+def _render_toeplitz_gallery(state: AppState, montage) -> None:
+    """Per-channel HRF gallery: clickable mini-plots + detail panel.
+
+    The mini-plots are rendered as base64 PNGs so they're inert (no plotly
+    state); clicks are wired through a ``ui.element`` wrapper around each
+    image that calls a closure setting ``state.hrf_selected_channel``. A
+    second ``@ui.refreshable`` block below the grid renders the full-size
+    plot for the currently-selected channel (with ±1 std shading).
+    """
+    channels = _gather_channel_traces(montage)
+    if not channels:
+        ui.label("No channel HRFs available.").classes("text-sm opacity-60")
+        return
+
+    if (
+        state.hrf_selected_channel is None
+        or state.hrf_selected_channel not in channels
+    ):
+        # Default-focus on the first channel so users see a detail view
+        # immediately rather than a blank "click one" prompt.
+        state.hrf_selected_channel = next(iter(channels))
+
+    # ── Grid of mini-plots
+    with ui.row().classes("flex-wrap gap-2 max-w-4xl"):
+        for ch_name in channels.keys():
+            png = _render_mini_hrf_png(channels[ch_name])
+            selected = ch_name == state.hrf_selected_channel
+            border = "border-primary border-2" if selected else "border border-slate-700"
+            with ui.element("div").classes(
+                f"cursor-pointer rounded p-1 {border}"
+            ).on(
+                "click", lambda c=ch_name: _on_channel_click(state, c)
+            ):
+                if png is not None:
+                    ui.image(png).classes("w-32 h-20")
+                ui.label(ch_name).classes(
+                    "text-xs font-mono opacity-80 text-center w-32"
+                )
+
+    # ── Detail panel for the selected channel
+    selected = state.hrf_selected_channel
+    if selected and selected in channels:
+        ui.separator()
+        ui.label(f"Channel detail — {selected}").classes(
+            "text-xs uppercase opacity-60 tracking-wide"
+        )
+        png = _render_detail_hrf_png(channels[selected], selected)
+        if png is not None:
+            ui.image(png).classes("max-w-2xl")
+
+
+def _on_channel_click(state: AppState, ch_name: str) -> None:
+    """Update the selected channel and publish the focused-refresh event.
+
+    Uses ``hrf_selection_changed`` (HRFs-tab-only) rather than
+    ``hrf_estimated`` (all 6 tab subscribers) so a click in the gallery
+    doesn't cause every other panel to re-render. The payload is the
+    new channel name so future subscribers can act on it without a
+    state lookup.
+    """
+    state.hrf_selected_channel = ch_name
+    state.publish("hrf_selection_changed", ch_name)
+
+
+def _gather_channel_traces(montage):
+    """Pull (ch_name → node) out of a Montage's channels, skipping empties.
+
+    Module-level so tests can call it directly. Filters out channels whose
+    ``trace`` attribute is missing, empty, or all-zeros — those would
+    render as blank plots and confuse the gallery UX.
+    """
+    import numpy as np
+
+    out = {}
+    channels = getattr(montage, "channels", {})
+    for ch_name, node in channels.items():
+        trace = getattr(node, "trace", None)
+        if trace is None:
+            continue
+        try:
+            arr = np.asarray(trace)
+            if arr.size == 0 or not np.any(np.abs(arr) > 0):
+                continue
+        except Exception:  # noqa: BLE001
+            continue
+        out[ch_name] = node
+    return out
+
+
+def _render_mini_hrf_png(node) -> Optional[str]:
+    """Render a tiny PNG for one channel's HRF — used in the gallery grid."""
     try:
         import matplotlib
         matplotlib.use("Agg", force=False)
@@ -580,34 +679,75 @@ def _render_toeplitz_preview_png(montage) -> Optional[str]:
         logger.warning("matplotlib unavailable: %s", exc)
         return None
 
+    trace = getattr(node, "trace", None)
+    if trace is None or len(trace) == 0:
+        return None
+
     fig = None
     try:
-        fig, ax = plt.subplots(1, 1, figsize=(8, 4))
-        channels = getattr(montage, "channels", {})
-        plotted = 0
-        for ch_name, node in channels.items():
-            trace = getattr(node, "trace", None)
-            if trace is None or len(trace) == 0:
-                continue
-            ax.plot(trace, lw=0.6, alpha=0.7, label=ch_name)
-            plotted += 1
-        if plotted == 0:
-            ax.text(
-                0.5, 0.5, "No channel HRFs available.",
-                ha="center", va="center", transform=ax.transAxes,
+        fig, ax = plt.subplots(1, 1, figsize=(1.6, 1.0))
+        ax.plot(trace, lw=0.8, color="#6366f1")
+        ax.set_xticks([])
+        ax.set_yticks([])
+        ax.spines["top"].set_visible(False)
+        ax.spines["right"].set_visible(False)
+        fig.tight_layout(pad=0.1)
+        buf = io.BytesIO()
+        fig.savefig(buf, format="png", dpi=80, bbox_inches="tight")
+        return f"data:image/png;base64,{base64.b64encode(buf.getvalue()).decode('ascii')}"
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("mini HRF render failed: %s", exc)
+        return None
+    finally:
+        if fig is not None:
+            plt.close(fig)
+
+
+def _render_detail_hrf_png(node, ch_name: str) -> Optional[str]:
+    """Render a full-size HRF plot for the currently-selected channel.
+
+    Shows the trace plus ±1 standard-deviation shading when ``trace_std``
+    is available. Time axis in seconds (computed from the node's sfreq).
+    """
+    try:
+        import matplotlib
+        matplotlib.use("Agg", force=False)
+        import matplotlib.pyplot as plt
+        import numpy as np
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("matplotlib unavailable: %s", exc)
+        return None
+
+    trace = getattr(node, "trace", None)
+    if trace is None or len(trace) == 0:
+        return None
+    sfreq = float(getattr(node, "sfreq", 1.0) or 1.0)
+    if sfreq <= 0:
+        sfreq = 1.0
+
+    fig = None
+    try:
+        t = np.arange(len(trace)) / sfreq
+        std = getattr(node, "trace_std", None)
+        fig, ax = plt.subplots(1, 1, figsize=(7, 3))
+        ax.plot(t, trace, lw=1.4, color="#6366f1", label=ch_name)
+        if std is not None and len(std) == len(trace):
+            arr = np.asarray(trace)
+            std_arr = np.asarray(std)
+            ax.fill_between(
+                t, arr - std_arr, arr + std_arr,
+                alpha=0.18, color="#6366f1",
+                label="±1 std",
             )
-        ax.set_title("Estimated HRFs (toeplitz deconvolution)")
-        ax.set_xlabel("samples")
+        ax.set_xlabel("time (s)")
         ax.set_ylabel("amplitude (a.u.)")
-        if plotted <= 24:
-            ax.legend(fontsize=6, loc="upper right")
+        ax.legend(fontsize=8, loc="upper right")
         fig.tight_layout()
         buf = io.BytesIO()
         fig.savefig(buf, format="png", dpi=100, bbox_inches="tight")
-        encoded = base64.b64encode(buf.getvalue()).decode("ascii")
-        return f"data:image/png;base64,{encoded}"
+        return f"data:image/png;base64,{base64.b64encode(buf.getvalue()).decode('ascii')}"
     except Exception as exc:  # noqa: BLE001
-        logger.warning("toeplitz preview render failed: %s", exc)
+        logger.warning("detail HRF render failed: %s", exc)
         return None
     finally:
         if fig is not None:

--- a/src/hrfunc/gui/pages/workspace.py
+++ b/src/hrfunc/gui/pages/workspace.py
@@ -44,6 +44,7 @@ from nicegui import background_tasks, ui
 from ..components import (
     activity_panel,
     dataset_tree,
+    export_panel,
     hrf_panel,
     preprocess_panel,
     quality_panel,
@@ -277,11 +278,13 @@ def _render_tab_panel(name: str, state: AppState) -> None:
     if name == "Quality":
         quality_panel.render(state)
         return
+    if name == "Export":
+        export_panel.render(state)
+        return
 
     # Map each placeholder tab to the sprint that fills it in.
     next_sprint = {
-        "HRtree": "Sprint 4 (plotly 3D explorer)",
-        "Export": "Sprint 5 (export panel)",
+        "HRtree": "Sprint 4 (plotly 3D explorer at /library)",
     }.get(name, "a future sprint")
 
     with ui.column().classes("p-6 gap-2"):

--- a/src/hrfunc/gui/state.py
+++ b/src/hrfunc/gui/state.py
@@ -144,6 +144,12 @@ class AppState:
     # plotly viz or a manual list selection). Stored as the gathered-form
     # dict (the value type produced by ``tree.gather``), or None.
     library_selected_hrf: Optional[Dict[str, Any]] = None
+    # Channel name selected for the HRF gallery's detail-pane focus
+    # (Sprint 5.1). Sprint 3.3 rendered all channel HRFs overlaid on one
+    # plot; Sprint 5 replaces that with a clickable grid + a per-channel
+    # full-detail view. None = no channel focused yet (grid renders, no
+    # detail view).
+    hrf_selected_channel: Optional[str] = None
 
     def subscribe(self, event: str, callback: EventCallback) -> None:
         """Register ``callback`` to be called on ``publish(event, ...)``.
@@ -217,6 +223,7 @@ class AppState:
         # re-loading on every dataset switch would burn ~100 ms unnecessarily.
         self.library_filter.clear()
         self.library_selected_hrf = None
+        self.hrf_selected_channel = None
 
 
 # Module-level singleton. Page handlers and components import this directly.

--- a/tests/test_gui_export.py
+++ b/tests/test_gui_export.py
@@ -1,0 +1,327 @@
+"""Targeted unit tests for feat/gui-sprint-5-polish (v1.3.0 Sprint 5).
+
+Covers the Export panel side of Sprint 5:
+
+- ``state.hrf_selected_channel`` field default + reset behavior.
+- ``save_montage_sync`` — delegates to ``montage.save``.
+- ``save_hrf_plots_sync`` — writes one PNG per channel with non-empty
+  trace; mkdir's the target folder; skips degenerate channels.
+- ``save_quality_csv_sync`` — flattens state.quality_metrics to a CSV;
+  header columns match the QualityMetrics fields; one row per
+  (scan, stage).
+- Export panel render — five rows present, each appropriately
+  enabled/disabled based on what's in state.
+- Workspace dispatches Export tab to the panel.
+"""
+
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+
+pytest.importorskip("nicegui")
+
+from nicegui.testing import User  # noqa: E402
+
+pytest_plugins = ["nicegui.testing.user_plugin"]
+
+from hrfunc.gui import app as gui_app  # noqa: E402
+from hrfunc.gui.components import export_panel, hrf_panel, quality_panel  # noqa: E402
+from hrfunc.gui.state import AppState, state as global_state  # noqa: E402
+from hrfunc.io.manifest import Manifest, ScanEntry  # noqa: E402
+
+gui_app._register_pages()
+
+
+def _make_fake_raw():
+    import mne
+    info = mne.create_info(
+        ch_names=["S1_D1 hbo", "S1_D1 hbr"], sfreq=10.0, ch_types="misc"
+    )
+    return mne.io.RawArray(np.zeros((2, 50)), info, verbose="ERROR")
+
+
+class _FakeNode:
+    """Minimal HRF-node-like object for testing the gallery + plot exporters."""
+
+    def __init__(self, trace, trace_std=None, sfreq=10.0):
+        self.trace = np.asarray(trace, dtype=np.float64)
+        self.trace_std = (
+            np.asarray(trace_std, dtype=np.float64)
+            if trace_std is not None else None
+        )
+        self.sfreq = sfreq
+
+
+class _FakeMontage:
+    """Minimal Montage stand-in for export tests — just channels + save()."""
+
+    def __init__(self, channels):
+        self.channels = channels
+        self.save_called_with = None
+
+    def save(self, filename):
+        self.save_called_with = filename
+
+
+# ---------------------------------------------------------------------------
+# state.hrf_selected_channel lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestStateHrfSelectedChannel:
+    def test_field_defaults_none(self):
+        s = AppState()
+        assert s.hrf_selected_channel is None
+
+    def test_reset_clears_field(self):
+        s = AppState()
+        s.hrf_selected_channel = "S1_D1 hbo"
+        s.reset()
+        assert s.hrf_selected_channel is None
+
+
+# ---------------------------------------------------------------------------
+# Sync exporters
+# ---------------------------------------------------------------------------
+
+
+class TestSaveMontageSync:
+    def test_delegates_to_montage_save(self, tmp_path):
+        m = _FakeMontage(channels={})
+        out = tmp_path / "montage.json"
+        export_panel.save_montage_sync(m, out)
+        assert m.save_called_with == str(out)
+
+
+class TestSaveHrfPlotsSync:
+    def test_writes_one_png_per_channel_with_trace(self, tmp_path):
+        montage = _FakeMontage(
+            channels={
+                "S1_D1 hbo": _FakeNode(trace=np.sin(np.linspace(0, 2, 30))),
+                "S1_D1 hbr": _FakeNode(trace=np.cos(np.linspace(0, 2, 30))),
+            }
+        )
+        folder = tmp_path / "plots"
+        count = export_panel.save_hrf_plots_sync(
+            montage, folder, prefix="sub-01"
+        )
+        assert count == 2
+        files = sorted(folder.glob("*.png"))
+        assert len(files) == 2
+        assert all(f.stat().st_size > 0 for f in files)
+        # Filename includes prefix + safe channel name
+        names = {f.name for f in files}
+        assert "sub-01_S1_D1_hbo.png" in names
+
+    def test_skips_empty_traces(self, tmp_path):
+        montage = _FakeMontage(
+            channels={
+                "good": _FakeNode(trace=np.sin(np.linspace(0, 1, 10))),
+                "empty": _FakeNode(trace=np.array([])),
+            }
+        )
+        folder = tmp_path / "plots"
+        count = export_panel.save_hrf_plots_sync(
+            montage, folder, prefix="sub"
+        )
+        assert count == 1
+
+    def test_creates_target_folder(self, tmp_path):
+        montage = _FakeMontage(
+            channels={"x": _FakeNode(trace=np.sin(np.linspace(0, 1, 10)))}
+        )
+        folder = tmp_path / "nested" / "subdir" / "plots"
+        assert not folder.exists()
+        export_panel.save_hrf_plots_sync(montage, folder, prefix="p")
+        assert folder.exists()
+
+
+class TestSaveQualityCsvSync:
+    def test_writes_csv_with_header_and_rows(self, tmp_path):
+        metrics = {
+            Path("/tmp/scan_a.snirf"): {
+                "raw": quality_panel.QualityMetrics(
+                    snr_mean=2.5, skew_mean=0.1, kurtosis_mean=3.0,
+                    sci_mean=0.95, n_channels=4,
+                ),
+                "preprocessed": quality_panel.QualityMetrics(
+                    snr_mean=3.0, skew_mean=0.2, kurtosis_mean=2.8,
+                    sci_mean=None, n_channels=4,
+                ),
+            },
+            Path("/tmp/scan_b.snirf"): {
+                "raw": quality_panel.QualityMetrics(
+                    snr_mean=1.5, skew_mean=0.05, kurtosis_mean=4.0,
+                    sci_mean=0.88, n_channels=3,
+                ),
+            },
+        }
+        out = tmp_path / "metrics.csv"
+        rows_written = export_panel.save_quality_csv_sync(metrics, out)
+        # 2 stages for scan_a + 1 stage for scan_b = 3 rows
+        assert rows_written == 3
+
+        with open(out) as f:
+            reader = csv.reader(f)
+            header = next(reader)
+            assert header == [
+                "scan_path", "stage", "n_channels", "snr_mean",
+                "skew_mean", "kurtosis_mean", "sci_mean",
+            ]
+            rows = list(reader)
+            assert len(rows) == 3
+        # Sanity-check one row
+        sample = next(
+            r for r in rows
+            if r[0].endswith("scan_a.snirf") and r[1] == "raw"
+        )
+        assert sample[2] == "4"
+        assert float(sample[3]) == 2.5
+
+    def test_empty_metrics_returns_zero_rows(self, tmp_path):
+        out = tmp_path / "empty.csv"
+        rows = export_panel.save_quality_csv_sync({}, out)
+        assert rows == 0
+        # Header still written
+        with open(out) as f:
+            assert "scan_path" in f.readline()
+
+
+# ---------------------------------------------------------------------------
+# Export panel rendering — User fixture
+# ---------------------------------------------------------------------------
+
+
+async def test_panel_prompts_when_no_scan(user: User, tmp_path):
+    global_state.reset()
+    global_state.manifest = Manifest(
+        root=tmp_path,
+        scans=(ScanEntry(format="snirf", path=tmp_path / "a.snirf",
+                         display_name="a"),),
+    )
+    await user.open("/workspace")
+    await user.should_see("Export")
+    await user.should_see("Select a scan from the dataset tree")
+
+
+async def test_panel_all_five_rows_visible(user: User, tmp_path):
+    """When a scan is selected, all five exporter rows render even if
+    most buttons are disabled."""
+    scan = ScanEntry(
+        format="snirf", path=tmp_path / "a.snirf", display_name="a"
+    )
+    global_state.reset()
+    global_state.manifest = Manifest(root=tmp_path, scans=(scan,))
+    global_state.selected_scan = scan
+    await user.open("/workspace")
+    # Each row's title appears as visible text
+    await user.should_see("Processed Raw")
+    await user.should_see("Activity Raw")
+    await user.should_see("Montage HRFs")
+    await user.should_see("HRF plots")
+    await user.should_see("Quality metrics")
+
+
+async def test_panel_processed_row_hint_when_unprocessed(
+    user: User, tmp_path
+):
+    scan = ScanEntry(
+        format="snirf", path=tmp_path / "a.snirf", display_name="a"
+    )
+    global_state.reset()
+    global_state.manifest = Manifest(root=tmp_path, scans=(scan,))
+    global_state.selected_scan = scan
+    await user.open("/workspace")
+    await user.should_see("Run the Preprocess tab first")
+
+
+async def test_panel_subscribes_to_all_state_events(user: User, tmp_path):
+    """Export panel re-renders on every state change so button enablement
+    tracks the workflow stages."""
+    global_state.reset()
+    global_state.manifest = Manifest(
+        root=tmp_path,
+        scans=(ScanEntry(format="snirf", path=tmp_path / "a.snirf",
+                         display_name="a"),),
+    )
+    await user.open("/workspace")
+    # Each event has at least one subscriber from the Export panel +
+    # other tabs.
+    for event in (
+        "scan_selected", "scan_loaded", "preprocess_done",
+        "hrf_estimated", "activity_estimated", "quality_computed",
+    ):
+        assert event in global_state.subscribers
+
+
+# ---------------------------------------------------------------------------
+# HRF gallery refactor (Sprint 5.1) — _gather_channel_traces + click handler
+# ---------------------------------------------------------------------------
+
+
+class TestGatherChannelTraces:
+    def test_filters_empty_traces(self):
+        montage = _FakeMontage(channels={
+            "good": _FakeNode(trace=np.sin(np.linspace(0, 1, 10))),
+            "empty": _FakeNode(trace=np.array([])),
+            "all_zeros": _FakeNode(trace=np.zeros(10)),
+        })
+        out = hrf_panel._gather_channel_traces(montage)
+        assert set(out.keys()) == {"good"}
+
+    def test_handles_montage_without_channels_attr(self):
+        out = hrf_panel._gather_channel_traces(object())
+        assert out == {}
+
+
+class TestOnChannelClick:
+    def test_updates_state_and_publishes_selection_event(self):
+        """The click handler now publishes the focused
+        ``hrf_selection_changed`` event (not the global ``hrf_estimated``)
+        so only the HRFs-tab body refreshes, avoiding cascading re-renders
+        in every other workspace tab."""
+        s = AppState()
+        s.selected_scan = ScanEntry(
+            format="snirf", path=Path("/tmp/x"), display_name="x"
+        )
+        selection_published = []
+        estimated_published = []
+        s.subscribe(
+            "hrf_selection_changed",
+            lambda payload: selection_published.append(payload),
+        )
+        s.subscribe(
+            "hrf_estimated",
+            lambda payload: estimated_published.append(payload),
+        )
+        hrf_panel._on_channel_click(s, "S1_D1 hbo")
+        assert s.hrf_selected_channel == "S1_D1 hbo"
+        assert selection_published == ["S1_D1 hbo"]
+        # hrf_estimated should NOT fire on selection change (otherwise
+        # every other tab would refresh per click).
+        assert estimated_published == []
+
+
+class TestSafeFilename:
+    """The Windows-friendly filename sanitizer for HRF plot exports."""
+
+    def test_replaces_unsafe_characters(self):
+        assert export_panel._safe_filename("S1/D1 hbo") == "S1_D1_hbo"
+        assert export_panel._safe_filename("ch:1*?<>|\"\\") == "ch_1"
+
+    def test_collapses_runs_of_underscores(self):
+        assert export_panel._safe_filename("a   b") == "a_b"
+
+    def test_strips_leading_trailing_dots(self):
+        assert export_panel._safe_filename(".hidden.") == "hidden"
+
+    def test_empty_after_sanitization_falls_back(self):
+        assert export_panel._safe_filename("???") == "channel"
+
+    def test_preserves_dots_in_middle(self):
+        assert export_panel._safe_filename("v1.2.3") == "v1.2.3"


### PR DESCRIPTION
## Summary

Sprint 5 closes out v1.3.0. Three things in one PR:

1. **HRF gallery** — HRFs-tab preview refactored from "all channels overlaid on one figure" to a clickable channel grid + per-channel detail panel (with ±1 std shading).
2. **Export tab** — five exporters: Processed Raw, Activity Raw, Montage HRFs JSON, HRF plot PNGs folder, Quality metrics CSV.
3. **v1.3.0 release bump** — `pyproject.toml` 1.1.2 → 1.3.0 + CHANGELOG entry.

The Export tab was the last placeholder; with this PR the whole v1.3.0 tab set is real.

## What changed

### `components/hrf_panel.py` (refactored)
- Toeplitz-mode preview replaced with a clickable mini-plot grid + a focused-channel detail panel.
- New `hrf_selection_changed` event (gallery-only refresh) instead of republishing `hrf_estimated` (which would cascade to all 6 tab subscribers).
- Removed the dead `_render_toeplitz_preview_png` function.

### `components/export_panel.py` (new, ~480 lines)
| Row | Source | Output |
|---|---|---|
| Processed Raw | `state.processed_cache[scan]` | SNIRF or FIF |
| Activity Raw | `state.activity_raw` | SNIRF or FIF — toast surfaces dropped-channel count |
| Montage HRFs JSON | `state.montage` (toeplitz only) | `montage.save(path)` |
| HRF plot PNGs | `state.montage` channels | one PNG per channel into chosen folder |
| Quality metrics CSV | `state.quality_metrics` | flat CSV, one row per (scan, stage) |

All saves dispatch async to executor threads; pywebview SAVE_DIALOG / FOLDER_DIALOG for file picking. Module-level sync workers (`_save_raw`, `save_montage_sync`, `save_hrf_plots_sync`, `save_quality_csv_sync`) are testable without dialog interaction.

### `pyproject.toml`
- `version = "1.3.0"` (was `"1.1.2"`).

### Documentation
- `gui_guide.md` — HRFs tab section explains the gallery; Troubleshooting gains entries on Export-button enablement and SNIRF round-trip caveats.
- `README.md` — Export row of the tabs walkthrough promoted from placeholder.
- `CHANGELOG.md` — v1.3.0 entry rounded out.

## Dual review findings + fixes

Architecture + data-integrity reviews both GO conditional on four real issues. All four fixed:

| Issue | Severity | Fix |
|---|---|---|
| `_on_channel_click` republished `hrf_estimated` → cascading re-render across all tabs, plus None-payload risk. | Architecture | New dedicated `hrf_selection_changed` event with channel-name payload; only the HRFs-tab body subscribes. |
| Filename sanitizer too narrow for Windows (`\\:*?"<>|` not handled). | Cross-platform | `_safe_filename` whitelist sanitizer — alphanumeric + `-_.` only; collapses underscore runs; strips leading/trailing dots. |
| Activity save notification didn't surface dropped-channel count from `estimate_activity`. | UX / data integrity | Save toast now reads "Saved activity scan: x.snirf (N channel(s) dropped during deconvolution)" when applicable. |
| MNE's `export_raw(fmt="snirf")` may lose haemoglobin channel-type metadata. | Documentation | Troubleshooting section recommends `.fif` for round-trips; `.snirf` remains fine when only data values matter. Flagged as a v1.4 to address at the library level. |

## Flagged for v1.4

- **Reproducibility gap.** Exported artifacts capture analysis OUTPUT but not analysis PARAMETERS (preprocess toggles, lmbda values, event selections). v1.4 should add a sibling `settings.json` export so re-runs are reproducible without remembering toggle state.
- **SNIRF round-trip semantics** — see review item 4 above. Library-level fix.

## Test plan

Full v1.3.0 gate (27 test files): **527 passed, zero regressions** (was 507 at end of 4.2-4.4; +20 new).

```
pytest tests/test_phase1a.py tests/test_phase1bc.py tests/test_phase2.py \
       tests/test_threading.py tests/test_input_validation.py \
       tests/test_state_lifecycle.py tests/test_oxygenation_guard.py \
       tests/test_tree_delete_filter.py tests/test_hasher_branch.py \
       tests/test_tree_hrf.py tests/test_canonical_hrf.py \
       tests/test_tree_edge_cases.py tests/test_observer_and_typos.py \
       tests/test_progress_callbacks.py tests/test_io_detect.py \
       tests/test_io_scan.py tests/test_io_raw_cache.py \
       tests/test_gui_foundation.py tests/test_gui_welcome.py \
       tests/test_gui_workspace.py tests/test_gui_scan_inspector.py \
       tests/test_gui_preprocess.py tests/test_gui_estimate_panel.py \
       tests/test_gui_activity_panel.py tests/test_gui_quality_panel.py \
       tests/test_gui_library.py tests/test_gui_export.py -q
```

New test classes:
- `TestStateHrfSelectedChannel` (2) — default None, reset clears.
- `TestSaveMontageSync` (1) — delegates to `montage.save`.
- `TestSaveHrfPlotsSync` (3) — one PNG per channel, empty-trace skip, mkdir target folder.
- `TestSaveQualityCsvSync` (2) — header + rows, empty-metrics zero rows.
- Panel rendering (4) — no-scan prompt, all-five rows, processed-row hint, six event subscribers registered.
- `TestGatherChannelTraces` (2) — empty-trace filter, no-channels-attr defensive.
- `TestOnChannelClick` (1) — publishes `hrf_selection_changed` NOT `hrf_estimated`.
- `TestSafeFilename` (5) — Windows-illegal char replacement, run collapse, leading/trailing dot strip, empty fallback, preserves mid-string dots.

- [x] All tests pass on macOS Darwin / Python 3.12
- [x] Editable install verified
- [ ] Manual smoke test against `tests/data/sNIRF_formatted/` — run the full pipeline (Inspect → Preprocess → HRFs → Activity → Quality), click around the new HRF gallery, then save each export type and verify the files (recommended before merge — release-grade)

🤖 Generated with [Claude Code](https://claude.com/claude-code)