### PR TITLE
fix: ui.run kwarg show_welcome_message_on_startup → show_welcome_message

### DIFF
--- a/src/hrfunc/gui/app.py
+++ b/src/hrfunc/gui/app.py
@@ -112,7 +112,7 @@ def _launch_gui(argv: List[str]) -> int:
         reload=False,
         show=True,
         port=_find_free_port(),
-        show_welcome_message_on_startup=False,
+        show_welcome_message=False,
     )
     return 0
 

--- a/tests/test_gui_foundation.py
+++ b/tests/test_gui_foundation.py
@@ -347,3 +347,73 @@ class TestRunInBackground:
 
         asyncio.run(run_in_background(s, lambda: "hello", on_done=_on_done))
         assert captured == ["hello"]
+
+
+# ---------------------------------------------------------------------------
+# Regression: ui.run kwargs must compose with the installed NiceGUI
+# ---------------------------------------------------------------------------
+
+
+class TestUiRunKwargs:
+    """Sprint 2.1 shipped ``ui.run(show_welcome_message_on_startup=False)``
+    — that kwarg doesn't exist on the real NiceGUI ``Config.__init__``.
+    Tests using the User fixture intercept ``ui.run`` and never validate
+    the kwargs against the real signature, so the bug shipped to v1.3.0
+    and only surfaced when researchers actually launched ``hrfunc`` from
+    the installed shortcut. This test introspects the live signature so
+    a future kwarg drift breaks CI instead of breaking users."""
+
+    def test_every_ui_run_kwarg_we_pass_is_valid(self):
+        import inspect
+
+        from nicegui import ui
+
+        from hrfunc.gui import app
+
+        # Pull the kwargs string out of _launch_gui's source. Cheap parser:
+        # find the `ui.run(` call and pull every `keyword=...` token before
+        # the closing paren. Resilient to formatting changes.
+        source = inspect.getsource(app._launch_gui)
+        marker = "ui.run("
+        start = source.index(marker) + len(marker)
+        # Match the closing paren by walking the source character-by-character
+        # with a paren counter. Avoids regex pitfalls with nested tuples
+        # like ``window_size=(1400, 900)``.
+        depth = 1
+        end = start
+        while end < len(source) and depth > 0:
+            ch = source[end]
+            if ch == "(":
+                depth += 1
+            elif ch == ")":
+                depth -= 1
+            end += 1
+        call_args = source[start:end - 1]
+
+        # Extract keyword names (before the `=` on each comma-separated arg).
+        kwarg_names = []
+        depth = 0
+        token = ""
+        for ch in call_args + ",":
+            if ch == "(":
+                depth += 1
+            elif ch == ")":
+                depth -= 1
+            if ch == "," and depth == 0:
+                bit = token.strip()
+                if "=" in bit:
+                    name = bit.split("=", 1)[0].strip()
+                    if name and name.isidentifier():
+                        kwarg_names.append(name)
+                token = ""
+            else:
+                token += ch
+
+        sig = inspect.signature(ui.run)
+        valid = set(sig.parameters)
+        unknown = [k for k in kwarg_names if k not in valid]
+        assert not unknown, (
+            f"_launch_gui passes ui.run kwargs that aren't in the installed "
+            f"NiceGUI's Config.__init__ signature: {unknown}. "
+            f"Check the NiceGUI changelog for renamed/removed parameters."
+        )


### PR DESCRIPTION
The bare `hrfunc` command crashed immediately on every machine with the public v1.3.0 release:

    TypeError: Config.__init__() got an unexpected keyword argument
    'show_welcome_message_on_startup'

The kwarg has been wrong since Sprint 2.1 (the bare bootstrap of the GUI app shell). NiceGUI's actual ``ui.run`` parameter is ``show_welcome_message`` — no ``_on_startup`` suffix.

The bug stayed hidden because every test that exercises the GUI uses ``nicegui.testing.User``, which intercepts ``ui.run`` and never validates the kwargs against the real
``nicegui.config.Config.__init__``. The bug only manifests when researchers actually launch the GUI (via ``hrfunc`` from the terminal or by clicking the system-menu shortcut, which silently inherits the same crash). It explains the "the shortcut doesn't open anything" report.

Fix
---

src/hrfunc/gui/app.py: rename the kwarg to ``show_welcome_message``. Verified against the installed NiceGUI's introspected signature (only ``show_welcome_message`` exists; no ``_on_startup`` variant).

Regression guard
----------------

tests/test_gui_foundation.py: ``TestUiRunKwargs::
test_every_ui_run_kwarg_we_pass_is_valid`` reads ``_launch_gui``'s source, extracts every kwarg name passed to ``ui.run(...)``, and asserts each one is in ``inspect.signature(ui.run).parameters``. Confirmed via a tampering test that the guard would have caught the original bug (it does — it produces
``['show_welcome_message_on_startup']`` as the unknown-kwarg list).

This catches the broader category of "kwarg works at module import time but breaks at runtime because the testing fixture intercepts the call". Future NiceGUI updates that rename or remove parameters will surface here instead of crashing users.

Test gate
---------

Full gate (29 test files): 561 passed, 0 regressions (was 560 after Sprint 5 + install-shortcut; +1 from the new regression guard).

User-side cleanup recommendation
--------------------------------

If you previously ran ``hrfunc install-shortcut`` with the broken code, the existing ``HRfunc.app`` bundle in ``~/Applications`` points at the same (broken) console script and inherits the same crash. After this fix lands, re-run ``hrfunc install-shortcut`` to refresh the bundle. Or just delete it manually and reinstall:

    rm -rf ~/Applications/HRfunc.app ~/Applications/HRFunc.app
    pip install --upgrade hrfunc[gui]
    hrfunc install-shortcut