### PR TITLE
feat: title styling + ROI download to workspace + fix pywebview ≥5 async dialog

### DIFF
--- a/docs/external/gui_guide.md
+++ b/docs/external/gui_guide.md
@@ -319,6 +319,24 @@ Empty until you click an HRF in the viz. Once selected, shows:
 - A trace preview plot in seconds (with ±1 standard-deviation shading
   when `hrf_std` is available)
 
+### Saving ROI averages
+
+After anchoring an HRF and pulling neighbors into the ROI (radius
+slider or Shift+hover paint), the detail pane shows an averaged
+trace and a **Save ROI average** button. Clicking saves the average
+plus its provenance as a JSON file in the **HRfunc workspace folder**:
+
+- Default location: `~/hrfunc_workspace/`
+- Override via the `HRFUNC_WORKSPACE` environment variable for shared
+  analysis directories: `export HRFUNC_WORKSPACE=/lab/shared/hrfunc`
+
+The file is named `roi_<anchor-key>_<UTC-timestamp>.json` and follows
+the same schema as the bundled library HRFs, so you can re-load with
+`hrfunc.tree.load_hrfs` if you want to treat the ROI average as a
+derived HRF. The `context` block records ROI provenance (anchor key,
+radius, member keys, active library filter, save timestamp) so you
+can audit what went into the average later.
+
 ### Library limitations to know about
 
 - **Read-only** — v1.3.0 does not let you delete, insert, or merge

--- a/src/hrfunc/gui/components/export_panel.py
+++ b/src/hrfunc/gui/components/export_panel.py
@@ -486,14 +486,17 @@ async def _pick_save_path(suggested: str, title: str) -> Optional[Path]:
         )
         return None
 
-    loop = asyncio.get_event_loop()
-    result = await loop.run_in_executor(
-        None,
-        lambda: window.create_file_dialog(
-            webview.SAVE_DIALOG,
-            save_filename=suggested,
-        ),
+    # pywebview ≥5 returns a coroutine here — see welcome.py:_pick_folder
+    # for the equivalent fix. Await the coroutine when present; older
+    # versions return synchronously.
+    import inspect
+
+    result = window.create_file_dialog(
+        webview.SAVE_DIALOG,
+        save_filename=suggested,
     )
+    if inspect.isawaitable(result):
+        result = await result
     if not result:
         return None
     # pywebview returns a string for SAVE_DIALOG and a list for OPEN/FOLDER
@@ -518,11 +521,10 @@ async def _pick_folder_path(title: str) -> Optional[Path]:
         )
         return None
 
-    loop = asyncio.get_event_loop()
-    paths = await loop.run_in_executor(
-        None,
-        lambda: window.create_file_dialog(webview.FOLDER_DIALOG),
-    )
+    import inspect
+
+    result = window.create_file_dialog(webview.FOLDER_DIALOG)
+    paths = await result if inspect.isawaitable(result) else result
     if not paths:
         return None
     return Path(paths[0])

--- a/src/hrfunc/gui/pages/library.py
+++ b/src/hrfunc/gui/pages/library.py
@@ -746,6 +746,42 @@ def _render_roi_average(state: AppState) -> None:
     if png is not None:
         ui.image(png).classes("max-w-md")
 
+    # ── Save-to-workspace button. Writes the averaged trace as JSON in
+    # the same schema as hrtree HRF entries (plus ROI provenance fields)
+    # so it can be re-loaded into hrfunc.tree if researchers want to
+    # treat the ROI average as a derived HRF.
+    def _on_save_roi() -> None:
+        from ..workspace_io import save_roi_average, workspace_dir
+
+        try:
+            out_path = save_roi_average(
+                anchor=anchor,
+                roi_keys=roi_keys,
+                hrf_mean=mean,
+                hrf_std=std,
+                sfreq=sfreq,
+                radius_m=state.library_roi_radius_m,
+                library_filter=state.library_filter,
+            )
+            ui.notify(
+                f"Saved ROI average to {out_path.name} "
+                f"({workspace_dir()})",
+                type="positive",
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("save ROI average failed: %s", exc)
+            ui.notify(
+                f"Save failed: {type(exc).__name__}: {exc}",
+                type="negative",
+            )
+
+    with ui.row().classes("gap-2 mt-1"):
+        ui.button(
+            "Save ROI average",
+            icon="download",
+            on_click=_on_save_roi,
+        ).props("color=primary dense")
+
 
 def _render_roi_average_png(
     mean, std, sfreq: float, n: int

--- a/src/hrfunc/gui/pages/welcome.py
+++ b/src/hrfunc/gui/pages/welcome.py
@@ -192,7 +192,16 @@ def _maybe_show_shortcut_prompt() -> None:
 
 def _render_header() -> None:
     with ui.column().classes("w-full items-center mt-12 mb-8 gap-2"):
-        ui.label("HRfunc").classes("text-6xl font-bold tracking-tight")
+        # "HR" upright, "func" italic — both Times New Roman to match
+        # the paper's typesetting. ui.html (vs ui.label) lets us emit
+        # the inline ``<em>`` tag for the italic span.
+        ui.html('HR<em>func</em>').style(
+            'font-family: "Times New Roman", Times, serif; '
+            'font-size: 4.5rem; '
+            'font-weight: bold; '
+            'letter-spacing: -0.025em; '
+            'line-height: 1;'
+        )
         ui.label("fNIRS hemodynamic response estimation").classes(
             "text-xl opacity-70"
         )
@@ -378,13 +387,20 @@ async def _pick_folder() -> Optional[Path]:
         )
         return None
 
-    import asyncio
+    # pywebview ≥5 made ``create_file_dialog`` an async coroutine
+    # (older versions were sync-blocking). The old ``run_in_executor``
+    # path returned the coroutine itself un-awaited, so ``paths`` was
+    # a coroutine object and the subsequent subscript raised
+    # ``TypeError: 'coroutine' object is not subscriptable``. Await
+    # the coroutine directly; pywebview's async API is built for the
+    # NiceGUI event loop.
+    import inspect
 
-    loop = asyncio.get_event_loop()
-    paths = await loop.run_in_executor(
-        None,
-        lambda: window.create_file_dialog(webview.FOLDER_DIALOG),
-    )
+    result = window.create_file_dialog(webview.FOLDER_DIALOG)
+    if inspect.isawaitable(result):
+        paths = await result
+    else:
+        paths = result
     if not paths:
         return None
     return Path(paths[0])

--- a/src/hrfunc/gui/workspace_io.py
+++ b/src/hrfunc/gui/workspace_io.py
@@ -1,0 +1,129 @@
+"""HRfunc workspace folder — outputs the GUI saves to disk.
+
+Researchers running HRfunc accumulate analysis outputs (ROI-averaged
+HRFs, exported HRF JSONs, etc.) that need a stable on-disk home so
+they aren't fishing through temp directories or downloading folders
+to find their saved files. This module owns the convention:
+
+- Default location: ``~/hrfunc_workspace/`` (cross-platform — works on
+  macOS, Linux, and Windows since every OS has a home directory).
+- Overridable via the ``HRFUNC_WORKSPACE`` environment variable for
+  researchers who keep their analysis outputs on a shared drive or
+  lab cluster.
+- Created lazily on first save — no directory clutter if the user
+  never saves anything.
+
+The naming ``workspace_io`` (vs just ``workspace``) is to keep this
+module distinct from the ``workspace`` *page* in ``pages/workspace.py``
+— that one is the scan-analysis surface; this one is on-disk file I/O.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Iterable, Optional
+
+logger = logging.getLogger(__name__)
+
+
+def workspace_dir() -> Path:
+    """Return the HRfunc workspace directory, creating it if missing.
+
+    Honors the ``HRFUNC_WORKSPACE`` environment variable for researchers
+    who keep their analysis outputs elsewhere; otherwise defaults to
+    ``~/hrfunc_workspace/``.
+
+    Created lazily on first call. Safe to call repeatedly; ``mkdir``
+    with ``exist_ok=True`` is a no-op when the directory already
+    exists.
+    """
+    override = os.environ.get("HRFUNC_WORKSPACE")
+    if override:
+        path = Path(override).expanduser()
+    else:
+        path = Path.home() / "hrfunc_workspace"
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _safe_filename_fragment(name: str) -> str:
+    """Sanitize a string for use as a filename fragment.
+
+    Replaces any character that's not alphanumeric, dash, underscore, or
+    dot with an underscore; collapses runs of underscores. Same idea as
+    the icon-bundle filename sanitizer in ``hrfunc.cli.install_shortcut``.
+    """
+    sanitized = re.sub(r"[^A-Za-z0-9._-]", "_", name)
+    sanitized = re.sub(r"__+", "_", sanitized)
+    return sanitized.strip("._") or "untitled"
+
+
+def save_roi_average(
+    *,
+    anchor: Dict[str, Any],
+    roi_keys: Iterable[str],
+    hrf_mean: Any,
+    hrf_std: Any,
+    sfreq: float,
+    radius_m: float,
+    library_filter: Optional[Dict[str, Any]] = None,
+    workspace: Optional[Path] = None,
+) -> Path:
+    """Save an ROI-averaged HRF to the workspace folder.
+
+    The output JSON extends the standard HRF entry schema (so it can
+    be re-loaded into ``hrfunc.tree`` if desired) with ROI provenance
+    fields so a researcher can audit what went into the average:
+
+    - ``hrf_mean`` / ``hrf_std`` — the averaged trace + per-sample std
+    - ``sfreq`` — sampling rate (same as the anchor)
+    - ``oxygenation`` — anchor's oxygenation (HbO or HbR)
+    - ``location`` — anchor's location (the spatial center of the ROI)
+    - ``context`` — extended with ROI metadata: anchor key, radius,
+      member keys, library filter that was active
+
+    File name: ``roi_<anchor_key_sanitized>_<YYYYMMDDTHHMMSSZ>.json``,
+    placed in the workspace folder. Returns the absolute Path.
+
+    Module-level so tests can call it without the GUI.
+    """
+    if workspace is None:
+        workspace = workspace_dir()
+
+    import numpy as np
+
+    mean_list = np.asarray(hrf_mean).tolist()
+    std_list = np.asarray(hrf_std).tolist()
+
+    anchor_key = anchor.get("_key") or "unknown"
+    payload: Dict[str, Any] = {
+        "hrf_mean": mean_list,
+        "hrf_std": std_list,
+        "sfreq": float(sfreq),
+        "oxygenation": bool(anchor.get("oxygenation")),
+        "location": anchor.get("location"),
+        "context": {
+            **(anchor.get("context") or {}),
+            "roi_average": True,
+            "roi_anchor_key": anchor_key,
+            "roi_radius_m": float(radius_m),
+            "roi_member_keys": sorted(roi_keys),
+            "roi_library_filter": dict(library_filter or {}),
+            "saved_at": datetime.now(timezone.utc).isoformat(),
+        },
+    }
+
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    fragment = _safe_filename_fragment(anchor_key)
+    out_path = workspace / f"roi_{fragment}_{timestamp}.json"
+
+    with open(out_path, "w", encoding="utf-8") as fh:
+        json.dump(payload, fh, indent=2)
+
+    logger.info("Saved ROI average to %s", out_path)
+    return out_path

--- a/tests/test_gui_workspace_io.py
+++ b/tests/test_gui_workspace_io.py
@@ -1,0 +1,199 @@
+"""Unit tests for ``hrfunc.gui.workspace_io``.
+
+Covers:
+- ``workspace_dir`` default location, env-var override, lazy mkdir.
+- ``save_roi_average`` schema, ROI provenance, filename sanitization.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+
+from hrfunc.gui.workspace_io import (
+    _safe_filename_fragment,
+    save_roi_average,
+    workspace_dir,
+)
+
+
+# ---------------------------------------------------------------------------
+# workspace_dir
+# ---------------------------------------------------------------------------
+
+
+class TestWorkspaceDir:
+    def test_env_override_used_when_set(self, tmp_path, monkeypatch):
+        target = tmp_path / "custom_workspace"
+        monkeypatch.setenv("HRFUNC_WORKSPACE", str(target))
+        result = workspace_dir()
+        assert result == target
+        assert target.exists()
+
+    def test_env_override_expands_user(self, tmp_path, monkeypatch):
+        """Tilde in HRFUNC_WORKSPACE should expand to the user's home."""
+        monkeypatch.setenv("HRFUNC_WORKSPACE", "~/test_hrfunc_ws_pytest")
+        result = workspace_dir()
+        assert str(result).startswith(str(Path.home()))
+        # Clean up
+        if result.exists():
+            result.rmdir()
+
+    def test_default_uses_home_when_no_env(self, monkeypatch, tmp_path):
+        # Stub Path.home() so the test doesn't pollute the real home dir.
+        monkeypatch.delenv("HRFUNC_WORKSPACE", raising=False)
+        fake_home = tmp_path / "fake_home"
+        fake_home.mkdir()
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: fake_home))
+        result = workspace_dir()
+        assert result == fake_home / "hrfunc_workspace"
+        assert result.exists()
+
+    def test_idempotent_create(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HRFUNC_WORKSPACE", str(tmp_path / "idempotent"))
+        first = workspace_dir()
+        second = workspace_dir()
+        assert first == second
+        assert first.exists()
+
+
+# ---------------------------------------------------------------------------
+# filename sanitization
+# ---------------------------------------------------------------------------
+
+
+class TestSafeFilenameFragment:
+    def test_alphanumeric_passes_through(self):
+        assert _safe_filename_fragment("s1_d1_hbo") == "s1_d1_hbo"
+
+    def test_replaces_slashes_colons_spaces(self):
+        out = _safe_filename_fragment("hbo:s1_d1_hbo-temp")
+        assert ":" not in out
+        # Underscore between the prefix and rest after sanitizing the colon
+        assert "hbo" in out and "s1_d1_hbo-temp" in out
+
+    def test_collapses_runs_of_underscores(self):
+        out = _safe_filename_fragment("a???b")
+        assert "__" not in out  # collapsed
+
+    def test_strips_leading_trailing_dots_underscores(self):
+        assert _safe_filename_fragment(".._hidden_._") == "hidden"
+
+    def test_empty_falls_back_to_untitled(self):
+        assert _safe_filename_fragment("") == "untitled"
+        assert _safe_filename_fragment("___") == "untitled"
+
+
+# ---------------------------------------------------------------------------
+# save_roi_average
+# ---------------------------------------------------------------------------
+
+
+class TestSaveRoiAverage:
+    def _anchor(self):
+        return {
+            "_key": "hbo:s1_d1_hbo-temp",
+            "oxygenation": True,
+            "location": [0.01, 0.02, 0.03],
+            "context": {"task": "flanker", "doi": "doi/A"},
+        }
+
+    def test_writes_json_in_workspace(self, tmp_path):
+        mean = np.array([1.0, 2.0, 3.0])
+        std = np.array([0.1, 0.2, 0.3])
+        out = save_roi_average(
+            anchor=self._anchor(),
+            roi_keys={"hbo:s1_d1_hbo-temp", "hbo:s2_d1_hbo-temp"},
+            hrf_mean=mean,
+            hrf_std=std,
+            sfreq=7.8125,
+            radius_m=0.02,
+            workspace=tmp_path,
+        )
+        assert out.parent == tmp_path
+        assert out.suffix == ".json"
+        assert out.exists()
+
+    def test_filename_includes_anchor_key_and_timestamp(self, tmp_path):
+        out = save_roi_average(
+            anchor=self._anchor(),
+            roi_keys=set(),
+            hrf_mean=[0.0],
+            hrf_std=[0.0],
+            sfreq=1.0,
+            radius_m=0.0,
+            workspace=tmp_path,
+        )
+        # Sanitized anchor key + timestamp pattern
+        assert out.name.startswith("roi_")
+        assert "hbo_s1_d1_hbo-temp" in out.name
+        # ISO basic format includes a 'T' separator
+        assert "T" in out.name
+
+    def test_payload_schema(self, tmp_path):
+        mean = np.array([1.5, 2.5])
+        std = np.array([0.5, 0.5])
+        out = save_roi_average(
+            anchor=self._anchor(),
+            roi_keys={"hbo:s1_d1_hbo-temp", "hbo:s2_d1_hbo-temp"},
+            hrf_mean=mean,
+            hrf_std=std,
+            sfreq=7.8125,
+            radius_m=0.02,
+            library_filter={"task": "flanker"},
+            workspace=tmp_path,
+        )
+        payload = json.loads(out.read_text())
+        assert payload["hrf_mean"] == [1.5, 2.5]
+        assert payload["hrf_std"] == [0.5, 0.5]
+        assert payload["sfreq"] == 7.8125
+        assert payload["oxygenation"] is True
+        assert payload["location"] == [0.01, 0.02, 0.03]
+        ctx = payload["context"]
+        # Anchor's original context preserved
+        assert ctx["task"] == "flanker"
+        assert ctx["doi"] == "doi/A"
+        # ROI provenance attached
+        assert ctx["roi_average"] is True
+        assert ctx["roi_anchor_key"] == "hbo:s1_d1_hbo-temp"
+        assert ctx["roi_radius_m"] == 0.02
+        assert ctx["roi_member_keys"] == [
+            "hbo:s1_d1_hbo-temp", "hbo:s2_d1_hbo-temp",
+        ]
+        assert ctx["roi_library_filter"] == {"task": "flanker"}
+        assert "saved_at" in ctx
+
+    def test_numpy_arrays_serialize_cleanly(self, tmp_path):
+        """numpy arrays must serialize through json.dump without TypeError."""
+        out = save_roi_average(
+            anchor=self._anchor(),
+            roi_keys={"a"},
+            hrf_mean=np.array([1.0, 2.0, 3.0], dtype=np.float32),
+            hrf_std=np.array([0.1, 0.2, 0.3], dtype=np.float32),
+            sfreq=10.0,
+            radius_m=0.02,
+            workspace=tmp_path,
+        )
+        payload = json.loads(out.read_text())
+        # Floats decode to plain Python floats
+        assert all(isinstance(x, float) for x in payload["hrf_mean"])
+
+    def test_member_keys_sorted_for_determinism(self, tmp_path):
+        """Set iteration order is unpredictable; ROI member keys in the
+        output should always sort for reproducibility."""
+        out = save_roi_average(
+            anchor=self._anchor(),
+            roi_keys={"hbo:z", "hbo:a", "hbo:m"},
+            hrf_mean=[0.0],
+            hrf_std=[0.0],
+            sfreq=1.0,
+            radius_m=0.0,
+            workspace=tmp_path,
+        )
+        payload = json.loads(out.read_text())
+        assert payload["context"]["roi_member_keys"] == ["hbo:a", "hbo:m", "hbo:z"]


### PR DESCRIPTION
## Summary

Three things bundled:

1. **Title styling.** Welcome title is now Times New Roman with `HR` upright and `func` italic. Uses `ui.html('HR<em>func</em>')` so the inline italic span renders directly.
2. **ROI download to workspace.** New `hrfunc.gui.workspace_io` module owns the on-disk convention: default `~/hrfunc_workspace/`, env-var override via `HRFUNC_WORKSPACE`. "Save ROI average" button in the detail pane writes the averaged trace as JSON matching the bundled HRF schema (so it's re-loadable with `hrfunc.tree.load_hrfs`) plus ROI provenance metadata.
3. **Bonus bug fix: pywebview ≥5 async `create_file_dialog`.** After the previous PR made the "Estimate hemodynamics" card actually fire, a deeper bug surfaced — pywebview ≥5 made the dialog API async, but our code wrapped it in `run_in_executor` and got back an unawaited coroutine. `paths[0]` raised `TypeError: 'coroutine' object is not subscriptable`. Fixed by detecting awaitability with `inspect.isawaitable` and awaiting when needed. Applied to all three dialog call sites (welcome folder picker, export save dialog, export folder picker).

## Save schema

```json
{
  "hrf_mean": [...], "hrf_std": [...],
  "sfreq": 7.8125, "oxygenation": true,
  "location": [-0.075, 0.062, 0.038],
  "context": {
    "task": "flanker", "doi": "...",
    "roi_average": true,
    "roi_anchor_key": "hbo:s1_d1_hbo-temp",
    "roi_radius_m": 0.02,
    "roi_member_keys": ["hbo:s1_d1_hbo-temp", "hbo:s2_d1_hbo-temp"],
    "roi_library_filter": {"task": "flanker"},
    "saved_at": "2026-05-12T07:32:00+00:00"
  }
}
```

Filename: `roi_<anchor_key_sanitized>_<UTC-timestamp>.json`.

## Test plan

- [x] Full gate: **617 passed, 0 regressions** (was 603; +14 net new).
- [x] `workspace_dir` env override + default + ~ expansion + idempotent create.
- [x] `_safe_filename_fragment` replaces special chars, collapses underscores, strips edges, falls back to "untitled".
- [x] `save_roi_average` schema verified end-to-end (payload + filename + numpy serialization + deterministic member key order).
- [ ] Smoke test: launch GUI; click "Estimate hemodynamics" → folder picker actually opens; in /library click HRF → "Save ROI average" → check `~/hrfunc_workspace/` for the JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
