### PR TITLE
fix: use direct RawCache reference in test fixture to dodge module-attr pollution

### DIFF
--- a/tests/test_io_raw_cache.py
+++ b/tests/test_io_raw_cache.py
@@ -46,6 +46,16 @@ def fake_loader(monkeypatch, tmp_path):
     Returns a callable that creates fake snirf files in tmp_path for tests
     that need real on-disk paths. Tests can inspect ``calls`` to verify how
     many disk loads occurred.
+
+    Uses the direct ``RawCache`` class reference (already imported at module
+    top) rather than the ``"hrfunc.io.raw_cache.RawCache._load_from_disk"``
+    string target. monkeypatch's string form walks the dotted path via
+    attribute access -- ``getattr(hrfunc, "io")``, then ``getattr(io,
+    "raw_cache")``. That fails with ``AttributeError: module 'hrfunc' has
+    no attribute 'io'`` whenever a prior test in the full-suite run has
+    reloaded or cleared the ``hrfunc`` package's submodule attributes
+    (some GUI test fixtures do this). The class reference is captured at
+    import time and is immune to that pollution.
     """
     calls = []
 
@@ -54,8 +64,7 @@ def fake_loader(monkeypatch, tmp_path):
         return _FakeRaw(path)
 
     monkeypatch.setattr(
-        "hrfunc.io.raw_cache.RawCache._load_from_disk",
-        staticmethod(_fake_load),
+        RawCache, "_load_from_disk", staticmethod(_fake_load),
     )
 
     def _make_fake_snirf(name="scan.snirf"):


### PR DESCRIPTION
## Summary

- Replaces the monkeypatch string target in `tests/test_io_raw_cache.py`'s `fake_loader` fixture with a direct `RawCache` class reference, fixing the order-dependent setup errors that crashed 15 tests in full-suite runs.
- Second of the two PR #46 follow-up cleanups (companion to PR #47).

## The bug

The `fake_loader` fixture used:

```python
monkeypatch.setattr(
    "hrfunc.io.raw_cache.RawCache._load_from_disk",
    staticmethod(_fake_load),
)
```

monkeypatch parses that string by walking attribute access: `getattr(hrfunc, "io")` → `getattr(io, "raw_cache")` → `getattr(raw_cache, "RawCache")` → `setattr(...)`. The first step fails with:

```
AttributeError: module 'hrfunc' has no attribute 'io'
```

whenever a prior test in the full-suite run has mutated submodule attributes off the `hrfunc` package (NiceGUI test fixtures and some session-scope reloaders do this). Run alone, `test_io_raw_cache.py` imports `hrfunc.io.raw_cache` cleanly and all 26 tests pass; in full-suite runs the 15 fixture-dependent tests all error during setup.

Surfaced during the PR #46 full-suite run.

## Fix

Use the already-imported `RawCache` class reference directly:

```python
monkeypatch.setattr(
    RawCache, "_load_from_disk", staticmethod(_fake_load),
)
```

The class object is captured at module-import time, immune to later `sys.modules` / package-attribute mutations. monkeypatch's two-arg form (target object + attribute name) skips the dotted-path walk entirely.

## Test plan

- [x] All 26 `test_io_raw_cache.py` tests pass alone
- [x] Full suite (703 tests, ignoring the script-style `test_localization.py`) is clean: **703 passed, 0 errors, 0 failures**
- [x] Previously had 15 setup-time errors in this file in full-suite runs

## Notes for reviewers

- The fix is one stylistic change at the monkeypatch site -- no test logic changes.
- The string-target form of `monkeypatch.setattr` is a real footgun in any test file that uses it; worth grepping the codebase for other instances if more flakes show up.

Generated with [Claude Code](https://claude.com/claude-code)