### PR TITLE
feat: ROI selection on /library viz (anchor + radius + shift-hover paint) + fix HbO/HbR co-location occlusion

### DIFF
--- a/src/hrfunc/gui/pages/library.py
+++ b/src/hrfunc/gui/pages/library.py
@@ -140,6 +140,79 @@ def _load_trees(state: AppState) -> None:
 
 
 # ---------------------------------------------------------------------------
+# ROI shift-hover paint — JS injection
+# ---------------------------------------------------------------------------
+
+
+_PAINT_HOOK_HEAD_INJECTED = False
+
+
+def _ensure_shift_tracker_injected() -> None:
+    """Inject a global shift-key tracker into the page head (once per process).
+
+    The tracker writes ``window._hrfShift = True/False`` on Shift down/up,
+    plus a safety reset on window blur (so a Shift-down outside the window
+    followed by a release-outside doesn't leave a stuck shift state).
+
+    Page-render-scope idempotency: every /library render calls this, but
+    a module-level flag ensures we add the ``<script>`` to the document
+    head only once per process. Subsequent calls are no-ops.
+    """
+    global _PAINT_HOOK_HEAD_INJECTED
+    if _PAINT_HOOK_HEAD_INJECTED:
+        return
+    ui.add_head_html(
+        """
+<script>
+  if (window._hrfShiftWired === undefined) {
+    window._hrfShift = false;
+    window._hrfShiftWired = true;
+    document.addEventListener('keydown', (e) => {
+      if (e.key === 'Shift') window._hrfShift = true;
+    });
+    document.addEventListener('keyup', (e) => {
+      if (e.key === 'Shift') window._hrfShift = false;
+    });
+    window.addEventListener('blur', () => { window._hrfShift = false; });
+  }
+</script>
+"""
+    )
+    _PAINT_HOOK_HEAD_INJECTED = True
+
+
+def _install_paint_hook(plot_id: int) -> None:
+    """Hook the freshly-rendered plotly element's ``plotly_hover`` event.
+
+    Plotly's native hover event includes the points data; what we need
+    beyond that is the Shift-key state. We read it from the global
+    ``window._hrfShift`` flag wired by :func:`_ensure_shift_tracker_injected`,
+    then forward a custom ``roi_paint`` event up to the NiceGUI Python
+    handler via the element's ``$emit``.
+
+    A small ``ui.timer`` delay gives plotly's render cycle time to attach
+    the underlying div to the DOM before we query it.
+    """
+    _ensure_shift_tracker_injected()
+
+    js = f"""
+const el = getElement({plot_id}).$el;
+if (el && el.on && !el._hrfPaintHooked) {{
+  el._hrfPaintHooked = true;
+  el.on('plotly_hover', function(data) {{
+    if (!window._hrfShift) return;
+    if (!data || !data.points || !data.points.length) return;
+    const key = data.points[0].customdata;
+    if (!key) return;
+    getElement({plot_id}).$emit('roi_paint', {{key: key}});
+  }});
+}}
+"""
+
+    ui.timer(0.5, lambda: ui.run_javascript(js), once=True)
+
+
+# ---------------------------------------------------------------------------
 # Toolbar + empty state
 # ---------------------------------------------------------------------------
 
@@ -298,6 +371,50 @@ def _render_filter_pane(state: AppState) -> None:
             "forehead/head-mounted fNIRS optodes physically sit."
         )
 
+        # ── Region-of-Interest controls. Anchor is set by clicking an
+        # HRF in the viz; the radius slider sweeps neighbours into the
+        # ROI; Shift+hover adds individual HRFs (paint mode) for
+        # non-spherical selections. The averaged ROI trace renders in
+        # the detail pane (right side of the page).
+        ui.separator()
+        ui.label("Region of interest").classes(
+            "text-xs uppercase opacity-60 tracking-wide"
+        )
+        ui.label(
+            "Click an HRF to anchor. Hold Shift + hover to paint extra "
+            "same-oxygenation HRFs into the selection. The detail pane "
+            "shows the averaged trace."
+        ).classes("text-xs opacity-60")
+
+        radius_label = ui.label(
+            f"Radius: {state.library_roi_radius_m * 100:.1f} cm"
+        ).classes("text-xs font-mono opacity-80")
+
+        def _on_radius_change(event) -> None:
+            # The slider is in centimetres for human-readable steps; we
+            # store metres on state so the geometric compute keeps its
+            # MNI-meter native units.
+            cm = float(event.value)
+            state.library_roi_radius_m = cm / 100.0
+            radius_label.set_text(f"Radius: {cm:.1f} cm")
+            state.publish("library_filter_changed", state.library_filter)
+
+        ui.slider(
+            min=0.5, max=10.0, step=0.1,
+            value=state.library_roi_radius_m * 100.0,
+            on_change=_on_radius_change,
+        ).props("dense")
+
+        def _on_clear_roi() -> None:
+            state.library_selected_hrf = None
+            state.library_roi_painted.clear()
+            state.publish("library_selection_changed", None)
+            state.publish("library_filter_changed", state.library_filter)
+
+        ui.button(
+            "Clear ROI", on_click=_on_clear_roi
+        ).props("flat dense")
+
 
 # ---------------------------------------------------------------------------
 # Center pane: HRtree 3D viz
@@ -330,13 +447,26 @@ def _render_viz_pane(state: AppState) -> None:
             return
 
         with ui.column().classes("w-full h-full p-3 gap-2"):
+            # Compute ROI keys now so the figure draws the highlight
+            # halo and the label can report the count.
+            anchor = state.library_selected_hrf
+            roi_keys = compute_roi_keys(
+                matched,
+                anchor,
+                state.library_roi_radius_m,
+                state.library_roi_painted,
+            )
+            roi_status = ""
+            if roi_keys:
+                roi_status = f"  •  ROI: {len(roi_keys)} highlighted"
             ui.label(
-                f"HRtree — {len(matched)} HRFs shown"
+                f"HRtree — {len(matched)} HRFs shown{roi_status}"
             ).classes("text-sm opacity-70")
             fig = build_plotly_figure(
                 matched,
                 show_brain=state.library_show_brain,
                 show_scalp=state.library_show_scalp,
+                roi_keys=roi_keys,
             )
             plot = ui.plotly(fig).classes("w-full h-full")
 
@@ -351,10 +481,39 @@ def _render_viz_pane(state: AppState) -> None:
                 if hrf is None:
                     return
                 # Stash the key on the dict so the detail pane can show it.
+                # A plain click also resets the painted set — the user is
+                # picking a fresh anchor, so accumulated shift-hover paint
+                # from a prior anchor shouldn't carry over.
                 state.library_selected_hrf = {**hrf, "_key": hrf_key}
+                state.library_roi_painted.clear()
                 state.publish("library_selection_changed", hrf_key)
 
+            def _on_paint(event) -> None:
+                # Shift+hover fired our custom roi_paint event with a key
+                # in event.args. Add to painted set, refresh viz + detail.
+                args = getattr(event, "args", None) or {}
+                key = args.get("key") if isinstance(args, dict) else None
+                if not key or key not in matched:
+                    return
+                # Only paint HRFs that match the anchor's oxygenation so
+                # the average trace doesn't mix HbO + HbR (different
+                # physiological signals, scientifically wrong to average).
+                anchor_inner = state.library_selected_hrf
+                if anchor_inner is not None:
+                    if matched[key].get("oxygenation") != anchor_inner.get("oxygenation"):
+                        return
+                if key in state.library_roi_painted:
+                    return  # already painted, no-op
+                state.library_roi_painted.add(key)
+                state.publish("library_selection_changed", key)
+
             plot.on("plotly_click", _on_click)
+            plot.on("roi_paint", _on_paint)
+            # Wire the JS shift-tracker + plotly_hover hook AFTER the
+            # plotly element has rendered. Slight delay so the
+            # underlying div is queryable in the DOM. once=True so
+            # the hook isn't registered repeatedly on each refresh.
+            _install_paint_hook(plot.id)
 
     _viz_body()
 
@@ -512,11 +671,93 @@ def _render_detail_pane(state: AppState) -> None:
                 if png is not None:
                     ui.image(png).classes("max-w-md")
 
+            # ROI average plot (only renders when the ROI has at least
+            # 2 averageable same-oxygenation HRFs — fewer than that
+            # means there's nothing useful to average).
+            _render_roi_average(state)
+
     _detail_body()
 
     def _refresh_detail(_payload=None) -> None:
         _detail_body.refresh()
     state.subscribe("library_selection_changed", _refresh_detail)
+    # The radius slider publishes ``library_filter_changed`` because the
+    # viz already listens there; the detail pane needs to refresh too
+    # so the ROI-average plot updates when the user widens the radius.
+    state.subscribe("library_filter_changed", _refresh_detail)
+
+
+def _render_roi_average(state: AppState) -> None:
+    """Render the averaged-trace plot for the current ROI.
+
+    Pulls ``compute_roi_keys`` for the same set the viz highlights, then
+    feeds those to ``compute_roi_average``. Renders nothing when the ROI
+    has fewer than 2 averageable HRFs.
+    """
+    anchor = state.library_selected_hrf
+    if anchor is None:
+        return
+    all_hrfs = gather_library_hrfs(state)
+    matched = apply_filter(all_hrfs, state.library_filter)
+    roi_keys = compute_roi_keys(
+        matched,
+        anchor,
+        state.library_roi_radius_m,
+        state.library_roi_painted,
+    )
+    result = compute_roi_average(matched, roi_keys)
+    if result is None:
+        return
+    mean, std, n = result
+    sfreq = float(anchor.get("sfreq") or 1.0)
+    if sfreq <= 0:
+        sfreq = 1.0
+    ui.separator()
+    ui.label(
+        f"ROI average ({n} HRFs)"
+    ).classes("text-xs uppercase opacity-60 tracking-wide")
+    png = _render_roi_average_png(mean, std, sfreq, n)
+    if png is not None:
+        ui.image(png).classes("max-w-md")
+
+
+def _render_roi_average_png(
+    mean, std, sfreq: float, n: int
+) -> Optional[str]:
+    """Plot ROI-averaged trace with ±1 std shading."""
+    try:
+        import base64
+        import io as _io
+        import matplotlib
+        matplotlib.use("Agg", force=False)
+        import matplotlib.pyplot as plt
+        import numpy as np
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("matplotlib unavailable for ROI average: %s", exc)
+        return None
+    fig = None
+    try:
+        t = np.arange(len(mean)) / sfreq
+        fig, ax = plt.subplots(1, 1, figsize=(5, 2.5))
+        ax.plot(t, mean, lw=1.4, color="#f59e0b", label=f"mean (n={n})")
+        ax.fill_between(
+            t, mean - std, mean + std,
+            alpha=0.18, color="#f59e0b",
+            label="±1 std",
+        )
+        ax.set_xlabel("time (s)")
+        ax.set_ylabel("amplitude (a.u.)")
+        ax.legend(fontsize=8, loc="best")
+        fig.tight_layout()
+        buf = _io.BytesIO()
+        fig.savefig(buf, format="png", dpi=100, bbox_inches="tight")
+        return f"data:image/png;base64,{base64.b64encode(buf.getvalue()).decode('ascii')}"
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("ROI average render failed: %s", exc)
+        return None
+    finally:
+        if fig is not None:
+            plt.close(fig)
 
 
 def _kv(key: str, value: str) -> None:
@@ -632,10 +873,11 @@ def build_plotly_figure(
     *,
     show_brain: bool = False,
     show_scalp: bool = False,
+    roi_keys: Optional[Any] = None,
 ):
     """Build the 3D scatter figure for the given HRF dict.
 
-    Up to four traces, ordered so the HRF scatter renders on top:
+    Up to five traces, ordered so the ROI highlight renders on top:
 
     - **Scalp** (``go.Mesh3d``, only when ``show_scalp=True``):
       fsaverage outer-skin surface — anatomically where the optodes
@@ -645,14 +887,13 @@ def build_plotly_figure(
       originates. Drawn inside the scalp.
     - **HbO** (``go.Scatter3d``, red): oxygenated HRFs.
     - **HbR** (``go.Scatter3d``, blue): deoxygenated HRFs.
+    - **ROI** (``go.Scatter3d``, gold, larger): every HRF whose key
+      is in ``roi_keys``. Drawn last so the highlight sits above the
+      regular markers. Skipped when ``roi_keys`` is None or empty.
 
-    Both overlays are independent toggles — users can show either,
-    both, or neither. Both have ``hoverinfo="skip"`` and
-    ``showlegend=False`` so they don't clutter legend / hover UX.
-
-    Each scatter point's ``customdata`` is the HRF key so click
-    handlers can look it up; ``hovertext`` carries a short context
-    summary.
+    Mesh overlays have ``hoverinfo="skip"`` and ``showlegend=False``
+    so they don't clutter legend / hover UX. Each scatter point's
+    ``customdata`` is the HRF key for click + shift-hover handlers.
     """
     import plotly.graph_objects as go
 
@@ -727,7 +968,18 @@ def build_plotly_figure(
             go.Scatter3d(
                 x=hbo_x, y=hbo_y, z=hbo_z,
                 mode="markers",
-                marker=dict(size=4, color="#fb7185", opacity=0.85),
+                # HbO and HbR for the same optode pair share the exact 3D
+                # location (one source-detector → two measurements at one
+                # spot). Plotly Scatter3d draws traces in order, so without
+                # distinct symbols the second trace fully occludes the first.
+                # Distinct symbols + sizes keep both visible at the same xyz.
+                marker=dict(
+                    size=6,
+                    color="#fb7185",
+                    opacity=0.9,
+                    symbol="circle",
+                    line=dict(width=1, color="#7f1d1d"),
+                ),
                 name="HbO",
                 customdata=hbo_keys,
                 hovertext=hbo_hover,
@@ -739,13 +991,54 @@ def build_plotly_figure(
             go.Scatter3d(
                 x=hbr_x, y=hbr_y, z=hbr_z,
                 mode="markers",
-                marker=dict(size=4, color="#38bdf8", opacity=0.85),
+                marker=dict(
+                    size=4,
+                    color="#38bdf8",
+                    opacity=0.85,
+                    symbol="diamond",
+                    line=dict(width=1, color="#0c4a6e"),
+                ),
                 name="HbR",
                 customdata=hbr_keys,
                 hovertext=hbr_hover,
                 hoverinfo="text",
             )
         )
+
+    # ROI highlight — drawn LAST so the gold markers visually sit above
+    # the regular HbO/HbR scatter (same points still appear in the
+    # underlying trace; the ROI layer is an emphasis halo).
+    if roi_keys:
+        roi_x, roi_y, roi_z, roi_keys_list, roi_hover = [], [], [], [], []
+        for key in roi_keys:
+            hrf = hrfs.get(key)
+            if hrf is None:
+                continue
+            loc = hrf.get("location")
+            if loc is None or len(loc) < 3:
+                continue
+            roi_x.append(loc[0])
+            roi_y.append(loc[1])
+            roi_z.append(loc[2])
+            roi_keys_list.append(key)
+            roi_hover.append(_hover_text_for(key, hrf))
+        if roi_x:
+            traces.append(
+                go.Scatter3d(
+                    x=roi_x, y=roi_y, z=roi_z,
+                    mode="markers",
+                    marker=dict(
+                        size=8,
+                        color="#fbbf24",   # gold
+                        opacity=0.9,
+                        line=dict(width=1, color="#92400e"),
+                    ),
+                    name=f"ROI ({len(roi_x)})",
+                    customdata=roi_keys_list,
+                    hovertext=roi_hover,
+                    hoverinfo="text",
+                )
+            )
 
     fig = go.Figure(data=traces)
     fig.update_layout(
@@ -761,6 +1054,113 @@ def build_plotly_figure(
         plot_bgcolor="rgba(0,0,0,0)",
     )
     return fig
+
+
+def compute_roi_keys(
+    hrfs: Dict[str, Dict[str, Any]],
+    anchor: Optional[Dict[str, Any]],
+    radius_m: float,
+    painted: Optional[Any] = None,
+) -> "set":
+    """Return the set of HRF keys that belong to the current ROI.
+
+    Membership rules:
+    - If ``anchor`` is set and has a 3-element ``location``, every HRF
+      with the SAME ``oxygenation`` as the anchor whose Euclidean
+      distance to the anchor is ``<= radius_m`` is included.
+    - Every key in ``painted`` is included (filtered to the anchor's
+      oxygenation when an anchor is set, so a stray paint on the
+      wrong haemoglobin doesn't contaminate the average).
+
+    The anchor's own key is always part of the ROI when it's still in
+    ``hrfs`` (otherwise filtering away the anchor's neighbourhood
+    would be confusing).
+
+    Module-level so tests can hit it without spinning up the GUI.
+    """
+    out: set = set()
+    if anchor is None and not painted:
+        return out
+
+    anchor_loc = None
+    anchor_oxy = None
+    anchor_key = None
+    if anchor is not None:
+        anchor_loc = anchor.get("location")
+        anchor_oxy = anchor.get("oxygenation")
+        anchor_key = anchor.get("_key")
+        if anchor_key is not None and anchor_key in hrfs:
+            out.add(anchor_key)
+
+    if anchor_loc is not None and len(anchor_loc) >= 3 and radius_m > 0:
+        ax, ay, az = float(anchor_loc[0]), float(anchor_loc[1]), float(anchor_loc[2])
+        r2 = float(radius_m) * float(radius_m)
+        for key, hrf in hrfs.items():
+            loc = hrf.get("location")
+            if loc is None or len(loc) < 3:
+                continue
+            if anchor_oxy is not None and hrf.get("oxygenation") != anchor_oxy:
+                continue
+            dx, dy, dz = float(loc[0]) - ax, float(loc[1]) - ay, float(loc[2]) - az
+            if dx * dx + dy * dy + dz * dz <= r2:
+                out.add(key)
+
+    if painted:
+        for key in painted:
+            if key not in hrfs:
+                continue
+            if anchor_oxy is not None:
+                if hrfs[key].get("oxygenation") != anchor_oxy:
+                    continue
+            out.add(key)
+
+    return out
+
+
+def compute_roi_average(
+    hrfs: Dict[str, Dict[str, Any]],
+    roi_keys: Any,
+):
+    """Average the ``hrf_mean`` arrays of all HRFs in the ROI.
+
+    Returns ``(mean, std, n_used)`` numpy arrays + a count, or None if
+    fewer than 2 traces in the ROI are averageable.
+
+    Skips HRFs with empty / None / mismatched-length ``hrf_mean``.
+    Anchor's trace length is the canonical length; HRFs whose traces
+    don't match are skipped (we'd otherwise smear different durations
+    together silently).
+
+    Module-level so tests can call without a UI.
+    """
+    import numpy as np
+
+    traces = []
+    canonical_len: Optional[int] = None
+    for key in roi_keys:
+        hrf = hrfs.get(key)
+        if hrf is None:
+            continue
+        trace = hrf.get("hrf_mean")
+        if trace is None:
+            continue
+        try:
+            arr = np.asarray(trace, dtype=float)
+        except Exception:  # noqa: BLE001
+            continue
+        if arr.size == 0:
+            continue
+        if canonical_len is None:
+            canonical_len = arr.shape[0]
+        if arr.shape[0] != canonical_len:
+            continue
+        traces.append(arr)
+
+    if len(traces) < 2:
+        return None
+
+    stacked = np.vstack(traces)
+    return stacked.mean(axis=0), stacked.std(axis=0, ddof=0), len(traces)
 
 
 def _hover_text_for(key: str, hrf: Dict[str, Any]) -> str:

--- a/src/hrfunc/gui/state.py
+++ b/src/hrfunc/gui/state.py
@@ -161,6 +161,29 @@ class AppState:
     # cortex-relative position is the scientifically meaningful one.
     library_show_brain: bool = True
     library_show_scalp: bool = True
+    # ROI selection on the /library viz. Two ways to add HRFs to the
+    # ROI, used in combination:
+    #
+    # 1. **Anchor + radius**: click an HRF and every same-oxygenation
+    #    HRF inside the sphere of radius ``library_roi_radius_m``
+    #    around it gets included. The clicked HRF is the same dict
+    #    as ``library_selected_hrf`` (anchor + detail-pane focus
+    #    share state).
+    # 2. **Shift-hover painting**: hold Shift and hover over HRFs.
+    #    Each hovered key is added to ``library_roi_painted`` and
+    #    joins the ROI regardless of radius. Lets researchers trace
+    #    a non-spherical region by mouse, like a lasso.
+    #
+    # The full ROI is the union of (in-radius set) and the painted
+    # set, filtered to the anchor's oxygenation. The averaged trace
+    # in the detail pane is computed from this union.
+    #
+    # Radius default 0.02 m (2 cm) — a typical fNIRS short-separation
+    # neighbourhood. ``library_roi_painted`` is cleared on every new
+    # anchor click so the painted carryover from a prior anchor
+    # doesn't follow into a fresh selection.
+    library_roi_radius_m: float = 0.02
+    library_roi_painted: set = field(default_factory=set)
 
     def subscribe(self, event: str, callback: EventCallback) -> None:
         """Register ``callback`` to be called on ``publish(event, ...)``.
@@ -238,6 +261,8 @@ class AppState:
         # context overlays when they re-enter the library page.
         self.library_show_brain = True
         self.library_show_scalp = True
+        self.library_roi_radius_m = 0.02
+        self.library_roi_painted.clear()
         self.hrf_selected_channel = None
 
 

--- a/tests/test_gui_library.py
+++ b/tests/test_gui_library.py
@@ -410,6 +410,175 @@ class TestStateLibraryOverlays:
 
 
 # ---------------------------------------------------------------------------
+# Region-of-Interest selection
+# ---------------------------------------------------------------------------
+
+
+class TestComputeRoiKeys:
+    """``compute_roi_keys`` is the membership rule for the ROI: the
+    anchor's same-oxygenation neighbours within ``radius_m`` plus any
+    keys manually added via shift-hover paint."""
+
+    def _hrfs(self):
+        return {
+            "hbo:a": {"location": [0.00, 0.00, 0.00], "oxygenation": True},
+            "hbo:b": {"location": [0.01, 0.00, 0.00], "oxygenation": True},  # 1cm
+            "hbo:c": {"location": [0.05, 0.00, 0.00], "oxygenation": True},  # 5cm
+            "hbr:d": {"location": [0.00, 0.00, 0.00], "oxygenation": False},  # same loc, wrong oxy
+            "hbo:loc_less": {"oxygenation": True},  # no location
+        }
+
+    def test_no_anchor_no_painted_returns_empty(self):
+        hrfs = self._hrfs()
+        keys = library.compute_roi_keys(hrfs, None, 0.02, set())
+        assert keys == set()
+
+    def test_anchor_only_within_radius_same_oxygenation(self):
+        hrfs = self._hrfs()
+        anchor = {**hrfs["hbo:a"], "_key": "hbo:a"}
+        keys = library.compute_roi_keys(hrfs, anchor, 0.02, set())
+        # 2 cm radius → anchor + 1cm-away `b`. `c` at 5cm is excluded.
+        assert keys == {"hbo:a", "hbo:b"}
+
+    def test_excludes_different_oxygenation(self):
+        """``hbr:d`` sits at the same xyz as anchor but is HbR — must be
+        excluded even though it's distance-0. Averaging HbO with HbR is
+        scientifically wrong."""
+        hrfs = self._hrfs()
+        anchor = {**hrfs["hbo:a"], "_key": "hbo:a"}
+        keys = library.compute_roi_keys(hrfs, anchor, 0.02, set())
+        assert "hbr:d" not in keys
+
+    def test_widening_radius_picks_up_more(self):
+        hrfs = self._hrfs()
+        anchor = {**hrfs["hbo:a"], "_key": "hbo:a"}
+        # 10 cm radius → all HbO with locations (a, b, c) — not loc_less.
+        keys = library.compute_roi_keys(hrfs, anchor, 0.10, set())
+        assert keys == {"hbo:a", "hbo:b", "hbo:c"}
+
+    def test_painted_set_unions_into_roi(self):
+        hrfs = self._hrfs()
+        anchor = {**hrfs["hbo:a"], "_key": "hbo:a"}
+        # 0.5cm radius would leave only the anchor; painted "c" widens
+        # the ROI manually.
+        keys = library.compute_roi_keys(hrfs, anchor, 0.005, {"hbo:c"})
+        assert "hbo:c" in keys
+        assert "hbo:a" in keys
+
+    def test_painted_filtered_by_anchor_oxygenation(self):
+        """Even if the user paints an HbR HRF, anchor=HbO drops it from
+        the ROI so the average stays mono-haemoglobin."""
+        hrfs = self._hrfs()
+        anchor = {**hrfs["hbo:a"], "_key": "hbo:a"}
+        keys = library.compute_roi_keys(hrfs, anchor, 0.005, {"hbr:d"})
+        assert "hbr:d" not in keys
+
+
+class TestComputeRoiAverage:
+    def test_returns_none_with_fewer_than_two_traces(self):
+        hrfs = {
+            "a": {"hrf_mean": [1.0, 2.0, 3.0]},
+        }
+        assert library.compute_roi_average(hrfs, {"a"}) is None
+
+    def test_averages_same_length_traces(self):
+        import numpy as np
+        hrfs = {
+            "a": {"hrf_mean": [1.0, 2.0, 3.0]},
+            "b": {"hrf_mean": [3.0, 4.0, 5.0]},
+        }
+        result = library.compute_roi_average(hrfs, {"a", "b"})
+        assert result is not None
+        mean, std, n = result
+        assert n == 2
+        np.testing.assert_array_almost_equal(mean, [2.0, 3.0, 4.0])
+
+    def test_skips_mismatched_length_traces(self):
+        hrfs = {
+            "a": {"hrf_mean": [1.0, 2.0, 3.0]},
+            "b": {"hrf_mean": [1.0, 2.0]},  # different length → skip
+            "c": {"hrf_mean": [5.0, 6.0, 7.0]},
+        }
+        result = library.compute_roi_average(hrfs, {"a", "b", "c"})
+        assert result is not None
+        _, _, n = result
+        assert n == 2  # b was skipped
+
+    def test_skips_missing_hrfs_silently(self):
+        hrfs = {
+            "a": {"hrf_mean": [1.0, 2.0]},
+            "b": {"hrf_mean": [3.0, 4.0]},
+        }
+        # nonexistent-key in the ROI set should be tolerated
+        result = library.compute_roi_average(hrfs, {"a", "b", "ghost"})
+        assert result is not None
+        _, _, n = result
+        assert n == 2
+
+
+class TestStateLibraryROI:
+    def test_radius_default_is_2cm(self):
+        s = AppState()
+        assert s.library_roi_radius_m == 0.02
+
+    def test_painted_set_defaults_empty(self):
+        s = AppState()
+        assert s.library_roi_painted == set()
+
+    def test_reset_clears_painted_and_restores_radius(self):
+        s = AppState()
+        s.library_roi_radius_m = 0.07
+        s.library_roi_painted.add("some-key")
+        s.reset()
+        assert s.library_roi_radius_m == 0.02
+        assert s.library_roi_painted == set()
+
+
+class TestBuildFigureWithRoi:
+    def _hrfs(self):
+        return {
+            "hbo:a": {"location": [0.0, 0.0, 0.0], "oxygenation": True, "context": {}},
+            "hbo:b": {"location": [0.01, 0.0, 0.0], "oxygenation": True, "context": {}},
+            "hbr:c": {"location": [-0.01, 0.0, 0.0], "oxygenation": False, "context": {}},
+        }
+
+    def test_no_roi_keys_adds_no_roi_trace(self):
+        library._MESH_CACHE.clear()
+        fig = library.build_plotly_figure(self._hrfs(), roi_keys=None)
+        names = [t.name for t in fig.data]
+        assert all(not n.startswith("ROI") for n in names)
+
+    def test_roi_trace_added_with_count(self):
+        library._MESH_CACHE.clear()
+        fig = library.build_plotly_figure(
+            self._hrfs(), roi_keys={"hbo:a", "hbo:b"}
+        )
+        names = [t.name for t in fig.data]
+        assert any(n.startswith("ROI") for n in names)
+        roi_trace = next(t for t in fig.data if t.name.startswith("ROI"))
+        assert len(roi_trace.x) == 2
+
+    def test_roi_trace_is_last_drawn(self):
+        """ROI highlight should sit on top of the regular HbO/HbR markers."""
+        library._MESH_CACHE.clear()
+        fig = library.build_plotly_figure(
+            self._hrfs(), roi_keys={"hbo:a"}
+        )
+        # ROI trace must be the final element so it paints over scatter.
+        assert fig.data[-1].name.startswith("ROI")
+
+    def test_hbo_hbr_distinct_symbols(self):
+        """Regression for the co-located HbO+HbR occlusion bug — both
+        markers need distinct plotly symbols so they remain visible
+        when at the same 3D coordinates."""
+        library._MESH_CACHE.clear()
+        fig = library.build_plotly_figure(self._hrfs())
+        hbo = next(t for t in fig.data if t.name == "HbO")
+        hbr = next(t for t in fig.data if t.name == "HbR")
+        assert hbo.marker.symbol != hbr.marker.symbol
+
+
+# ---------------------------------------------------------------------------
 # Click extraction
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Two asks bundled because both touched `build_plotly_figure` and would otherwise have shipped on top of each other:

1. **ROI selection on the `/library` viz** — anchor + radius + shift-hover paint, with an averaged-trace plot in the detail pane.
2. **Fix for the "HbO HRFs aren't showing" bug** — HbO and HbR HRFs for the same optode pair share the exact 3D location, and plotly's render order made the second-drawn trace fully occlude the first. Same-coord, no distinguishable markers, HbO invisible.

## ROI selection

Two ways to add HRFs to the ROI:

- **Anchor + radius** (Option A from the design discussion): click an HRF → every same-oxygenation HRF within the radius (0.5-10 cm slider, default 2 cm) joins the ROI automatically.
- **Shift-hover paint** (Option C): hold Shift, hover over additional HRFs; each hovered key joins the painted set. Manual lasso-style selection for non-spherical regions.

Active ROI = (in-radius set) ∪ painted set, filtered to the anchor's oxygenation. Averaging HbO with HbR is scientifically wrong — this filter is non-negotiable.

Highlight = gold scatter trace drawn last (above the regular HbO/HbR markers). Detail pane gains an ROI-average plot with ±1 std shading.

## Shift-hover wiring

Plotly's hover event doesn't expose modifier keys to Python. I bridged it with ~30 lines of injected JS:

- `ui.add_head_html` once per process: tracks `window._hrfShift` on Shift down/up plus a window-blur safety reset.
- After plot render, `ui.run_javascript` hooks `plotly_hover`: when shift is held, the hovered key emits to Python via `$emit('roi_paint', ...)`.
- Python handler adds to `state.library_roi_painted` and refreshes.

500ms timer delay before the hover hook installs so the plotly div is in the DOM.

## HbO/HbR distinct symbols fix

- HbO: `circle`, size 6, dark-red outline
- HbR: `diamond`, size 4, dark-blue outline

Both visible when co-located — HbO ring with HbR diamond inside.

## State additions

```python
library_roi_radius_m: float = 0.02
library_roi_painted: set = field(default_factory=set)
```

`reset()` clears both.

## Test plan

- [x] Full gate: **597 passed, 0 regressions** (was 580; +17 net).
- [x] `compute_roi_keys` covers no-anchor, anchor-only-within-radius, oxygenation filter, radius widening, painted set union, painted oxygenation filter.
- [x] `compute_roi_average` covers <2 traces returns None, equal-length averaging, mismatched-length skip, missing key tolerance.
- [x] `build_plotly_figure` covers ROI trace presence + last-drawn order + distinct HbO/HbR symbols.
- [ ] Smoke test: launch GUI, click an HbO HRF, watch ROI radius highlight other HbOs in gold; widen slider; hold shift + hover an outlier to paint it in; verify detail pane shows averaged trace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
