### PR TITLE
refactor: extract spatial/viz primitives into modality-agnostic packages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,8 @@ packages = [
     "hrfunc.gui",
     "hrfunc.gui.components",
     "hrfunc.gui.pages",
+    "hrfunc.spatial",
+    "hrfunc.viz",
     ]
 include-package-data = true
 

--- a/src/hrfunc/gui/components/hrtree_panel.py
+++ b/src/hrfunc/gui/components/hrtree_panel.py
@@ -38,6 +38,12 @@ from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Tuple
 
 from nicegui import ui
 
+from ...spatial.coords import meters_to_mm
+from ...spatial.shapes import Sphere
+from ...viz.brain_scene import make_surface_trace
+from ...viz.meshes import MESH_CACHE as _MESH_CACHE
+from ...viz.meshes import MESH_FILENAMES as _MESH_FILENAMES
+from ...viz.meshes import load_brain_mesh, load_mesh
 from . import brand
 from ..state import AppState
 
@@ -46,22 +52,18 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-
-# Cached MNI head + brain meshes. Both are bundled in the wheel as decimated
-# fsaverage surfaces (~2.5k verts / 5k tris each, MNI-meter coords).
-# Loaded lazily on first toggle-on and reused for every subsequent render.
-#
-# Two layers (researchers find both useful and they show different things):
-#   - "pial"  → fsaverage lh.pial + rh.pial, stitched. The cortical surface.
-#   - "scalp" → fsaverage bem/outer_skin.surf. The head's outer skin —
-#               where forehead-mounted optodes physically sit, so HRF
-#               points overlay this surface anatomically correctly.
-_MESH_CACHE: Dict[str, Optional[Tuple["np.ndarray", "np.ndarray"]]] = {}
-
-_MESH_FILENAMES = {
-    "pial": "fsaverage_pial_lowpoly.npz",
-    "scalp": "fsaverage_scalp_lowpoly.npz",
-}
+# Mesh loaders were moved to :mod:`hrfunc.viz.meshes` during the v1.3
+# spatial/viz compartmentalization refactor. The names are re-exported
+# here so existing callers (``library.load_mesh``, ``library.load_brain_mesh``,
+# ``library._MESH_CACHE``, ``library._MESH_FILENAMES``) and the v1.3.0
+# test suite continue to work without import-path churn. New code should
+# import from ``hrfunc.viz.meshes`` directly.
+__all__ = (
+    "load_mesh",
+    "load_brain_mesh",
+    "_MESH_CACHE",
+    "_MESH_FILENAMES",
+)
 
 
 # Subset of context fields exposed as filter controls. The library tree
@@ -699,58 +701,6 @@ def _render_viz_pane(state: AppState) -> None:
     state.subscribe("hrtree_filter_changed", _refresh_viz)
 
 
-def load_mesh(layer: str) -> Optional[Tuple["np.ndarray", "np.ndarray"]]:
-    """Return a bundled MNI anatomical mesh as ``(vertices, faces)``.
-
-    Args:
-        layer: ``"pial"`` for the cortical surface (fsaverage lh.pial +
-            rh.pial stitched) or ``"scalp"`` for the outer-skin head
-            surface (fsaverage bem/outer_skin.surf). Anything else
-            returns None.
-
-    Both meshes are pre-decimated to ~2.5k verts / 5k triangles in
-    MNI-meter coordinates so they overlay directly on bundled HRF
-    locations without any transform. Results are cached per-layer at
-    module scope; the first call per layer pays the .npz load cost.
-
-    Returns None if the asset is missing, numpy can't be imported, or
-    the requested layer is unknown. Callers fall back to no-overlay
-    rendering rather than crashing.
-    """
-    if layer in _MESH_CACHE:
-        cached = _MESH_CACHE[layer]
-        return cached
-    filename = _MESH_FILENAMES.get(layer)
-    if filename is None:
-        logger.warning("load_mesh: unknown layer %r", layer)
-        _MESH_CACHE[layer] = None
-        return None
-    try:
-        import numpy as np
-        from importlib import resources
-
-        ref = resources.files("hrfunc.assets") / filename
-        with resources.as_file(ref) as path:
-            data = np.load(path)
-            verts = data["vertices"]
-            faces = data["faces"]
-        _MESH_CACHE[layer] = (verts, faces)
-        return _MESH_CACHE[layer]
-    except Exception as exc:  # noqa: BLE001
-        logger.warning("mesh load failed for layer=%r: %s", layer, exc)
-        _MESH_CACHE[layer] = None
-        return None
-
-
-# Back-compat alias for the original Sprint 4 single-mesh loader. Kept so
-# external callers (and the test suite) that imported ``load_brain_mesh``
-# don't break. Defaults to the scalp layer because that's the new visible
-# default in the GUI.
-def load_brain_mesh() -> Optional[Tuple["np.ndarray", "np.ndarray"]]:
-    """Deprecated alias for ``load_mesh("scalp")``."""
-    return load_mesh("scalp")
-
-
 def _extract_clicked_hrf_key(event) -> Optional[str]:
     """Pull the clicked HRF's key from a plotly click event payload."""
     try:
@@ -1117,15 +1067,12 @@ def build_plotly_figure(
         if mesh is not None:
             verts, faces = mesh
             traces.append(
-                go.Mesh3d(
-                    x=verts[:, 0], y=verts[:, 1], z=verts[:, 2],
-                    i=faces[:, 0], j=faces[:, 1], k=faces[:, 2],
+                make_surface_trace(
+                    verts, faces,
                     color="#c4b5a0",  # warm skin tone
                     opacity=0.12,
                     name="MNI head",
-                    hoverinfo="skip",
-                    showlegend=False,
-                    lighting=dict(ambient=0.6, diffuse=0.5),
+                    ambient=0.6, diffuse=0.5,
                 )
             )
     if show_brain:
@@ -1133,15 +1080,12 @@ def build_plotly_figure(
         if mesh is not None:
             verts, faces = mesh
             traces.append(
-                go.Mesh3d(
-                    x=verts[:, 0], y=verts[:, 1], z=verts[:, 2],
-                    i=faces[:, 0], j=faces[:, 1], k=faces[:, 2],
+                make_surface_trace(
+                    verts, faces,
                     color="#9ca3af",  # cool grey for cortex
                     opacity=0.30,
                     name="MNI brain",
-                    hoverinfo="skip",
-                    showlegend=False,
-                    lighting=dict(ambient=0.5, diffuse=0.6),
+                    ambient=0.5, diffuse=0.6,
                 )
             )
 
@@ -1258,6 +1202,14 @@ def compute_roi_keys(
     ``hrfs`` (otherwise filtering away the anchor's neighbourhood would
     be confusing).
 
+    The radius check is delegated to :class:`hrfunc.spatial.shapes.Sphere`.
+    HRF locations are stored in meters internally; the spatial layer
+    works in mm per the v1.3 compartmentalization convention, so this
+    function converts both the anchor and each candidate location to mm
+    before asking the sphere. The result is bit-identical to the
+    pre-refactor Euclidean check (``loc * 1000`` is exact for the
+    head-scale magnitudes here in float64).
+
     Module-level so tests can hit it without spinning up the GUI.
     """
     out: set = set()
@@ -1267,24 +1219,28 @@ def compute_roi_keys(
     anchor_loc = None
     anchor_oxy = None
     anchor_key = None
+    sphere: Optional[Sphere] = None
     if anchor is not None:
         anchor_loc = anchor.get("location")
         anchor_oxy = anchor.get("oxygenation")
         anchor_key = anchor.get("_key")
         if anchor_key is not None and anchor_key in hrfs:
             out.add(anchor_key)
+        if anchor_loc is not None and len(anchor_loc) >= 3 and radius_m > 0:
+            sphere = Sphere(
+                center_mm=meters_to_mm(anchor_loc[:3]).tolist(),
+                radius_mm=float(meters_to_mm(radius_m)),
+            )
 
-    if anchor_loc is not None and len(anchor_loc) >= 3 and radius_m > 0:
-        ax, ay, az = float(anchor_loc[0]), float(anchor_loc[1]), float(anchor_loc[2])
-        r2 = float(radius_m) * float(radius_m)
+    if sphere is not None:
         for key, hrf in hrfs.items():
             loc = hrf.get("location")
             if loc is None or len(loc) < 3:
                 continue
             if anchor_oxy is not None and hrf.get("oxygenation") != anchor_oxy:
                 continue
-            dx, dy, dz = float(loc[0]) - ax, float(loc[1]) - ay, float(loc[2]) - az
-            if dx * dx + dy * dy + dz * dz <= r2:
+            loc_mm = meters_to_mm(loc[:3]).tolist()
+            if sphere.contains(loc_mm):
                 out.add(key)
 
     if painted:

--- a/src/hrfunc/hrtree.py
+++ b/src/hrfunc/hrtree.py
@@ -638,6 +638,71 @@ class tree:
         }
         return hrfs
 
+    def to_hrf_points(self, modality_tag = "fnirs"):
+        """Yield modality-agnostic HRFPoint instances for every HRF in the tree.
+
+        Bridges the fNIRS-specific kd-tree to the modality-agnostic
+        :mod:`hrfunc.spatial` layer used by spatial selection shapes,
+        the GUI's 3D viz, and (in the future) a parallel fMRI HRF
+        pipeline. Internal coordinates are stored in meters; HRFPoints
+        live in MNI millimeters per the spatial-layer convention, so
+        coordinates are converted here at the boundary.
+
+        fNIRS-specific fields that don't fit the generic schema
+        (``oxygenation``, ``ch_name``, ``doi``) ride in
+        ``HRFPoint.context`` alongside the existing study/task/etc.
+        metadata. Consumers that don't care about them ignore the
+        extra keys; consumers that do (e.g. an HbO/HbR-grouped viz)
+        read them from context.
+
+        Skips HRFs that lack a usable 3-element location — those
+        can't be placed in MNI space and have no business in a
+        spatial pipeline.
+
+        Arguments:
+            modality_tag (str) - Tag used to identify the source
+                pipeline. Defaults to ``"fnirs"``; reserved for a
+                future fMRI tree to override.
+
+        Yields:
+            HRFPoint - One per traversable HRF node.
+        """
+        from .spatial.point import HRFPoint
+
+        if self.root is None:
+            return
+
+        nodes = self.gather(self.root)
+        for key, payload in nodes.items():
+            loc = payload.get("location")
+            if loc is None or len(loc) < 3:
+                continue
+            ctx = dict(payload.get("context") or {})
+            # Carry the fNIRS-specific bits and the tree's own key so
+            # spatial-layer consumers can route by oxygenation / look
+            # the source HRF back up without re-walking the tree.
+            ctx.setdefault("oxygenation", payload.get("oxygenation"))
+            ctx.setdefault("hrf_key", key)
+            hrf_mean = np.asarray(payload.get("hrf_mean") or [], dtype=np.float64)
+            std_raw = payload.get("hrf_std")
+            hrf_std = (
+                np.asarray(std_raw, dtype=np.float64)
+                if std_raw is not None and len(std_raw) > 0
+                else None
+            )
+            yield HRFPoint(
+                xyz_mm=(
+                    float(loc[0]) * 1000.0,
+                    float(loc[1]) * 1000.0,
+                    float(loc[2]) * 1000.0,
+                ),
+                hrf_mean=hrf_mean,
+                hrf_std=hrf_std,
+                sfreq=float(payload.get("sfreq") or 1.0),
+                context=ctx,
+                modality_tag=modality_tag,
+            )
+
     def save(self, filename = 'tree_hrfs.json'):
         hrfs = self.gather(self.root)
         # Save to a JSON file

--- a/src/hrfunc/spatial/__init__.py
+++ b/src/hrfunc/spatial/__init__.py
@@ -1,0 +1,44 @@
+"""Modality-agnostic spatial primitives.
+
+This package holds the data types and geometric helpers used by every
+downstream consumer of HRF spatial information: the GUI's HRtree
+panel, future ROI / clustering tools, and the planned parallel fMRI
+HRF pipeline. None of the code here knows about HbO/HbR, optodes, or
+any fNIRS-specific concept; that knowledge stays in :mod:`hrfunc.hrtree`.
+
+The boundary is intentional. fNIRS and fMRI both produce HRFs that
+live in MNI space and share the same downstream consumers (spatial
+selection, 3D visualization, ROI averaging). Keeping the spatial
+layer modality-agnostic lets a future fMRI module emit
+:class:`~hrfunc.spatial.point.HRFPoint` instances into the same
+pipeline without forking the viz stack.
+
+Public surface:
+
+- :class:`HRFPoint` — the modality-bridge DTO. Holds one HRF's
+  spatial location (MNI mm), mean / std trace, sampling rate, free-form
+  context dict, and a modality tag.
+- :class:`Shape` / :class:`Sphere` — point-in-region predicates for
+  ROI selection. Both operate in MNI mm.
+- :func:`meters_to_mm` / :func:`mm_to_meters` — the single conversion
+  point between MNE's internal meter coordinates and the mm scale
+  the spatial layer uses throughout.
+- :func:`apply_affine` / :func:`identity_affine` — 4×4 transform
+  helpers. Used by the v1.3.1 anatomical NIfTI viewer to map user-
+  supplied image coordinates into MNI mm.
+"""
+
+from .affine import apply_affine, identity_affine
+from .coords import meters_to_mm, mm_to_meters
+from .point import HRFPoint
+from .shapes import Shape, Sphere
+
+__all__ = [
+    "HRFPoint",
+    "Shape",
+    "Sphere",
+    "apply_affine",
+    "identity_affine",
+    "meters_to_mm",
+    "mm_to_meters",
+]

--- a/src/hrfunc/spatial/affine.py
+++ b/src/hrfunc/spatial/affine.py
@@ -1,0 +1,56 @@
+"""4×4 homogeneous affine transform helpers.
+
+Lives in :mod:`hrfunc.spatial` (not :mod:`hrfunc.viz`) because affines
+are a coordinate-system concern, not a rendering one. The full
+registration UX — loading a user-supplied NIfTI, deriving its
+sform/qform, letting the user override the transform — lands in
+PR #49 (v1.3.1). This module is the minimal API that PR will build
+on; locking it in now keeps the v1.3.1 work focused on the loader and
+QA UX rather than the math.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+def identity_affine() -> np.ndarray:
+    """Return the 4×4 identity matrix.
+
+    Convenience for callers that want an "no transform" affine without
+    having to reach for ``numpy.eye(4)`` directly.
+    """
+    return np.eye(4, dtype=np.float64)
+
+
+def apply_affine(affine: np.ndarray, points: np.ndarray) -> np.ndarray:
+    """Apply a 4×4 homogeneous affine to an ``(N, 3)`` array of points.
+
+    Args:
+        affine: 4×4 transform matrix (e.g. a NIfTI ``sform``/``qform``).
+        points: ``(N, 3)`` array of points in the source coordinate
+            system. A single ``(3,)`` point is also accepted for
+            convenience and returned with the leading axis preserved.
+
+    Returns:
+        Transformed points as a float64 array with the same leading-axis
+        shape as ``points``.
+    """
+    affine = np.asarray(affine, dtype=np.float64)
+    if affine.shape != (4, 4):
+        raise ValueError(f"affine must be 4x4, got shape {affine.shape}")
+
+    pts = np.asarray(points, dtype=np.float64)
+    single = pts.ndim == 1
+    if single:
+        if pts.shape != (3,):
+            raise ValueError(
+                f"single point must be shape (3,), got {pts.shape}"
+            )
+        pts = pts.reshape(1, 3)
+    if pts.ndim != 2 or pts.shape[1] != 3:
+        raise ValueError(f"points must be (N, 3), got shape {pts.shape}")
+
+    homo = np.column_stack([pts, np.ones(len(pts))])
+    transformed = (affine @ homo.T).T[:, :3]
+    return transformed[0] if single else transformed

--- a/src/hrfunc/spatial/coords.py
+++ b/src/hrfunc/spatial/coords.py
@@ -1,0 +1,39 @@
+"""Unit conversions between meters (MNE-internal) and millimeters (MNI mm).
+
+MNE-Python stores optode and channel positions in meters because the
+sensor-space transforms are defined that way internally. Neuroimaging
+atlases (Harvard-Oxford, AAL, MNI152) and the conventions used in
+fNIRS / fMRI publications work in millimeters.
+
+To avoid the "is this mm or m?" bug at every site that touches
+coordinates, the :mod:`hrfunc.spatial` and :mod:`hrfunc.viz` layers
+adopt the convention that **all spatial reasoning happens in MNI mm**.
+The meter representation is treated as an MNE storage detail; callers
+convert at the boundary using the helpers in this module.
+"""
+
+from __future__ import annotations
+
+from typing import Union
+
+import numpy as np
+
+ArrayLike = Union[float, "np.ndarray", list, tuple]
+
+
+def meters_to_mm(value: ArrayLike) -> "np.ndarray":
+    """Convert a scalar, sequence, or array from meters to millimeters.
+
+    Accepts any numeric input that ``numpy.asarray`` can interpret and
+    returns a float ndarray in millimeters. A 0-d ndarray is returned
+    for scalar input; callers that want a Python float can call
+    ``.item()`` on the result.
+    """
+    arr = np.asarray(value, dtype=np.float64)
+    return arr * 1000.0
+
+
+def mm_to_meters(value: ArrayLike) -> "np.ndarray":
+    """Convert a scalar, sequence, or array from millimeters to meters."""
+    arr = np.asarray(value, dtype=np.float64)
+    return arr / 1000.0

--- a/src/hrfunc/spatial/point.py
+++ b/src/hrfunc/spatial/point.py
@@ -1,0 +1,49 @@
+"""The :class:`HRFPoint` DTO — the modality bridge between fNIRS and fMRI."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional, Tuple
+
+import numpy as np
+
+
+@dataclass(frozen=True)
+class HRFPoint:
+    """One HRF's spatial location + trace, in a modality-agnostic shape.
+
+    This is the contract between HRF *producers* (today :mod:`hrfunc.hrtree`
+    for fNIRS, in the future a parallel fMRI pipeline) and HRF
+    *consumers* (the GUI's HRtree viz, spatial-shape ROI selection,
+    atlas lookups). Producers emit ``HRFPoint`` streams; consumers read
+    them without caring which modality produced the data.
+
+    Fields:
+
+    - ``xyz_mm`` — 3-tuple of MNI millimeters. The spatial layer's
+      single coordinate convention; producers convert from whatever
+      they store internally (e.g. MNE meters for fNIRS) at the
+      boundary.
+    - ``hrf_mean`` / ``hrf_std`` — the HRF trace and per-sample
+      standard deviation. ``hrf_std`` may be ``None`` for HRFs that
+      didn't carry uncertainty.
+    - ``sfreq`` — sampling frequency of the trace, in Hz.
+    - ``context`` — free-form metadata. Modality-specific fields
+      (``oxygenation`` for fNIRS, future fMRI-specific fields) ride
+      here so the DTO doesn't need to grow per-modality columns.
+    - ``modality_tag`` — short string identifying the source pipeline,
+      e.g. ``"fnirs"`` or ``"fmri"``. Consumers can use it for display
+      grouping or for routing modality-specific behavior.
+
+    The dataclass is frozen so consumers can pass it around without
+    worrying about mutation. Trace arrays are stored as ``np.ndarray``
+    for downstream math; producers should convert lists at construction
+    time.
+    """
+
+    xyz_mm: Tuple[float, float, float]
+    hrf_mean: np.ndarray
+    hrf_std: Optional[np.ndarray]
+    sfreq: float
+    context: Dict[str, Any] = field(default_factory=dict)
+    modality_tag: str = "unknown"

--- a/src/hrfunc/spatial/shapes.py
+++ b/src/hrfunc/spatial/shapes.py
@@ -1,0 +1,92 @@
+"""Spatial-region shapes for ROI selection.
+
+The :class:`Shape` abstract base defines a uniform predicate API:
+``contains(xyz_mm)`` returns whether a single MNI-mm point is inside
+the region. Concrete shapes (sphere now; box, atlas-region next)
+implement the predicate. All shapes operate in **MNI millimeters**
+so callers never juggle unit conversions inside their selection
+logic.
+
+PR #46 (this PR) ships only :class:`Sphere` and refactors the
+existing radius-based ROI selection on top of it. :class:`Box` lands
+in PR #47, :class:`AtlasRegion` in PR #48.
+"""
+
+from __future__ import annotations
+
+import abc
+from typing import Sequence, Tuple
+
+import numpy as np
+
+
+class Shape(abc.ABC):
+    """Abstract spatial region defined in MNI millimeters.
+
+    Subclasses implement :meth:`contains` (per-point) and optionally
+    override :meth:`contains_batch` to use a vectorised implementation;
+    the default loops over points and calls ``contains`` for each. For
+    small point counts (~hundreds, the fNIRS HRF library scale) the
+    looping default is fast enough that subclasses rarely need to
+    override.
+    """
+
+    @abc.abstractmethod
+    def contains(self, xyz_mm: Sequence[float]) -> bool:
+        """Return True iff ``xyz_mm`` (3-element sequence, MNI mm) is inside."""
+
+    def contains_batch(self, points_mm: np.ndarray) -> np.ndarray:
+        """Vectorised version of :meth:`contains` for an ``(N, 3)`` array.
+
+        Returns a boolean ``(N,)`` ndarray. The default implementation
+        loops over points and calls :meth:`contains` for each; vectorised
+        subclasses override for the hot path.
+        """
+        points = np.asarray(points_mm, dtype=np.float64)
+        if points.ndim != 2 or points.shape[1] != 3:
+            raise ValueError(
+                f"points_mm must be an (N, 3) array, got shape {points.shape}"
+            )
+        return np.array([self.contains(p) for p in points], dtype=bool)
+
+
+class Sphere(Shape):
+    """A sphere defined by an MNI-mm centre and a radius in mm.
+
+    Membership is closed (``distance <= radius``), matching the
+    existing ROI-radius semantics in the HRtree panel before this
+    refactor. Vectorised batch check avoids the per-point Python
+    call overhead.
+    """
+
+    __slots__ = ("center_mm", "radius_mm", "_radius_sq")
+
+    def __init__(self, center_mm: Sequence[float], radius_mm: float):
+        center = tuple(float(c) for c in center_mm)
+        if len(center) != 3:
+            raise ValueError(f"center_mm must have 3 elements, got {len(center)}")
+        if radius_mm < 0:
+            raise ValueError(f"radius_mm must be non-negative, got {radius_mm}")
+        self.center_mm: Tuple[float, float, float] = center
+        self.radius_mm: float = float(radius_mm)
+        self._radius_sq: float = float(radius_mm) * float(radius_mm)
+
+    def contains(self, xyz_mm: Sequence[float]) -> bool:
+        cx, cy, cz = self.center_mm
+        dx = float(xyz_mm[0]) - cx
+        dy = float(xyz_mm[1]) - cy
+        dz = float(xyz_mm[2]) - cz
+        return dx * dx + dy * dy + dz * dz <= self._radius_sq
+
+    def contains_batch(self, points_mm: np.ndarray) -> np.ndarray:
+        points = np.asarray(points_mm, dtype=np.float64)
+        if points.ndim != 2 or points.shape[1] != 3:
+            raise ValueError(
+                f"points_mm must be an (N, 3) array, got shape {points.shape}"
+            )
+        diff = points - np.asarray(self.center_mm, dtype=np.float64)
+        return np.einsum("ij,ij->i", diff, diff) <= self._radius_sq
+
+    def __repr__(self) -> str:
+        cx, cy, cz = self.center_mm
+        return f"Sphere(center_mm=({cx:.2f}, {cy:.2f}, {cz:.2f}), radius_mm={self.radius_mm:.2f})"

--- a/src/hrfunc/viz/__init__.py
+++ b/src/hrfunc/viz/__init__.py
@@ -1,0 +1,39 @@
+"""Modality-agnostic 3D visualisation primitives.
+
+Companion package to :mod:`hrfunc.spatial`. Where ``spatial`` owns
+the data and geometry, ``viz`` owns the rendering: anatomical surface
+loaders (fsaverage today, user-supplied NIfTI in v1.3.1) and the
+plotly-trace builders that compose them into a brain scene.
+
+Like ``spatial``, nothing here knows about HbO/HbR or any other
+fNIRS-specific concept. The future fMRI HRF pipeline will share this
+rendering layer unchanged — point clouds, shape overlays, and
+anatomical surfaces are all modality-agnostic.
+
+Public surface:
+
+- :func:`load_mesh` / :func:`load_brain_mesh` — fsaverage anatomical
+  surface loader (pial cortical + outer-skin scalp), bundled with
+  the wheel as decimated NPZ assets. ``load_brain_mesh`` is the
+  back-compat alias for callers that pre-date the dual-layer split.
+- :func:`make_surface_trace` — build a plotly ``Mesh3d`` trace from
+  ``(vertices, faces)`` arrays. Used by the HRtree panel to render
+  fsaverage surfaces today; will also be used by the v1.3.1
+  anatomical-NIfTI viewer.
+"""
+
+from .brain_scene import make_surface_trace
+from .meshes import (
+    MESH_CACHE,
+    MESH_FILENAMES,
+    load_brain_mesh,
+    load_mesh,
+)
+
+__all__ = [
+    "MESH_CACHE",
+    "MESH_FILENAMES",
+    "load_brain_mesh",
+    "load_mesh",
+    "make_surface_trace",
+]

--- a/src/hrfunc/viz/brain_scene.py
+++ b/src/hrfunc/viz/brain_scene.py
@@ -1,0 +1,69 @@
+"""Plotly trace builders for anatomical surfaces.
+
+Today this module exposes :func:`make_surface_trace`, the helper used
+by the HRtree panel to render the fsaverage scalp + pial overlays.
+The same helper will be re-used by the v1.3.1 anatomical-NIfTI viewer
+once user-supplied surfaces enter the pipeline — the brain-scene
+layer doesn't care whether the verts came from a bundled fsaverage
+NPZ or a marching-cubes pass over a user image.
+
+Kept deliberately thin in PR #46. As shape overlays (PR #47) and
+user anatomicals (PR #48) land, this module will grow a
+``BrainScene`` composer that owns ``add_surface`` / ``add_points``
+/ ``add_shape`` builder methods. For now, the figure assembly stays
+in the panel and only the per-trace construction lives here.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+
+def make_surface_trace(
+    verts: np.ndarray,
+    faces: np.ndarray,
+    *,
+    color: str,
+    opacity: float,
+    name: str,
+    ambient: float = 0.5,
+    diffuse: float = 0.6,
+) -> Any:
+    """Build a plotly ``Mesh3d`` trace for a 3D anatomical surface.
+
+    Args:
+        verts: ``(N, 3)`` array of vertex coordinates in the scene's
+            spatial units (MNI meters for the fsaverage bundle).
+        faces: ``(M, 3)`` array of triangle vertex indices.
+        color: CSS-style colour string for the surface.
+        opacity: Surface opacity in ``[0, 1]``.
+        name: Trace name; appears in plotly's hoverable trace list
+            even though we hide it from the legend.
+        ambient / diffuse: Plotly ``lighting`` parameters. The
+            fsaverage scalp uses a higher ambient (skin-tone reads
+            warmer); the brain mesh uses higher diffuse (so the
+            sulcal geometry is more legible).
+
+    The trace is configured with ``hoverinfo="skip"`` and
+    ``showlegend=False`` so anatomical surfaces don't clutter the
+    legend or steal hover events from the HRF point markers above
+    them.
+    """
+    import plotly.graph_objects as go
+
+    return go.Mesh3d(
+        x=verts[:, 0],
+        y=verts[:, 1],
+        z=verts[:, 2],
+        i=faces[:, 0],
+        j=faces[:, 1],
+        k=faces[:, 2],
+        color=color,
+        opacity=opacity,
+        name=name,
+        hoverinfo="skip",
+        showlegend=False,
+        lighting=dict(ambient=ambient, diffuse=diffuse),
+    )

--- a/src/hrfunc/viz/meshes.py
+++ b/src/hrfunc/viz/meshes.py
@@ -1,0 +1,95 @@
+"""Anatomical mesh loaders.
+
+Bundled fsaverage surfaces ship in :mod:`hrfunc.assets` as decimated
+NPZ files so no runtime fsaverage download is required. Two layers
+are available:
+
+- ``"pial"`` — fsaverage ``lh.pial`` + ``rh.pial`` stitched into a
+  single cortical-surface mesh.
+- ``"scalp"`` — fsaverage ``bem/outer_skin.surf``; the head's outer
+  skin, where forehead/head-mounted fNIRS optodes physically sit.
+
+Both meshes are pre-decimated to ~2.5k verts / 5k triangles and live
+in MNI-meter coordinates so they overlay directly on bundled HRF
+locations without any transform.
+
+This module was extracted from ``hrfunc.gui.components.hrtree_panel``
+during the v1.3 spatial/viz compartmentalization refactor. The GUI
+panel re-exports the public functions so existing callers (and tests)
+that import ``library.load_mesh`` keep working.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Dict, Optional, Tuple
+
+if TYPE_CHECKING:
+    import numpy as np
+
+logger = logging.getLogger(__name__)
+
+
+MESH_FILENAMES: Dict[str, str] = {
+    "pial": "fsaverage_pial_lowpoly.npz",
+    "scalp": "fsaverage_scalp_lowpoly.npz",
+}
+
+
+# Module-level cache shared across the process. Each layer is loaded
+# at most once; ``None`` is cached on load failure so repeated misses
+# don't keep retrying the asset import.
+MESH_CACHE: Dict[str, Optional[Tuple["np.ndarray", "np.ndarray"]]] = {}
+
+
+def load_mesh(layer: str) -> Optional[Tuple["np.ndarray", "np.ndarray"]]:
+    """Return a bundled MNI anatomical mesh as ``(vertices, faces)``.
+
+    Args:
+        layer: ``"pial"`` for the cortical surface or ``"scalp"`` for
+            the outer-skin head surface. Unknown layers return
+            ``None`` (and the unknown name is cached so repeated calls
+            don't keep warning).
+
+    Returns:
+        ``(verts, faces)`` as numpy arrays where ``verts`` is shape
+        ``(N, 3)`` of MNI-meter coordinates and ``faces`` is shape
+        ``(M, 3)`` of triangle vertex indices. Returns ``None`` if
+        numpy can't be imported, the asset is missing, or the layer
+        name is unknown — callers should fall back to no-overlay
+        rendering rather than crashing.
+    """
+    if layer in MESH_CACHE:
+        return MESH_CACHE[layer]
+    filename = MESH_FILENAMES.get(layer)
+    if filename is None:
+        logger.warning("load_mesh: unknown layer %r", layer)
+        MESH_CACHE[layer] = None
+        return None
+    try:
+        import numpy as np
+        from importlib import resources
+
+        ref = resources.files("hrfunc.assets") / filename
+        with resources.as_file(ref) as path:
+            data = np.load(path)
+            verts = data["vertices"]
+            faces = data["faces"]
+        MESH_CACHE[layer] = (verts, faces)
+        return MESH_CACHE[layer]
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("mesh load failed for layer=%r: %s", layer, exc)
+        MESH_CACHE[layer] = None
+        return None
+
+
+def load_brain_mesh() -> Optional[Tuple["np.ndarray", "np.ndarray"]]:
+    """Deprecated alias for ``load_mesh("scalp")``.
+
+    Kept so external callers and the test suite that imported
+    ``load_brain_mesh`` from the pre-dual-layer GUI module keep
+    working. Defaults to the scalp layer because that's the new
+    visible default. New code should call :func:`load_mesh` with an
+    explicit layer name.
+    """
+    return load_mesh("scalp")

--- a/tests/test_hrtree_to_hrf_points.py
+++ b/tests/test_hrtree_to_hrf_points.py
@@ -1,0 +1,124 @@
+"""Tests for the :meth:`hrfunc.hrtree.tree.to_hrf_points` adapter.
+
+The adapter is the bridge between the fNIRS-specific kd-tree and the
+modality-agnostic :class:`HRFPoint` DTO consumed by spatial selection
+and the GUI's 3D viz. These tests pin down the conversion semantics
+so a future fMRI tree class can target the same DTO contract.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import io as _io
+
+import numpy as np
+
+from hrfunc.hrtree import HRF, tree
+from hrfunc.spatial.point import HRFPoint
+
+
+def _silent(fn, *args, **kwargs):
+    """tree internals print on insert; suppress for clean test output."""
+    with contextlib.redirect_stdout(_io.StringIO()):
+        return fn(*args, **kwargs)
+
+
+def _make_tree_with_one_hbo_node():
+    t = tree()
+    hrf = HRF(
+        doi="doi/test",
+        ch_name="s1 d1 hbo",
+        duration=10.0,
+        sfreq=5.0,
+        trace=np.array([0.0, 0.5, 1.0, 0.5, 0.0]),
+        trace_std=np.array([0.1, 0.1, 0.1, 0.1, 0.1]),
+        location=[0.01, 0.02, 0.03],   # 10, 20, 30 mm
+        context={
+            "method": "toeplitz",
+            "doi": "doi/test",
+            "task": "flanker",
+            "duration": 10.0,
+        },
+    )
+    _silent(t.insert, hrf)
+    return t
+
+
+class TestEmptyTree:
+    def test_returns_no_points(self):
+        t = tree()
+        assert list(t.to_hrf_points()) == []
+
+
+class TestSingleNode:
+    def test_yields_one_hrf_point(self):
+        t = _make_tree_with_one_hbo_node()
+        points = list(_silent(lambda: list(t.to_hrf_points())))
+        assert len(points) == 1
+        assert isinstance(points[0], HRFPoint)
+
+    def test_coordinates_converted_to_mm(self):
+        t = _make_tree_with_one_hbo_node()
+        points = _silent(lambda: list(t.to_hrf_points()))
+        np.testing.assert_array_almost_equal(
+            points[0].xyz_mm, (10.0, 20.0, 30.0)
+        )
+
+    def test_trace_carried_as_ndarray(self):
+        t = _make_tree_with_one_hbo_node()
+        points = _silent(lambda: list(t.to_hrf_points()))
+        assert isinstance(points[0].hrf_mean, np.ndarray)
+        np.testing.assert_array_almost_equal(
+            points[0].hrf_mean, [0.0, 0.5, 1.0, 0.5, 0.0]
+        )
+
+    def test_std_carried_when_present(self):
+        t = _make_tree_with_one_hbo_node()
+        points = _silent(lambda: list(t.to_hrf_points()))
+        assert points[0].hrf_std is not None
+        np.testing.assert_array_almost_equal(
+            points[0].hrf_std, [0.1, 0.1, 0.1, 0.1, 0.1]
+        )
+
+    def test_sfreq_carried(self):
+        t = _make_tree_with_one_hbo_node()
+        points = _silent(lambda: list(t.to_hrf_points()))
+        assert points[0].sfreq == 5.0
+
+    def test_modality_tag_defaults_to_fnirs(self):
+        t = _make_tree_with_one_hbo_node()
+        points = _silent(lambda: list(t.to_hrf_points()))
+        assert points[0].modality_tag == "fnirs"
+
+    def test_modality_tag_can_be_overridden(self):
+        """Reserved for a future fMRI tree class to set its own tag."""
+        t = _make_tree_with_one_hbo_node()
+        points = _silent(lambda: list(t.to_hrf_points(modality_tag="fmri")))
+        assert points[0].modality_tag == "fmri"
+
+
+class TestContextCarriesFnirsFields:
+    def test_oxygenation_in_context(self):
+        """fNIRS-specific oxygenation flag rides in context so the DTO
+        stays modality-agnostic. HbO routes via context, not via a
+        first-class field."""
+        t = _make_tree_with_one_hbo_node()
+        points = _silent(lambda: list(t.to_hrf_points()))
+        # Channel name 's1 d1 hbo' → oxygenation=True
+        assert points[0].context.get("oxygenation") is True
+
+    def test_hrf_key_in_context(self):
+        """Consumers (e.g. spatial-shape ROI selection) need to map points
+        back to tree keys so they can recover the source HRF for averaging
+        / display. The adapter stores the key in context."""
+        t = _make_tree_with_one_hbo_node()
+        points = _silent(lambda: list(t.to_hrf_points()))
+        key = points[0].context.get("hrf_key")
+        assert key is not None
+        assert "s1" in key or "hbo" in key
+
+    def test_existing_context_preserved(self):
+        t = _make_tree_with_one_hbo_node()
+        points = _silent(lambda: list(t.to_hrf_points()))
+        assert points[0].context.get("task") == "flanker"
+        assert points[0].context.get("method") == "toeplitz"

--- a/tests/test_spatial_affine.py
+++ b/tests/test_spatial_affine.py
@@ -1,0 +1,56 @@
+"""Unit tests for :mod:`hrfunc.spatial.affine`.
+
+Affine is a stub in PR #46 — the full registration-QA workflow lands
+in PR #49 (v1.3.1 anatomical NIfTI viewer). These tests lock the
+minimal contract so PR #49 can build on it without surprises.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from hrfunc.spatial.affine import apply_affine, identity_affine
+
+
+class TestIdentityAffine:
+    def test_is_eye_four(self):
+        np.testing.assert_array_equal(identity_affine(), np.eye(4))
+
+    def test_is_float64(self):
+        assert identity_affine().dtype == np.float64
+
+
+class TestApplyAffine:
+    def test_identity_returns_points_unchanged(self):
+        points = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+        result = apply_affine(identity_affine(), points)
+        np.testing.assert_array_almost_equal(result, points)
+
+    def test_pure_translation(self):
+        affine = np.eye(4)
+        affine[:3, 3] = [10.0, 20.0, 30.0]
+        points = np.array([[0.0, 0.0, 0.0], [1.0, 1.0, 1.0]])
+        result = apply_affine(affine, points)
+        np.testing.assert_array_almost_equal(
+            result, [[10.0, 20.0, 30.0], [11.0, 21.0, 31.0]]
+        )
+
+    def test_pure_scale(self):
+        affine = np.diag([2.0, 3.0, 4.0, 1.0])
+        points = np.array([[1.0, 1.0, 1.0]])
+        result = apply_affine(affine, points)
+        np.testing.assert_array_almost_equal(result, [[2.0, 3.0, 4.0]])
+
+    def test_single_point_3vec_returns_3vec(self):
+        result = apply_affine(identity_affine(), np.array([1.0, 2.0, 3.0]))
+        assert result.shape == (3,)
+        np.testing.assert_array_almost_equal(result, [1.0, 2.0, 3.0])
+
+    def test_rejects_wrong_affine_shape(self):
+        with pytest.raises(ValueError, match="4x4"):
+            apply_affine(np.eye(3), np.array([[1.0, 2.0, 3.0]]))
+
+    def test_rejects_wrong_point_shape(self):
+        with pytest.raises(ValueError, match=r"\(N, 3\)"):
+            apply_affine(identity_affine(), np.array([[1.0, 2.0]]))

--- a/tests/test_spatial_coords.py
+++ b/tests/test_spatial_coords.py
@@ -1,0 +1,58 @@
+"""Unit tests for :mod:`hrfunc.spatial.coords`.
+
+The conversion helpers are tiny but load-bearing: every spatial-layer
+call site relies on them to bridge between MNE's internal meter
+representation and the MNI-mm convention used by the spatial /
+viz / atlas layers. A regression here would cascade into wrong
+shape-membership results and wrong atlas labels.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from hrfunc.spatial.coords import meters_to_mm, mm_to_meters
+
+
+class TestMetersToMm:
+    def test_scalar_input(self):
+        assert float(meters_to_mm(0.05)) == 50.0
+
+    def test_list_input(self):
+        result = meters_to_mm([0.01, 0.02, 0.03])
+        np.testing.assert_array_almost_equal(result, [10.0, 20.0, 30.0])
+
+    def test_tuple_input(self):
+        result = meters_to_mm((0.07, -0.05, 0.0))
+        np.testing.assert_array_almost_equal(result, [70.0, -50.0, 0.0])
+
+    def test_array_input(self):
+        arr = np.array([[0.01, 0.02], [0.03, 0.04]])
+        result = meters_to_mm(arr)
+        np.testing.assert_array_almost_equal(result, [[10.0, 20.0], [30.0, 40.0]])
+
+    def test_returns_float64(self):
+        result = meters_to_mm([1, 2, 3])
+        assert result.dtype == np.float64
+
+
+class TestMmToMeters:
+    def test_scalar_input(self):
+        assert float(mm_to_meters(50.0)) == 0.05
+
+    def test_list_input(self):
+        result = mm_to_meters([10.0, 20.0, 30.0])
+        np.testing.assert_array_almost_equal(result, [0.01, 0.02, 0.03])
+
+
+class TestRoundTrip:
+    def test_meters_round_trip(self):
+        """m → mm → m must be exact for head-scale magnitudes."""
+        original = np.array([0.01, 0.05, -0.07, 0.123456])
+        result = mm_to_meters(meters_to_mm(original))
+        np.testing.assert_array_equal(result, original)
+
+    def test_mm_round_trip(self):
+        original = np.array([10.0, 50.0, -70.0, 123.456])
+        result = meters_to_mm(mm_to_meters(original))
+        np.testing.assert_array_equal(result, original)

--- a/tests/test_spatial_point.py
+++ b/tests/test_spatial_point.py
@@ -1,0 +1,88 @@
+"""Unit tests for :class:`hrfunc.spatial.point.HRFPoint`.
+
+The DTO is the contract between HRF producers (fNIRS / fMRI) and
+HRF consumers (spatial selection, viz). These tests pin down its
+shape so a future fMRI module can target the same contract without
+breaking fNIRS callers.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+import numpy as np
+import pytest
+
+from hrfunc.spatial.point import HRFPoint
+
+
+class TestHRFPointConstruction:
+    def test_basic_construction(self):
+        trace = np.array([0.0, 1.0, 0.5])
+        point = HRFPoint(
+            xyz_mm=(10.0, 20.0, 30.0),
+            hrf_mean=trace,
+            hrf_std=None,
+            sfreq=10.0,
+            context={"task": "rest"},
+            modality_tag="fnirs",
+        )
+        assert point.xyz_mm == (10.0, 20.0, 30.0)
+        np.testing.assert_array_equal(point.hrf_mean, trace)
+        assert point.hrf_std is None
+        assert point.sfreq == 10.0
+        assert point.context == {"task": "rest"}
+        assert point.modality_tag == "fnirs"
+
+    def test_std_is_optional(self):
+        point = HRFPoint(
+            xyz_mm=(0.0, 0.0, 0.0),
+            hrf_mean=np.array([1.0]),
+            hrf_std=None,
+            sfreq=1.0,
+        )
+        assert point.hrf_std is None
+
+    def test_context_default_is_independent(self):
+        """Mutable-default-argument trap regression: each instance must own
+        its own context dict so mutating one doesn't leak to others."""
+        a = HRFPoint(xyz_mm=(0, 0, 0), hrf_mean=np.array([]), hrf_std=None, sfreq=1.0)
+        b = HRFPoint(xyz_mm=(1, 1, 1), hrf_mean=np.array([]), hrf_std=None, sfreq=1.0)
+        a.context["leak"] = True
+        assert "leak" not in b.context
+
+
+class TestHRFPointImmutability:
+    def test_frozen_prevents_reassignment(self):
+        point = HRFPoint(
+            xyz_mm=(0.0, 0.0, 0.0),
+            hrf_mean=np.array([0.0]),
+            hrf_std=None,
+            sfreq=1.0,
+        )
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            point.sfreq = 100.0  # type: ignore[misc]
+
+
+class TestHRFPointModalityTag:
+    def test_default_tag_is_unknown(self):
+        point = HRFPoint(
+            xyz_mm=(0.0, 0.0, 0.0),
+            hrf_mean=np.array([]),
+            hrf_std=None,
+            sfreq=1.0,
+        )
+        assert point.modality_tag == "unknown"
+
+    def test_modality_tag_distinguishes_sources(self):
+        """The whole point of the tag: future fMRI consumers should be
+        able to route by it without sniffing context fields."""
+        fnirs = HRFPoint(
+            xyz_mm=(0, 0, 0), hrf_mean=np.array([]), hrf_std=None,
+            sfreq=1.0, modality_tag="fnirs",
+        )
+        fmri = HRFPoint(
+            xyz_mm=(0, 0, 0), hrf_mean=np.array([]), hrf_std=None,
+            sfreq=1.0, modality_tag="fmri",
+        )
+        assert fnirs.modality_tag != fmri.modality_tag

--- a/tests/test_spatial_shapes.py
+++ b/tests/test_spatial_shapes.py
@@ -1,0 +1,112 @@
+"""Unit tests for :mod:`hrfunc.spatial.shapes`.
+
+The :class:`Shape` API is the foundation of the upcoming ROI shape
+selector (sphere now, box + atlas-region in PRs #47 and #48). These
+tests pin down the contains-semantics so the new shapes in those
+PRs can be added with the same predicate contract.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from hrfunc.spatial.shapes import Shape, Sphere
+
+
+class TestSphereConstruction:
+    def test_basic_construction(self):
+        sphere = Sphere(center_mm=(0.0, 0.0, 0.0), radius_mm=10.0)
+        assert sphere.center_mm == (0.0, 0.0, 0.0)
+        assert sphere.radius_mm == 10.0
+
+    def test_list_center_accepted(self):
+        sphere = Sphere(center_mm=[1.0, 2.0, 3.0], radius_mm=5.0)
+        assert sphere.center_mm == (1.0, 2.0, 3.0)
+
+    def test_rejects_wrong_dimensions(self):
+        with pytest.raises(ValueError, match="3 elements"):
+            Sphere(center_mm=(0.0, 0.0), radius_mm=5.0)
+
+    def test_rejects_negative_radius(self):
+        with pytest.raises(ValueError, match="non-negative"):
+            Sphere(center_mm=(0.0, 0.0, 0.0), radius_mm=-1.0)
+
+    def test_zero_radius_is_allowed(self):
+        """A degenerate point-sphere: only the centre is inside."""
+        sphere = Sphere(center_mm=(5.0, 5.0, 5.0), radius_mm=0.0)
+        assert sphere.contains((5.0, 5.0, 5.0)) is True
+        assert sphere.contains((5.0, 5.0, 5.001)) is False
+
+
+class TestSphereContains:
+    def test_inside_point(self):
+        sphere = Sphere(center_mm=(0.0, 0.0, 0.0), radius_mm=10.0)
+        assert sphere.contains((1.0, 2.0, 3.0)) is True
+
+    def test_outside_point(self):
+        sphere = Sphere(center_mm=(0.0, 0.0, 0.0), radius_mm=10.0)
+        assert sphere.contains((100.0, 0.0, 0.0)) is False
+
+    def test_boundary_point_is_inside(self):
+        """Membership is closed (``distance <= radius``) — matches the
+        pre-refactor ROI-radius semantics in the HRtree panel."""
+        sphere = Sphere(center_mm=(0.0, 0.0, 0.0), radius_mm=10.0)
+        assert sphere.contains((10.0, 0.0, 0.0)) is True
+
+    def test_offset_centre(self):
+        sphere = Sphere(center_mm=(30.0, 20.0, 10.0), radius_mm=5.0)
+        assert sphere.contains((30.0, 20.0, 10.0)) is True
+        assert sphere.contains((34.0, 20.0, 10.0)) is True   # 4 mm away
+        assert sphere.contains((36.0, 20.0, 10.0)) is False  # 6 mm away
+
+    def test_accepts_tuple_list_ndarray(self):
+        sphere = Sphere(center_mm=(0.0, 0.0, 0.0), radius_mm=10.0)
+        assert sphere.contains((1.0, 2.0, 3.0)) is True
+        assert sphere.contains([1.0, 2.0, 3.0]) is True
+        assert sphere.contains(np.array([1.0, 2.0, 3.0])) is True
+
+
+class TestSphereBatch:
+    def test_basic_batch(self):
+        sphere = Sphere(center_mm=(0.0, 0.0, 0.0), radius_mm=10.0)
+        points = np.array([
+            [0.0, 0.0, 0.0],   # inside
+            [10.0, 0.0, 0.0],  # boundary — inside (closed)
+            [11.0, 0.0, 0.0],  # outside
+            [3.0, 4.0, 0.0],   # 5 mm away — inside
+        ])
+        result = sphere.contains_batch(points)
+        np.testing.assert_array_equal(result, [True, True, False, True])
+
+    def test_batch_matches_per_point(self):
+        """Vectorised must agree with per-point loop. Catches einsum slip-ups."""
+        rng = np.random.default_rng(seed=42)
+        points = rng.uniform(-50, 50, size=(100, 3))
+        sphere = Sphere(center_mm=(0.0, 0.0, 0.0), radius_mm=20.0)
+        batch = sphere.contains_batch(points)
+        per_point = np.array([sphere.contains(p) for p in points])
+        np.testing.assert_array_equal(batch, per_point)
+
+    def test_batch_rejects_wrong_shape(self):
+        sphere = Sphere(center_mm=(0.0, 0.0, 0.0), radius_mm=10.0)
+        with pytest.raises(ValueError, match=r"\(N, 3\)"):
+            sphere.contains_batch(np.array([1.0, 2.0, 3.0]))  # 1D, not (N,3)
+
+
+class TestShapeABC:
+    def test_cannot_instantiate(self):
+        with pytest.raises(TypeError):
+            Shape()  # type: ignore[abstract]
+
+    def test_default_batch_uses_contains(self):
+        """A naive subclass that only implements ``contains`` should still
+        get a working ``contains_batch`` from the base class."""
+
+        class _OnlyContains(Shape):
+            def contains(self, xyz_mm):
+                return xyz_mm[0] >= 0
+
+        s = _OnlyContains()
+        result = s.contains_batch(np.array([[1.0, 0.0, 0.0], [-1.0, 0.0, 0.0]]))
+        np.testing.assert_array_equal(result, [True, False])

--- a/tests/test_viz_brain_scene.py
+++ b/tests/test_viz_brain_scene.py
@@ -1,0 +1,81 @@
+"""Unit tests for :mod:`hrfunc.viz.brain_scene`.
+
+The :func:`make_surface_trace` helper is intentionally thin in PR #46
+(it just wraps ``go.Mesh3d`` with our default hover / legend / lighting
+conventions). These tests pin those defaults so changes to the rendering
+behaviour are deliberate.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+pytest.importorskip("plotly")
+
+from hrfunc.viz.brain_scene import make_surface_trace  # noqa: E402
+
+
+def _tiny_mesh():
+    """A degenerate single-triangle mesh — enough to exercise plotly's
+    Mesh3d constructor without depending on the bundled fsaverage assets."""
+    verts = np.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]])
+    faces = np.array([[0, 1, 2]])
+    return verts, faces
+
+
+class TestMakeSurfaceTrace:
+    def test_returns_mesh3d(self):
+        verts, faces = _tiny_mesh()
+        trace = make_surface_trace(
+            verts, faces, color="#abc", opacity=0.5, name="x"
+        )
+        assert trace.type == "mesh3d"
+
+    def test_color_and_opacity_propagated(self):
+        verts, faces = _tiny_mesh()
+        trace = make_surface_trace(
+            verts, faces, color="#c4b5a0", opacity=0.12, name="MNI head"
+        )
+        assert trace.color == "#c4b5a0"
+        assert trace.opacity == 0.12
+        assert trace.name == "MNI head"
+
+    def test_hidden_from_legend_and_hover(self):
+        """Anatomical surfaces should never steal hover events from the
+        HRF scatter markers above them, and never clutter the legend."""
+        verts, faces = _tiny_mesh()
+        trace = make_surface_trace(
+            verts, faces, color="#abc", opacity=0.3, name="x"
+        )
+        assert trace.showlegend is False
+        assert trace.hoverinfo == "skip"
+
+    def test_lighting_defaults(self):
+        verts, faces = _tiny_mesh()
+        trace = make_surface_trace(
+            verts, faces, color="#abc", opacity=0.3, name="x"
+        )
+        assert trace.lighting.ambient == 0.5
+        assert trace.lighting.diffuse == 0.6
+
+    def test_lighting_overrides(self):
+        verts, faces = _tiny_mesh()
+        trace = make_surface_trace(
+            verts, faces, color="#abc", opacity=0.3, name="x",
+            ambient=0.6, diffuse=0.4,
+        )
+        assert trace.lighting.ambient == 0.6
+        assert trace.lighting.diffuse == 0.4
+
+    def test_vertex_coords_routed(self):
+        verts, faces = _tiny_mesh()
+        trace = make_surface_trace(
+            verts, faces, color="#abc", opacity=0.3, name="x"
+        )
+        np.testing.assert_array_equal(trace.x, verts[:, 0])
+        np.testing.assert_array_equal(trace.y, verts[:, 1])
+        np.testing.assert_array_equal(trace.z, verts[:, 2])
+        np.testing.assert_array_equal(trace.i, faces[:, 0])
+        np.testing.assert_array_equal(trace.j, faces[:, 1])
+        np.testing.assert_array_equal(trace.k, faces[:, 2])

--- a/tests/test_viz_meshes.py
+++ b/tests/test_viz_meshes.py
@@ -1,0 +1,79 @@
+"""Unit tests for :mod:`hrfunc.viz.meshes`.
+
+These tests exercise the mesh-loader's new home in ``hrfunc.viz.meshes``.
+The legacy v1.3.0 tests in ``test_gui_library.py::TestMeshLoader`` still
+exercise the same loader via the back-compat alias on ``hrtree_panel``;
+both test paths must agree because the panel re-exports the names.
+"""
+
+from __future__ import annotations
+
+from hrfunc.viz.meshes import (
+    MESH_CACHE,
+    MESH_FILENAMES,
+    load_brain_mesh,
+    load_mesh,
+)
+
+
+class TestKnownLayers:
+    def test_pial_returns_arrays(self):
+        MESH_CACHE.clear()
+        result = load_mesh("pial")
+        assert result is not None
+        verts, faces = result
+        assert verts.shape[1] == 3
+        assert faces.shape[1] == 3
+        assert 1_000 < verts.shape[0] < 50_000
+
+    def test_scalp_returns_arrays(self):
+        MESH_CACHE.clear()
+        result = load_mesh("scalp")
+        assert result is not None
+        verts, faces = result
+        assert verts.shape[1] == 3
+        assert faces.shape[1] == 3
+        assert 1_000 < verts.shape[0] < 50_000
+
+    def test_layers_in_mni_meter_scale(self):
+        """Same defensive bound that catches the 360-meter globals bug —
+        a future mm-scale rebuild would blow plotly's aspectmode=data."""
+        MESH_CACHE.clear()
+        for layer in ("pial", "scalp"):
+            verts, _ = load_mesh(layer)
+            assert float(abs(verts).max()) < 1.0
+
+
+class TestUnknownLayer:
+    def test_returns_none(self):
+        MESH_CACHE.clear()
+        assert load_mesh("not-a-real-layer") is None
+
+
+class TestCaching:
+    def test_per_layer_caching(self):
+        MESH_CACHE.clear()
+        a = load_mesh("pial")
+        b = load_mesh("pial")
+        assert a is b
+
+    def test_unknown_layer_cached_too(self):
+        """Repeated misses shouldn't keep re-warning."""
+        MESH_CACHE.clear()
+        load_mesh("ghost")
+        assert "ghost" in MESH_CACHE
+        assert MESH_CACHE["ghost"] is None
+
+
+class TestBackCompatAlias:
+    def test_load_brain_mesh_is_scalp(self):
+        MESH_CACHE.clear()
+        result = load_brain_mesh()
+        scalp = load_mesh("scalp")
+        assert result is scalp
+
+
+class TestMeshFilenamesDict:
+    def test_known_layers_listed(self):
+        assert "pial" in MESH_FILENAMES
+        assert "scalp" in MESH_FILENAMES


### PR DESCRIPTION
## Summary

- Extracts spatial/viz primitives from `hrtree_panel.py` into two new modality-agnostic top-level packages: `hrfunc.spatial` (Shape ABC + Sphere, HRFPoint DTO, m<->mm coords, affine helpers) and `hrfunc.viz` (fsaverage mesh loader, plotly Mesh3d builder).
- Pure refactor -- no user-visible behaviour change. Sets up the foundation for PRs #47-#49 (box shape + atlas + anatomical viewer) and the planned parallel fMRI HRF pipeline, both of which need a spatial/viz layer that knows nothing about HbO/HbR.
- `compute_roi_keys` now delegates the radius check to `Sphere.contains`; `build_plotly_figure` builds mesh traces via `hrfunc.viz.brain_scene.make_surface_trace`. Sphere semantics are bit-identical to the previous Euclidean check.
- New `tree.to_hrf_points()` adapter yields modality-agnostic `HRFPoint` DTOs. Used by the upcoming shape selector and the v1.3.1 anatomical viewer.

## What moved where

| Symbol | Before | After |
|---|---|---|
| `load_mesh`, `load_brain_mesh` | `gui.components.hrtree_panel` | `hrfunc.viz.meshes` (re-exported from panel for back-compat) |
| `_MESH_CACHE`, `_MESH_FILENAMES` | `gui.components.hrtree_panel` | `hrfunc.viz.meshes.MESH_CACHE`, `MESH_FILENAMES` (re-exported with underscore alias for back-compat) |
| Sphere distance math | inline in `compute_roi_keys` | `hrfunc.spatial.shapes.Sphere.contains` |
| Mesh3d trace construction | inline in `build_plotly_figure` | `hrfunc.viz.brain_scene.make_surface_trace` |

## Back-compat preserved

The GUI panel re-exports `load_mesh`, `load_brain_mesh`, `_MESH_CACHE`, and `_MESH_FILENAMES` at module level so existing callers and the v1.3.0 test suite continue to work without churn. All 67 pre-existing `test_gui_library` tests pass.

## New tests

63 tests across 7 new files (`test_spatial_coords`, `test_spatial_shapes`, `test_spatial_point`, `test_spatial_affine`, `test_viz_meshes`, `test_viz_brain_scene`, `test_hrtree_to_hrf_points`). All green.

## Test plan

- [x] All 63 new unit tests pass
- [x] All 67 existing `test_gui_library` tests pass (back-compat aliases + sphere refactor verified bit-identical)
- [x] Full test suite is green outside two pre-existing flakes (`test_localization.py` collection error in `nearest_neighbor`, `test_io_raw_cache.py` order-dependent fixture errors -- both present on `main`, both out of scope for this PR)
- [ ] Manual smoke: launch `hrfunc` GUI, open HRtree tab, verify sphere ROI + shift-hover paint + save-ROI all behave identically to v1.3.0

## Out of scope

- Box shape -- PR #47
- Harvard-Oxford atlas -- PR #48
- Anatomical NIfTI viewer + registration QA -- PR #49 (v1.3.1)
- Pre-existing `nearest_neighbor` bug at `hrtree.py:505` that prevents `test_localization.py` from collecting (`best[0].ch_name` on `(None, inf)` tuple)
- Pre-existing order-dependent fixture errors in `test_io_raw_cache.py`

## Notes for reviewers

- `tree.to_hrf_points()` does an MNE-meters-to-MNI-mm conversion at the boundary. All downstream spatial code works in mm; this is the single conversion point.
- `Sphere` membership is closed (`distance <= radius`), matching the previous ROI semantics. Tested explicitly.
- `HRFPoint` is a frozen dataclass; fNIRS-specific fields (`oxygenation`, `hrf_key`) ride in `context` to keep the DTO modality-agnostic.

Generated with [Claude Code](https://claude.com/claude-code)