### PR TITLE
fix: guard nearest_neighbor verbose-print against (None, inf) sentinel

### DIFF
--- a/src/hrfunc/hrtree.py
+++ b/src/hrfunc/hrtree.py
@@ -502,7 +502,17 @@ class tree:
         # Handle base cases
         if node is None:
             if best is not None:
-                if verbose: print(f"No further branch, returning running best {best[0].ch_name}")
+                # ``best`` may be the ``(None, inf)`` sentinel returned by a
+                # deeper-recursion empty-tree or no-match path, not a real
+                # ``(node, distance)`` tuple. Guard the verbose-print branch
+                # so it doesn't dereference ``ch_name`` on None — pre-fix
+                # this crashed ``test_localization.py`` at collection time
+                # whenever an optode had no in-radius match under verbose.
+                if verbose:
+                    if best[0] is not None:
+                        print(f"No further branch, returning running best {best[0].ch_name}")
+                    else:
+                        print("No further branch, propagating empty-result sentinel")
                 return best
             else:
                 if verbose: print("No further branch and no best yet")

--- a/tests/test_tree_edge_cases.py
+++ b/tests/test_tree_edge_cases.py
@@ -243,3 +243,38 @@ class TestNearestNeighborEmptyTree:
         result, distance = t.nearest_neighbor(near_probe, max_distance=0.01)
         assert result is a
         assert distance < 0.01
+
+    def test_verbose_with_no_match_does_not_crash(self):
+        """Regression for the ``best[0].ch_name`` crash in the verbose
+        print branch.
+
+        When recursion bottoms out with no real best (e.g. every
+        candidate node fails the oxygenation match), the inner call
+        returns the ``(None, inf)`` sentinel. The outer call then hits
+        the ``node is None`` base case with a *non-None tuple* whose
+        first element IS None, and the verbose-print at the old
+        line 505 dereferenced ``best[0].ch_name`` and crashed with
+        ``AttributeError: 'NoneType' object has no attribute 'ch_name'``.
+
+        The user-visible impact was that ``test_localization.py``
+        couldn't even *collect* — its top-level code calls
+        ``localize_hrfs`` with ``verbose=True`` and hits this path
+        whenever a probe has no in-radius match.
+
+        This test reproduces the failure shape (oxygenation-mismatched
+        single-node tree under ``verbose=True``) and proves the guard
+        on the verbose-print path prevents the crash.
+        """
+        from hrfunc.hrtree import tree
+        t = tree()
+        # Insert an HbR node; probe is HbO, so oxygenation will mismatch
+        # at every node visited and ``best`` stays the ``(None, inf)``
+        # sentinel through the recursion.
+        t.insert(_hrf('a', 0.0, 0.0, 0.0, oxygenation=False))
+        hbo_probe = _hrf('probe', 0.001, 0.001, 0.001, oxygenation=True)
+        # Should not raise — the verbose-print path is now guarded.
+        result, distance = t.nearest_neighbor(
+            hbo_probe, max_distance=0.001, verbose=True,
+        )
+        assert result is None
+        assert distance == float('inf')


### PR DESCRIPTION
## Summary

- Guards the verbose-print branch in `tree.nearest_neighbor` against the `(None, inf)` empty-result sentinel.
- Pre-existing bug, flagged during PR #46 review as out of scope and fixed here as the first of two follow-up cleanups (the other is the `io_raw_cache` monkeypatch order issue, coming next).

## The bug

`tree.nearest_neighbor` returns `(None, float("inf"))` from the empty-tree early return and the no-match recursive base case. Both produce a non-None tuple whose first element is None. When that sentinel propagates back up and a parent invocation hits the `node is None` base case with this `best`, the old verbose-print line at [hrtree.py:505](src/hrfunc/hrtree.py#L505) dereferenced `best[0].ch_name` and crashed:

```
AttributeError: 'NoneType' object has no attribute 'ch_name'
```

## User-visible impact

`test_localization.py` couldn't even **collect**. Its top-level code calls `localize_hrfs(..., verbose=True)` and hits this path whenever an optode has no in-radius match. Surfaced during the PR #46 full-suite run.

## Fix

One guarded branch in the verbose-print path -- when `best[0]` is None, print an explicit empty-result message instead of dereferencing it. Return semantics unchanged so callers that already handled `(None, inf)` keep working.

## Regression test

`TestNearestNeighborEmptyTree::test_verbose_with_no_match_does_not_crash` reproduces the failure shape (oxygenation-mismatched single-node tree under `verbose=True`) and proves the guard.

## Test plan

- [x] New regression test passes
- [x] All 11 existing `test_tree_edge_cases` tests pass
- [x] `test_localization.py` collects cleanly post-fix (reports "no tests collected" -- it's a script-style file with no `test_*` functions; restructuring is its own concern)

## Out of scope

- `test_localization.py` script-style structure -- pytest reports "no tests collected" for it because it has no `test_*` functions. Converting the top-level code into proper pytest tests is a separate cleanup.
- The structural inconsistency of using `(None, inf)` instead of plain `None` as the "no result" sentinel. Multiple callers depend on the tuple shape; canonicalizing would be a larger refactor.

Generated with [Claude Code](https://claude.com/claude-code)