### PR TITLE
chore: standardize brand name HRFunc → HRfunc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,7 @@
 - New: `hrfunc install-shortcut` / `hrfunc uninstall-shortcut`
   subcommands add or remove a system-level launcher (Spotlight on
   macOS, Start menu on Windows, Activities on Linux) so non-coder
-  researchers can open HRFunc like any other desktop app. First GUI
+  researchers can open HRfunc like any other desktop app. First GUI
   launch prompts the user to install the shortcut automatically.
 - See [docs/external/gui_guide.md](docs/external/gui_guide.md) for the
   full GUI walkthrough and troubleshooting guide

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-# HRFunc
-HRFunc is a Python library for estimating hemodynamic response functions and neural activity from hemoglobin concentration in functional near infrared spectroscopy (fNIRS), through modeling hemodynamic response functions through the brain recorded from fNIRS signals and deconvolving neural activity. Toeplitz deconvolution with Tikhonov regularization is employed for HRF and neural activity estimation. For more guidance on using the HRfunc tool, visit www.hrfunc.org for in-depth guides and demo videos.
+# HRfunc
+HRfunc is a Python library for estimating hemodynamic response functions and neural activity from hemoglobin concentration in functional near infrared spectroscopy (fNIRS), through modeling hemodynamic response functions through the brain recorded from fNIRS signals and deconvolving neural activity. Toeplitz deconvolution with Tikhonov regularization is employed for HRF and neural activity estimation. For more guidance on using the HRfunc tool, visit www.hrfunc.org for in-depth guides and demo videos.
 
 ---
 
@@ -61,13 +61,13 @@ hrfunc /path/to/study           # preloads a folder of scans
 hrfunc subject_01.snirf         # preloads a single scan
 ```
 
-On first launch HRFunc offers to add itself to your system menu
+On first launch HRfunc offers to add itself to your system menu
 (Spotlight on macOS, Start menu on Windows, Activities on Linux) so
 you can open it without the terminal afterward. You can also run the
 install manually at any time:
 
 ```bash
-hrfunc install-shortcut         # add HRFunc to your system menu
+hrfunc install-shortcut         # add HRfunc to your system menu
 hrfunc uninstall-shortcut       # remove it
 ```
 

--- a/docs/external/api_reference.md
+++ b/docs/external/api_reference.md
@@ -1,4 +1,4 @@
-# HRFunc API Reference
+# HRfunc API Reference
 
 **Version:** 1.2.0 (correctness release, in flight)
 **Python:** ≥ 3.8
@@ -31,7 +31,7 @@ scan = hrf.preprocess_fnirs(scan)           # Preprocess fNIRS data
 
 ## Return-value capture pattern
 
-Several MNE NIRS preprocessing steps internally call `.copy().load_data()` and return a new object rather than mutating in place. HRFunc follows the same convention:
+Several MNE NIRS preprocessing steps internally call `.copy().load_data()` and return a new object rather than mutating in place. HRfunc follows the same convention:
 
 ```python
 # WRONG — scan is still unpreprocessed
@@ -275,7 +275,7 @@ except ValueError as e:
 
 ## `preprocess_fnirs(scan, deconvolution=False)`
 
-Preprocess a raw fNIRS scan using the standard HRFunc pipeline. Returns a **new** MNE Raw object — capture the return value.
+Preprocess a raw fNIRS scan using the standard HRfunc pipeline. Returns a **new** MNE Raw object — capture the return value.
 
 **Pipeline steps:**
 1. Convert to optical density
@@ -389,7 +389,7 @@ Context keys with `None` values are excluded from similarity comparisons. Pass c
 
 ## Units Convention
 
-**HRFunc outputs estimated HRFs and deconvolved neural activity in arbitrary units (a.u.)**, matching the fMRI BOLD analysis convention. Specifically:
+**HRfunc outputs estimated HRFs and deconvolved neural activity in arbitrary units (a.u.)**, matching the fMRI BOLD analysis convention. Specifically:
 
 - `estimate_hrf` z-scores the signal before the least-squares solve and does **not** denormalize back to absolute hemoglobin concentrations. Returned HRF traces are in z-score space.
 - `estimate_activity` peak-normalizes the HRF kernel before using it as a deconvolution template. Returned neural activity is a relative deviation from baseline, not an absolute metric.
@@ -413,7 +413,7 @@ This is intentional. Treat HRF shapes and neural activity traces as relative tem
 
 ## Supported fNIRS Formats
 
-HRFunc accepts any `mne.io.Raw` object. Load your data through MNE:
+HRfunc accepts any `mne.io.Raw` object. Load your data through MNE:
 
 ```python
 import mne

--- a/docs/external/gui_guide.md
+++ b/docs/external/gui_guide.md
@@ -1,4 +1,4 @@
-# HRFunc Desktop GUI — User Guide
+# HRfunc Desktop GUI — User Guide
 
 A point-and-click workflow for fNIRS HRF estimation and neural-activity
 recovery without writing Python.
@@ -43,7 +43,7 @@ added as positional commands.
 ### System menu integration
 
 After your first `hrfunc` launch, the welcome screen offers to add
-HRFunc to your system menu so you can open it without the terminal.
+HRfunc to your system menu so you can open it without the terminal.
 "Yes, add it" puts a clickable launcher in Spotlight (macOS), the
 Start menu (Windows), or Activities (Linux); "Not now" defers the
 question to the next launch; "Don't ask again" silences the prompt
@@ -52,7 +52,7 @@ without installing.
 You can also manage the shortcut from the command line at any time:
 
 ```bash
-hrfunc install-shortcut      # add HRFunc to your system menu
+hrfunc install-shortcut      # add HRfunc to your system menu
 hrfunc uninstall-shortcut    # remove the system menu entry
 ```
 
@@ -66,7 +66,7 @@ identical no matter which path you took.
 
 When the GUI opens with no folder pre-loaded, you see three paths:
 
-1. **Open my data** — pick a folder on disk. HRFunc scans for SNIRF,
+1. **Open my data** — pick a folder on disk. HRfunc scans for SNIRF,
    NIRx, and FIF files (with BIDS subject/session metadata if your
    folders follow the convention). Opens the workspace once the scan
    completes.
@@ -244,7 +244,7 @@ orange vertical lines.
 ## HRF Library
 
 The `/library` page is the **Browser** persona's entry point — a
-researcher who wants to explore HRFunc's bundled literature HRFs without
+researcher who wants to explore HRfunc's bundled literature HRFs without
 opening their own data. Reach it via the welcome screen's "Browse HRF
 library" card, or by navigating directly.
 
@@ -474,7 +474,7 @@ all-bad-channel inputs.
 
 ### GUI crashes on launch with a port-binding error
 
-NiceGUI defaults to port 8080, but HRFunc asks the OS to pick a free
+NiceGUI defaults to port 8080, but HRfunc asks the OS to pick a free
 loopback port at launch time, so the bound port should never collide
 with another service. If you still see a "port in use" error, the most
 likely cause is a host firewall blocking loopback ports — check that

--- a/docs/external/workflow_examples.md
+++ b/docs/external/workflow_examples.md
@@ -1,6 +1,6 @@
-# HRFunc Workflow Examples
+# HRfunc Workflow Examples
 
-Practical end-to-end examples for the most common HRFunc workflows. Assumes you've already installed HRFunc and have a working MNE-Python environment.
+Practical end-to-end examples for the most common HRfunc workflows. Assumes you've already installed HRfunc and have a working MNE-Python environment.
 
 For reference-level documentation of each function, see [api_reference.md](api_reference.md).
 
@@ -22,7 +22,7 @@ import numpy as np
 
 ## Workflow 1 — Localize pre-trained HRFs to a new scan
 
-Use this when you don't have subject-specific HRF estimates and want to rely on HRFunc's bundled community library. The library is spatially indexed by optode location, so each channel gets the nearest match.
+Use this when you don't have subject-specific HRF estimates and want to rely on HRfunc's bundled community library. The library is spatially indexed by optode location, so each channel gets the nearest match.
 
 ```python
 # Load a scan
@@ -213,7 +213,7 @@ print(f"Canonical HbO at 10 Hz, 30 s: {len(canonical.trace)} samples")
 
 ## Units reminder
 
-HRFunc intentionally outputs HRF traces and deconvolved neural activity in **arbitrary units (a.u.)**, matching the fMRI BOLD analysis convention. Traces are z-score-normalized inputs and peak-normalized kernels; the absolute magnitude is not meaningful. Treat HRF shapes and activity traces as relative templates for comparison across conditions and subjects. See [api_reference.md](api_reference.md#units-convention) for the full rationale.
+HRfunc intentionally outputs HRF traces and deconvolved neural activity in **arbitrary units (a.u.)**, matching the fMRI BOLD analysis convention. Traces are z-score-normalized inputs and peak-normalized kernels; the absolute magnitude is not meaningful. Treat HRF shapes and activity traces as relative templates for comparison across conditions and subjects. See [api_reference.md](api_reference.md#units-convention) for the full rationale.
 
 ---
 
@@ -230,4 +230,4 @@ scan = mne.io.read_raw_nirx("path/to/nirx_directory")
 scan = mne.io.read_raw_fif("subject.fif")
 ```
 
-HRFunc accepts any `mne.io.Raw` object.
+HRfunc accepts any `mne.io.Raw` object.

--- a/docs/internal/architecture.md
+++ b/docs/internal/architecture.md
@@ -1,4 +1,4 @@
-# HRFunc Internal Architecture
+# HRfunc Internal Architecture
 
 **Version:** 1.2.0 (correctness release in flight)
 **Last reviewed:** 2026-04-14
@@ -8,7 +8,7 @@
 
 ## Overview
 
-HRFunc estimates hemodynamic response functions (HRFs) and neural activity from fNIRS (functional near-infrared spectroscopy) brain imaging data. It wraps MNE-Python's Raw fNIRS objects and applies Toeplitz deconvolution with Tikhonov regularization to recover HRF shapes and neural activity timeseries.
+HRfunc estimates hemodynamic response functions (HRFs) and neural activity from fNIRS (functional near-infrared spectroscopy) brain imaging data. It wraps MNE-Python's Raw fNIRS objects and applies Toeplitz deconvolution with Tikhonov regularization to recover HRF shapes and neural activity timeseries.
 
 The library is used by neuroscientists to:
 1. Estimate channel-wise HRFs from event-related fNIRS scans
@@ -368,7 +368,7 @@ The `_flatten_context_value` helper bridges the gap between HRF context values (
 
 ## Units Convention (intentional)
 
-HRFunc intentionally outputs HRF traces and deconvolved neural activity in **arbitrary units (a.u.)**, matching the fMRI BOLD analysis convention:
+HRfunc intentionally outputs HRF traces and deconvolved neural activity in **arbitrary units (a.u.)**, matching the fMRI BOLD analysis convention:
 
 - `estimate_hrf` z-scores the input signal before the least-squares solve and does not denormalize back to absolute hemoglobin concentrations. Returned HRF traces are in z-score space.
 - `estimate_activity` peak-normalizes the HRF kernel (`hrf.trace / np.max(np.abs(hrf.trace))`) before using it as a deconvolution template. Returned activity is relative deviation from baseline.

--- a/docs/internal/known_issues.md
+++ b/docs/internal/known_issues.md
@@ -1,4 +1,4 @@
-# HRFunc Known Issues
+# HRfunc Known Issues
 
 **Status as of:** 2026-04-14
 **Active work:** v1.2.0 correctness release (10 branches in flight, 6 merged to main, 4 pushed pending merge)

--- a/docs/internal/v1_2_0_changelog_summary.md
+++ b/docs/internal/v1_2_0_changelog_summary.md
@@ -1,4 +1,4 @@
-# HRFunc v1.2.0 — Change Summary
+# HRfunc v1.2.0 — Change Summary
 
 **Release type:** Correctness release (minor version bump 1.1.2 → 1.2.0)
 **Strategy:** Fix every crash, silent-wrong-result, and input-validation hole without changing architecture. See [../plans/plan_v1_2_0.md](../plans/plan_v1_2_0.md) for the detailed plan.

--- a/docs/plans/phase_breakdown.md
+++ b/docs/plans/phase_breakdown.md
@@ -1,4 +1,4 @@
-# HRFunc Release Roadmap
+# HRfunc Release Roadmap
 
 **Current version:** 1.1.2
 **Next release:** 1.2.0 — Correctness Release (PyPI)
@@ -10,7 +10,7 @@
 
 ## Release Strategy
 
-HRFunc is a scientific library that researchers rely on for publishable data. We split refactoring into two releases with distinct goals:
+HRfunc is a scientific library that researchers rely on for publishable data. We split refactoring into two releases with distinct goals:
 
 ### **1.2.0 — Correctness Release**
 Every user-facing path works without crashes, silent wrong results, or data corruption. No architectural changes. No breaking API changes. This is a **minor version bump** so existing users can upgrade without code changes and gain stability. Detailed plan: [plan_v1_2_0.md](plan_v1_2_0.md).
@@ -24,7 +24,7 @@ Code cleanliness, performance, type safety, and breaking API improvements (notab
 
 ## Working Practices (Apply to Every Branch)
 
-Every branch in either release follows the review protocol defined in the "Working Practices for HRFunc Sessions" memory:
+Every branch in either release follows the review protocol defined in the "Working Practices for HRfunc Sessions" memory:
 
 1. **Feature-branch-per-change** — each branch addresses one cohesive fix or refactor, stacks on the previous branch in the dependency chain
 2. **Targeted unit tests** — add a `tests/test_<branch-name>.py` file exercising the specific behavior changed. Must run in under a few seconds and require no fNIRS data files

--- a/docs/plans/plan_v1_2_0.md
+++ b/docs/plans/plan_v1_2_0.md
@@ -1,4 +1,4 @@
-# HRFunc v1.2.0 — Correctness Release Plan
+# HRfunc v1.2.0 — Correctness Release Plan
 
 **Release type:** Minor version bump (1.1.2 → 1.2.0)
 **Goal:** Every user-facing path works without crashes, silent wrong results, or data corruption. No breaking API changes. No architectural refactors. Ship to PyPI.
@@ -26,7 +26,7 @@
 - Test suite restructuring
 - Breaking API changes
 
-**Rule of thumb:** if a fix changes observable behavior for a scientist who's already using HRFunc correctly, it belongs in 2.0.0 unless the current behavior is scientifically wrong.
+**Rule of thumb:** if a fix changes observable behavior for a scientist who's already using HRfunc correctly, it belongs in 2.0.0 unless the current behavior is scientifically wrong.
 
 ---
 
@@ -463,7 +463,7 @@ Each branch stacks on the previous. Each gets its own targeted test file and the
 
 7. **Git tag and GitHub release:**
     ```bash
-    git tag -a v1.2.0 -m "HRFunc 1.2.0 — Correctness Release"
+    git tag -a v1.2.0 -m "HRfunc 1.2.0 — Correctness Release"
     git push origin v1.2.0
     gh release create v1.2.0 --notes-file CHANGELOG_1_2_0.md
     ```

--- a/docs/plans/plan_v2_0_0.md
+++ b/docs/plans/plan_v2_0_0.md
@@ -1,4 +1,4 @@
-# HRFunc v2.0.0 — Architectural Refactor Plan
+# HRfunc v2.0.0 — Architectural Refactor Plan
 
 **Release type:** Major version bump (1.2.0 → 2.0.0)
 **Prerequisite:** 1.2.0 shipped and validated in Denny's pipeline
@@ -520,7 +520,7 @@ Robustness guards that weren't critical enough for 1.2.0 but improve error messa
         with open(filename, 'r') as file:
             data = json.load(file)
     except FileNotFoundError:
-        raise FileNotFoundError(f"HRFunc montage file not found: {filename}")
+        raise FileNotFoundError(f"HRfunc montage file not found: {filename}")
     except json.JSONDecodeError as e:
         raise ValueError(f"Invalid JSON in {filename}: {e}")
     ```
@@ -628,7 +628,7 @@ To be written during `release/2.0.0`. Must cover:
 - **`estimate_activity` returns a `NeuralActivity` wrapper, not an `mne.io.Raw`**: `.save()` and `.get_data()` still work directly; for Raw-specific methods, access `.raw`. Rationale: disambiguates deconvolved neural activity from preprocessed HbO/HbR concentration data.
 - **All `print` output is now logging**: users who want the old verbose behavior call `logging.basicConfig(level=logging.DEBUG)`
 - **`estimate_hrf` performance improvement** — same results, much faster
-- **Type hints available** — downstream projects can now `mypy` HRFunc usages
+- **Type hints available** — downstream projects can now `mypy` HRfunc usages
 - Any other observable changes from the refactors
 
 ---

--- a/docs/plans/refactoring_plan.md
+++ b/docs/plans/refactoring_plan.md
@@ -1,4 +1,4 @@
-# HRFunc Refactoring Plan — Index
+# HRfunc Refactoring Plan — Index
 
 **Status:** This document was decomposed on 2026-04-14 into three cohesive plans. Use the documents below instead of this one.
 

--- a/src/hrfunc/cli/__init__.py
+++ b/src/hrfunc/cli/__init__.py
@@ -1,4 +1,4 @@
-"""HRFunc CLI helpers shared between subcommands.
+"""HRfunc CLI helpers shared between subcommands.
 
 The bare ``hrfunc`` command launches the GUI (see ``hrfunc.gui.app:main``);
 the subcommands live in this package so they can be imported lazily by

--- a/src/hrfunc/cli/install_shortcut.py
+++ b/src/hrfunc/cli/install_shortcut.py
@@ -1,6 +1,6 @@
-"""Cross-platform "install HRFunc to system menu" shortcut helpers.
+"""Cross-platform "install HRfunc to system menu" shortcut helpers.
 
-The HRFunc GUI is designed for fNIRS researchers who don't otherwise live
+The HRfunc GUI is designed for fNIRS researchers who don't otherwise live
 in a terminal. Requiring them to type ``hrfunc`` every time they want to
 analyze a scan defeats the point of shipping a GUI — so we install a
 system-level launcher (Spotlight on macOS, Start menu on Windows,
@@ -9,7 +9,7 @@ script.
 
 The heavy lifting is delegated to ``pyshortcuts`` (a small cross-platform
 shortcut-builder library that handles the per-OS file formats and icon
-conversions). HRFunc only contributes:
+conversions). HRfunc only contributes:
 
 - ``install_shortcut`` — the high-level entry point. Resolves the icon
   asset bundled inside ``hrfunc.assets``, dispatches to
@@ -38,7 +38,7 @@ from typing import List, Optional
 logger = logging.getLogger(__name__)
 
 # The user-facing name that appears in Spotlight / Start menu / Activities.
-SHORTCUT_NAME = "HRFunc"
+SHORTCUT_NAME = "HRfunc"
 SHORTCUT_DESCRIPTION = (
     "fNIRS hemodynamic response function estimation "
     "and neural activity recovery"
@@ -160,7 +160,7 @@ def install_shortcut(
             locations=[],
             message=(
                 "Could not find the installed `hrfunc` console script. "
-                "Reinstall HRFunc with `pip install --force-reinstall "
+                "Reinstall HRfunc with `pip install --force-reinstall "
                 "hrfunc[gui]` and try again."
             ),
         )
@@ -200,7 +200,7 @@ def install_shortcut(
     if is_mac:
         moved = _move_mac_app_to_applications()
         if moved is not None:
-            logger.info("moved HRFunc.app to %s", moved)
+            logger.info("moved HRfunc.app to %s", moved)
 
     written = _discover_shortcuts()
     if not written:
@@ -218,12 +218,12 @@ def install_shortcut(
     return InstallResult(
         ok=True,
         locations=written,
-        message=f"HRFunc shortcut installed: {where}",
+        message=f"HRfunc shortcut installed: {where}",
     )
 
 
 def _move_mac_app_to_applications() -> Optional[Path]:
-    """Move ``~/Desktop/HRFunc.app`` to ``~/Applications/HRFunc.app``.
+    """Move ``~/Desktop/HRfunc.app`` to ``~/Applications/HRfunc.app``.
 
     pyshortcuts' macOS path always writes the .app bundle to Desktop.
     Spotlight will index it there (the home directory is included in
@@ -257,7 +257,7 @@ def _move_mac_app_to_applications() -> Optional[Path]:
 
 
 def uninstall_shortcut() -> UninstallResult:
-    """Delete any HRFunc shortcut files we can find.
+    """Delete any HRfunc shortcut files we can find.
 
     Walks the standard pyshortcuts output directories (Desktop +
     Applications / Start menu / Activities for the current OS) and
@@ -269,7 +269,7 @@ def uninstall_shortcut() -> UninstallResult:
         return UninstallResult(
             ok=True,
             removed=[],
-            message="No HRFunc shortcut found to remove.",
+            message="No HRfunc shortcut found to remove.",
         )
 
     removed: List[Path] = []
@@ -290,14 +290,14 @@ def uninstall_shortcut() -> UninstallResult:
             ok=False,
             removed=[],
             message=(
-                f"Could not remove HRFunc shortcuts: "
+                f"Could not remove HRfunc shortcuts: "
                 f"{', '.join(str(p) for p in failed)}"
             ),
         )
     return UninstallResult(
         ok=True,
         removed=removed,
-        message=f"Removed {len(removed)} HRFunc shortcut(s).",
+        message=f"Removed {len(removed)} HRfunc shortcut(s).",
     )
 
 
@@ -358,7 +358,7 @@ def _resolve_target_script() -> Optional[str]:
 
 
 def _discover_shortcuts() -> List[Path]:
-    """Return existing HRFunc shortcut files in the standard locations.
+    """Return existing HRfunc shortcut files in the standard locations.
 
     Walks pyshortcuts' get_folders() output plus a hardcoded
     ``~/Applications`` directory on macOS (where we post-move .app

--- a/src/hrfunc/gui/__init__.py
+++ b/src/hrfunc/gui/__init__.py
@@ -1,4 +1,4 @@
-"""HRFunc desktop GUI — NiceGUI-based interface for non-tech researchers.
+"""HRfunc desktop GUI — NiceGUI-based interface for non-tech researchers.
 
 The GUI is an optional install (`pip install hrfunc[gui]`) that adds NiceGUI,
 plotly, and pywebview. The `hrfunc` CLI entry point launches `hrfunc.gui.app.main`,

--- a/src/hrfunc/gui/app.py
+++ b/src/hrfunc/gui/app.py
@@ -1,4 +1,4 @@
-"""HRFunc GUI entry point.
+"""HRfunc GUI entry point.
 
 ``hrfunc`` (the CLI command installed by ``pip install hrfunc[gui]``)
 calls ``main()``, which dispatches three classes of invocation:
@@ -10,7 +10,7 @@ calls ``main()``, which dispatches three classes of invocation:
    ``hrfunc uninstall-shortcut``. Adds or removes a system-level
    launcher (Spotlight on macOS, Start menu on Windows, Activities on
    Linux) via ``pyshortcuts``. Researchers who don't live in a terminal
-   only need to run this once and can then click HRFunc like any other
+   only need to run this once and can then click HRfunc like any other
    desktop app.
 3. **Help / version** — ``hrfunc --help``, ``hrfunc help``, or
    ``hrfunc --version``. Print and exit.
@@ -19,8 +19,8 @@ Usage:
     hrfunc                              # launch the GUI
     hrfunc /path/to/study               # launch with that folder preloaded
     hrfunc subject_01.snirf             # launch with a single file preloaded
-    hrfunc install-shortcut             # add HRFunc to your system menu
-    hrfunc uninstall-shortcut           # remove the HRFunc system menu entry
+    hrfunc install-shortcut             # add HRfunc to your system menu
+    hrfunc uninstall-shortcut           # remove the HRfunc system menu entry
     hrfunc --version                    # print version and exit
     hrfunc --help                       # show CLI help
     hrfunc help                         # alias for --help
@@ -106,7 +106,7 @@ def _launch_gui(argv: List[str]) -> int:
     _register_pages()
 
     ui.run(
-        title="HRFunc",
+        title="HRfunc",
         native=True,
         window_size=(1400, 900),
         reload=False,
@@ -121,16 +121,16 @@ def _build_argument_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="hrfunc",
         description=(
-            "HRFunc — fNIRS hemodynamic response function estimation and "
+            "HRfunc — fNIRS hemodynamic response function estimation and "
             "neural activity recovery. Bare `hrfunc` launches the desktop "
-            "GUI; use `hrfunc install-shortcut` to add HRFunc to your "
+            "GUI; use `hrfunc install-shortcut` to add HRfunc to your "
             "system menu so you can launch it without the terminal."
         ),
         epilog=(
             "Subcommands:\n"
-            "  install-shortcut   Add HRFunc to system menu (Spotlight / "
+            "  install-shortcut   Add HRfunc to system menu (Spotlight / "
             "Start menu / Activities)\n"
-            "  uninstall-shortcut Remove the HRFunc system menu entry\n"
+            "  uninstall-shortcut Remove the HRfunc system menu entry\n"
             "  help               Show this help text (alias for --help)"
         ),
         formatter_class=argparse.RawDescriptionHelpFormatter,

--- a/src/hrfunc/gui/components/__init__.py
+++ b/src/hrfunc/gui/components/__init__.py
@@ -1,4 +1,4 @@
-"""Reusable UI components for the HRFunc GUI.
+"""Reusable UI components for the HRfunc GUI.
 
 Each module here exports one component (or one closely related family) that
 pages compose. Components encapsulate rendering + event wiring; they do not

--- a/src/hrfunc/gui/pages/__init__.py
+++ b/src/hrfunc/gui/pages/__init__.py
@@ -1,4 +1,4 @@
-"""Page handlers for the HRFunc GUI.
+"""Page handlers for the HRfunc GUI.
 
 Each module in this subpackage registers one or more ``@ui.page`` handlers
 when imported. ``app._register_pages()`` imports all of them at startup so

--- a/src/hrfunc/gui/pages/library.py
+++ b/src/hrfunc/gui/pages/library.py
@@ -2,7 +2,7 @@
 
 The /library route is the entry path for the **Browser** persona — a
 researcher who has no scan of their own but wants to explore the
-literature HRFs HRFunc bundles (``hbo_hrfs.json`` / ``hbr_hrfs.json``)
+literature HRFs HRfunc bundles (``hbo_hrfs.json`` / ``hbr_hrfs.json``)
 and the community-contributed entries that get merged in over time.
 
 Sprint 4.2 + 4.3 + 4.4 ship together as one combined branch because the

--- a/src/hrfunc/gui/pages/welcome.py
+++ b/src/hrfunc/gui/pages/welcome.py
@@ -71,7 +71,7 @@ async def _render(state: AppState) -> None:
         _render_footer()
 
     # First-launch shortcut prompt — show a one-time dialog asking the
-    # user whether they want HRFunc added to their system menu
+    # user whether they want HRfunc added to their system menu
     # (Spotlight / Start menu / Activities). The XDG-cache marker means
     # this dialog appears at most once per machine.
     _maybe_show_shortcut_prompt()
@@ -105,11 +105,11 @@ def _maybe_show_shortcut_prompt() -> None:
         return
 
     with ui.dialog() as dialog, ui.card().classes("max-w-md"):
-        ui.label("Add HRFunc to your system menu?").classes(
+        ui.label("Add HRfunc to your system menu?").classes(
             "text-lg font-semibold"
         )
         ui.label(
-            "We can install a launcher so HRFunc appears in your system's "
+            "We can install a launcher so HRfunc appears in your system's "
             "app search (Spotlight on macOS, Start menu on Windows, "
             "Activities on Linux). You'll be able to open it like any "
             "other desktop app — no terminal needed."
@@ -151,7 +151,7 @@ def _maybe_show_shortcut_prompt() -> None:
 
 def _render_header() -> None:
     with ui.column().classes("w-full items-center mt-12 mb-8 gap-2"):
-        ui.label("HRFunc").classes("text-6xl font-bold tracking-tight")
+        ui.label("HRfunc").classes("text-6xl font-bold tracking-tight")
         ui.label("fNIRS hemodynamic response estimation").classes(
             "text-xl opacity-70"
         )

--- a/src/hrfunc/gui/pages/workspace.py
+++ b/src/hrfunc/gui/pages/workspace.py
@@ -117,7 +117,7 @@ def _render_toolbar() -> None:
     ):
         with ui.row().classes("items-center gap-3"):
             ui.icon("psychology", size="2rem").classes("text-primary")
-            ui.label("HRFunc").classes("text-2xl font-semibold")
+            ui.label("HRfunc").classes("text-2xl font-semibold")
         with ui.row().classes("items-center gap-2"):
             ui.button(
                 "Back to welcome",

--- a/src/hrfunc/gui/theme.py
+++ b/src/hrfunc/gui/theme.py
@@ -1,4 +1,4 @@
-"""Quasar / Tailwind theming for the HRFunc GUI.
+"""Quasar / Tailwind theming for the HRfunc GUI.
 
 NiceGUI ships Quasar (Vue) and Tailwind under the hood. This module sets the
 brand color tokens, default dark mode, and shared layout primitives so every
@@ -42,7 +42,7 @@ COLORS = {
 
 
 def apply_theme(dark: bool = True) -> None:
-    """Apply the HRFunc color palette and (optionally) enable dark mode.
+    """Apply the HRfunc color palette and (optionally) enable dark mode.
 
     Call once per page handler before constructing UI elements. Subsequent
     calls are idempotent — Quasar caches the colors and `ui.dark_mode` is a

--- a/src/hrfunc/hrfunc.py
+++ b/src/hrfunc/hrfunc.py
@@ -912,7 +912,7 @@ class montage(tree):
     
     def _merge_montages(self, nirx_obj, verbose = False):
         """
-        Function to merge a NIRX object montage with the HRFunc montage.
+        Function to merge a NIRX object montage with the HRfunc montage.
         This function should only be used when initializing an empty
         montage or if merging nirx objects with the same NIRS montage layout
         and with different channel names (useful when dealing with multiple
@@ -980,7 +980,7 @@ class montage(tree):
     def _merge_trees(self, filename = 'tree_hrfs.json'):
         """
         Merge montage, HbO and HbR trees. This function is meant to be used
-        by the creators of HRFunc to merge submitted HRF estimates with the
+        by the creators of HRfunc to merge submitted HRF estimates with the
         HRF toolbox
 
         Arguments:

--- a/src/hrfunc/io/__init__.py
+++ b/src/hrfunc/io/__init__.py
@@ -1,4 +1,4 @@
-"""Path-level I/O utilities for HRFunc — format detection, folder scanning,
+"""Path-level I/O utilities for HRfunc — format detection, folder scanning,
 and Raw caching for the v1.3.0 GUI.
 
 Public API:

--- a/src/hrfunc/observer.py
+++ b/src/hrfunc/observer.py
@@ -29,7 +29,7 @@ class lens:
         # 3.9: self.sfreq was previously read by calc_snr without ever
         # being initialized anywhere in the class, raising AttributeError
         # on any direct SNR call before compare_subject. Initialize with
-        # a sensible default (~7.81 Hz is the HRFunc library default used
+        # a sensible default (~7.81 Hz is the HRfunc library default used
         # for bundled HRFs) and allow override via the constructor.
         self.sfreq = sfreq
         self.channels = []

--- a/tests/gui_main.py
+++ b/tests/gui_main.py
@@ -3,7 +3,7 @@
 NiceGUI's ``nicegui.testing.User`` fixture needs a Python file it can import
 to bootstrap the app — the equivalent of a vanilla NiceGUI app's
 ``main.py``. This module exists solely to satisfy that contract: it imports
-the HRFunc gui package, registers all routes, and calls ``ui.run()``
+the HRfunc gui package, registers all routes, and calls ``ui.run()``
 (intercepted by the User fixture, so no real server starts).
 
 Not a pytest test file (name does not start with ``test_``) so pytest will

--- a/tests/test_cli_install_shortcut.py
+++ b/tests/test_cli_install_shortcut.py
@@ -154,7 +154,7 @@ class TestInstallShortcutSuccess:
         # Force the non-macOS path for cross-platform behavior testing
         monkeypatch.setattr(ish.platform, "system", lambda: "Linux")
 
-        fake_path = tmp_path / "HRFunc.desktop"
+        fake_path = tmp_path / "HRfunc.desktop"
         fake_path.write_text("[Desktop Entry]\n")
 
         called_with = {}
@@ -209,7 +209,7 @@ class TestInstallShortcutMacOS:
         assert called_with["startmenu"] is False
 
     def test_move_mac_app_to_applications(self, monkeypatch, tmp_path):
-        """The post-move helper relocates Desktop/HRFunc.app → Applications/HRFunc.app."""
+        """The post-move helper relocates Desktop/HRfunc.app → Applications/HRfunc.app."""
         # Fake home directory layout
         home = tmp_path
         desktop = home / "Desktop"
@@ -230,7 +230,7 @@ class TestInstallShortcutMacOS:
 
     def test_move_mac_app_no_op_when_source_missing(self, monkeypatch, tmp_path):
         monkeypatch.setattr(ish.Path, "home", classmethod(lambda cls: tmp_path))
-        # No Desktop/HRFunc.app to start with
+        # No Desktop/HRfunc.app to start with
         result = ish._move_mac_app_to_applications()
         assert result is None
 
@@ -295,11 +295,11 @@ class TestUninstallShortcut:
         result = ish.uninstall_shortcut()
         assert result.ok is True
         assert result.removed == []
-        assert "No HRFunc shortcut" in result.message
+        assert "No HRfunc shortcut" in result.message
 
     def test_removes_files_and_reports_count(self, monkeypatch, tmp_path):
-        a = tmp_path / "HRFunc.lnk"
-        b = tmp_path / "HRFunc.desktop"
+        a = tmp_path / "HRfunc.lnk"
+        b = tmp_path / "HRfunc.desktop"
         a.write_text("fake shortcut a")
         b.write_text("fake shortcut b")
         monkeypatch.setattr(ish, "_discover_shortcuts", lambda: [a, b])
@@ -309,11 +309,11 @@ class TestUninstallShortcut:
         assert set(result.removed) == {a, b}
         assert not a.exists()
         assert not b.exists()
-        assert "2 HRFunc shortcut(s)" in result.message
+        assert "2 HRfunc shortcut(s)" in result.message
 
     def test_removes_directory_bundle(self, monkeypatch, tmp_path):
         """macOS .app bundles are directories; verify we use rmtree."""
-        bundle = tmp_path / "HRFunc.app"
+        bundle = tmp_path / "HRfunc.app"
         bundle.mkdir()
         (bundle / "Contents").mkdir()
         (bundle / "Contents" / "Info.plist").write_text("<plist/>")

--- a/tests/test_gui_welcome.py
+++ b/tests/test_gui_welcome.py
@@ -176,7 +176,7 @@ gui_app._register_pages()
 @pytest.mark.asyncio
 async def test_welcome_page_shows_brand_header(user: User):
     await user.open("/")
-    await user.should_see("HRFunc")
+    await user.should_see("HRfunc")
     await user.should_see("fNIRS hemodynamic response estimation")
 
 

--- a/tests/test_gui_welcome_shortcut_prompt.py
+++ b/tests/test_gui_welcome_shortcut_prompt.py
@@ -46,7 +46,7 @@ async def test_dialog_visible_when_not_yet_prompted(
         ish, "_marker_path", lambda: tmp_path / ".shortcut_prompted"
     )
     await user.open("/")
-    await user.should_see("Add HRFunc to your system menu?")
+    await user.should_see("Add HRfunc to your system menu?")
     await user.should_see("Yes, add it")
     await user.should_see("Not now")
     await user.should_see("Don't ask again")
@@ -63,7 +63,7 @@ async def test_dialog_hidden_when_already_prompted(
     await user.open("/")
     # The dialog title shouldn't appear
     with pytest.raises(AssertionError):
-        await user.should_see("Add HRFunc to your system menu?", retries=2)
+        await user.should_see("Add HRfunc to your system menu?", retries=2)
 
 
 async def test_yes_button_invokes_install_and_writes_marker(
@@ -80,7 +80,7 @@ async def test_yes_button_invokes_install_and_writes_marker(
         install_calls.append(1)
         return ish.InstallResult(
             ok=True,
-            locations=[Path("/tmp/HRFunc.app")],
+            locations=[Path("/tmp/HRfunc.app")],
             message="installed in Spotlight",
         )
 

--- a/tests/test_gui_workspace.py
+++ b/tests/test_gui_workspace.py
@@ -218,7 +218,7 @@ async def test_workspace_empty_state_when_no_manifest(user: User):
 async def test_workspace_renders_toolbar(user: User):
     global_state.reset()
     await user.open("/workspace")
-    await user.should_see("HRFunc")
+    await user.should_see("HRfunc")
     await user.should_see("Back to welcome")
 
 


### PR DESCRIPTION
## Summary

Standardize the project's brand name to match the paper: **HRFunc → HRfunc** (lowercase f). Mechanical find-and-replace across every `.py` / `.md` / `.toml` file. The GitHub repo itself was renamed separately.

## What changed

Pure string substitution: `HRFunc` → `HRfunc`. **30 files, 88 occurrences swapped, 88 insertions + 88 deletions** — zero behavioural changes.

**Not touched** (by design):
- Python package name `hrfunc` (already lowercase)
- PyPI distribution name `hrfunc`
- CLI command `hrfunc`
- Scientific abbreviation `HRF` (different string)
- File paths / imports (already lowercase)

**User-visible surfaces that flip:**
- Spotlight / Start menu / Activities shortcut display name → "HRfunc"
- NiceGUI window title → "HRfunc"
- All docstrings / README / CHANGELOG / inline comments
- Test assertions on display-text (`should_see("Add HRfunc to your system menu?")`)

## Implementation

Single sed pass over all `.py` / `.md` / `.toml` files outside the standard exclude dirs:

```bash
find . -type f \( -name "*.py" -o -name "*.md" -o -name "*.toml" \) \
    -not -path "*/.git/*" -not -path "*/.mypy_cache/*" \
    -not -path "*/.pytest_cache/*" -not -path "*/.ruff_cache/*" \
    -not -path "*/dist/*" \
    -exec sed -i '' 's/HRFunc/HRfunc/g' {} +
```

## Test plan

Full gate (29 test files): **560 passed, zero regressions** — test strings that asserted on user-visible display copy were swept by the same sed pass, so source + tests stayed in sync.

```
grep -rn "HRFunc" --include="*.py" --include="*.md" --include="*.toml" \
    --exclude-dir=.git --exclude-dir=.mypy_cache --exclude-dir=.pytest_cache \
    --exclude-dir=.ruff_cache --exclude-dir=dist .
# → zero matches
```

## Downstream notes

Anyone who previously ran `hrfunc install-shortcut` should re-run it after this merges to refresh the Spotlight / Start menu entry's display label. The CLI command itself (`hrfunc`) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)