### PR TITLE
fix: library viz shows real HRFs by filtering global sentinels + rekeying collisions

### DIFF
--- a/src/hrfunc/gui/pages/library.py
+++ b/src/hrfunc/gui/pages/library.py
@@ -404,16 +404,42 @@ def _kv(key: str, value: str) -> None:
 def gather_library_hrfs(state: AppState) -> Dict[str, Dict[str, Any]]:
     """Combine the HbO + HbR trees into a single name → HRF-dict map.
 
-    Returns empty dict if the trees aren't loaded. Each value is the
-    gathered-form dict produced by ``tree.gather``.
+    Returns empty dict if the trees aren't loaded.
+
+    Two filters applied while merging:
+
+    1. **Global sentinels excluded.** ``montage.estimate_hrf`` and friends
+       seed every Montage with ``global_hbo`` / ``global_hbr`` placeholder
+       entries at the sentinel location ``[~360, ~360, ~360]`` (out-of-
+       MNI-range so they don't collide with real optodes — see
+       ``montage._merge_montages`` and ``tree.get_canonical_hrf``). Those
+       entries leak into the bundled HRF databases when a researcher
+       saves their montage. They have no business in the user-facing
+       library browser, and at ``[360, 360, 360]`` they dominate
+       plotly's ``aspectmode="data"`` axis range, compressing the real
+       optode cluster (~0.07 m) to a single invisible pixel. Skip
+       anything whose key starts with ``global_``.
+    2. **Re-keyed by oxygenation prefix.** The bundled HbO and HbR
+       JSONs share at least one key (``s8_d4_hbr-temp`` appears in
+       both — community-contributed entries can be duplicated across
+       files). A plain ``dict.update`` would silently drop one copy on
+       collision. Prefixing with ``hbo:`` / ``hbr:`` preserves both
+       oxygenation flavors even when their optode-pair keys match.
     """
     out: Dict[str, Dict[str, Any]] = {}
-    for tree_obj in (state.library_hbo, state.library_hbr):
+    for tree_obj, prefix in (
+        (state.library_hbo, "hbo:"),
+        (state.library_hbr, "hbr:"),
+    ):
         if tree_obj is None:
             continue
         hrfs = tree_obj.gather(tree_obj.root)
-        if hrfs:
-            out.update(hrfs)
+        if not hrfs:
+            continue
+        for key, hrf in hrfs.items():
+            if key.startswith("global_"):
+                continue
+            out[f"{prefix}{key}"] = hrf
     return out
 
 

--- a/tests/test_gui_library.py
+++ b/tests/test_gui_library.py
@@ -158,6 +158,80 @@ class TestGatherLibraryHrfs:
         assert True in oxys
         assert False in oxys
 
+    def test_excludes_global_sentinel_entries(self):
+        """Regression: globals at sentinel location ~[360, 360, 360] were
+        dragging plotly's aspectmode=data axis range out 5000x and
+        compressing the real 0.07m HRF cluster to a single invisible
+        pixel. The user reported 'I only see 2 globals on the screen'.
+        gather_library_hrfs now skips any entry whose tree key starts
+        with 'global_'."""
+        s = AppState()
+        fake_hbo = type("FakeTree", (), {
+            "root": True,
+            "gather": lambda self, root: {
+                "s1_d1_hbo-temp": {"oxygenation": True, "location": [0.05, 0.05, 0.05]},
+                "global_hbo-temp": {"oxygenation": True, "location": [360, 360, 360]},
+            },
+        })()
+        s.library_hbo = fake_hbo
+        s.library_hbr = None
+
+        result = library.gather_library_hrfs(s)
+        keys = list(result.keys())
+        assert any("s1_d1_hbo" in k for k in keys), "real HRF should be present"
+        assert not any("global_" in k for k in keys), \
+            "global sentinel entries must be filtered out"
+        # And no entries with sentinel-scale locations
+        for hrf in result.values():
+            loc = hrf.get("location") or []
+            if len(loc) >= 3:
+                assert max(abs(c) for c in loc[:3]) < 1.0, \
+                    f"location {loc} looks like a sentinel; should have been filtered"
+
+    def test_namespaces_prefix_preserves_cross_file_collisions(self):
+        """Regression: the bundled HbO and HbR JSONs share at least one key
+        (e.g. ``s8_d4_hbr-temp`` appears in both). The previous plain
+        dict.update silently dropped one of the duplicates. Re-keying
+        with ``hbo:`` / ``hbr:`` prefixes preserves both."""
+        s = AppState()
+        shared = {"oxygenation": True, "location": [0.01, 0.02, 0.03]}
+        fake_hbo = type("FakeTree", (), {
+            "root": True,
+            "gather": lambda self, root: {"shared-key": shared},
+        })()
+        fake_hbr = type("FakeTree", (), {
+            "root": True,
+            "gather": lambda self, root: {
+                "shared-key": {**shared, "oxygenation": False},
+            },
+        })()
+        s.library_hbo = fake_hbo
+        s.library_hbr = fake_hbr
+
+        result = library.gather_library_hrfs(s)
+        # Both copies should survive, distinguished by namespace prefix
+        assert "hbo:shared-key" in result
+        assert "hbr:shared-key" in result
+        assert result["hbo:shared-key"]["oxygenation"] is True
+        assert result["hbr:shared-key"]["oxygenation"] is False
+
+    def test_bundled_library_no_sentinel_locations_reach_viz(self):
+        """End-to-end: after gather_library_hrfs filters globals, every
+        surviving HRF has an MNI-scale location (< 1 meter magnitude).
+        plotly's aspectmode=data won't blow up the axis range."""
+        s = AppState()
+        _silent(library._load_trees, s)
+        all_hrfs = _silent(library.gather_library_hrfs, s)
+        for key, hrf in all_hrfs.items():
+            loc = hrf.get("location") or []
+            if len(loc) >= 3:
+                max_coord = max(abs(c) for c in loc[:3])
+                assert max_coord < 1.0, (
+                    f"HRF {key} has location {loc} with coord {max_coord} m — "
+                    f"sentinel locations should have been filtered, real "
+                    f"optode locations should be on head scale (~0.1 m)."
+                )
+
 
 # ---------------------------------------------------------------------------
 # build_plotly_figure


### PR DESCRIPTION
## Summary

Bug Denny saw: the `/library` page HRtree viz showed only 2 HRF points (both at sentinel coords `[~360, ~360, ~360]`), with the actual brain-scale cluster nowhere to be found — even though the filter sidebar said "22 / 22 HRFs match".

Root cause: the bundled `hbo_hrfs.json` and `hbr_hrfs.json` each contain a `global_*` sentinel entry at `[~360, ~360, ~360]` (construction artifacts from `montage._merge_montages` that leaked into the saved databases). Plotly's `aspectmode="data"` auto-scaled the axes to fit these outliers, blowing up the visible range to a 360-meter cube and compressing the real ~0.07 m HRF cluster to a single sub-pixel dot. User saw 2 globals + invisible-tiny cluster.

Latent secondary issue: `gather_library_hrfs` used `dict.update` to merge HbO + HbR trees. The two JSONs share at least one key (`s8_d4_hbr-temp` exists in both), so the merge silently dropped one entry — that's why the filter said 22 instead of the true 23.

## Fix

`gather_library_hrfs`:
1. Skip any tree entry whose key starts with `global_`. Internal montage-construction artifacts shouldn't appear in a user-facing library browser.
2. Re-key on combine: HbO entries get `hbo:` prefix, HbR get `hbr:`. Cross-file collisions preserve both copies under their namespaced keys.

Result: 21 real HRFs reach the viz, all with MNI-scale locations. Plotly's auto-axis range now frames the actual brain cluster.

## Regression coverage

`TestGatherLibraryHrfs` gets 3 new tests:
- `test_excludes_global_sentinel_entries` — fake tree with a global; verify it's dropped.
- `test_namespaces_prefix_preserves_cross_file_collisions` — two fake trees emitting the same key; both survive under `hbo:` / `hbr:` namespaces.
- `test_bundled_library_no_sentinel_locations_reach_viz` — end-to-end against the real bundled JSON; every HRF reaching the viz has `max(|coord|) < 1.0 m`. This is the test that would have caught the original bug.

## Test plan

- [x] Full gate: **567 passed, 0 regressions** (was 564; +3 net).
- [ ] Smoke test on Denny's machine: pull main, run `hrfunc`, navigate to `/library`, confirm ~21 points visible on head-scale axes (not 2 outliers + invisible cluster).

## Why the parallel review caught this

Three specialist agents reviewed in parallel with different lenses (plotly rendering, AppState pollution, install/cache shenanigans). The install/cache reviewer found the sentinel `[~360, ~360, ~360]` entries in the JSON; I initially dismissed that finding because my smaller sample didn't include the globals at the dict's tail. Denny's "filter shows 22 but viz shows 2" observation forced a re-check, which surfaced the same sentinel-location finding empirically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
