### PR TITLE
feat: box ROI shape + decoupled anchor + MNI readout in Cluster sub-tab

### DIFF
--- a/src/hrfunc/gui/components/hrtree_panel.py
+++ b/src/hrfunc/gui/components/hrtree_panel.py
@@ -39,8 +39,12 @@ from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Tuple
 from nicegui import ui
 
 from ...spatial.coords import meters_to_mm
-from ...spatial.shapes import Sphere
-from ...viz.brain_scene import make_surface_trace
+from ...spatial.shapes import Box, Shape, Sphere
+from ...viz.brain_scene import (
+    make_box_overlay_trace,
+    make_sphere_overlay_trace,
+    make_surface_trace,
+)
 from ...viz.meshes import MESH_CACHE as _MESH_CACHE
 from ...viz.meshes import MESH_FILENAMES as _MESH_FILENAMES
 from ...viz.meshes import load_brain_mesh, load_mesh
@@ -78,6 +82,84 @@ FILTER_FIELDS = (
     "stimulus",
     "conditions",
 )
+
+
+# Available shape modes for the Cluster sub-tab's ROI selector.
+SHAPE_SPHERE = "sphere"
+SHAPE_BOX = "box"
+SHAPE_MODES = (SHAPE_SPHERE, SHAPE_BOX)
+
+
+def _resolve_cluster_oxygenation(state: AppState) -> Optional[bool]:
+    """Pick the oxygenation filter the Cluster sub-tab should apply.
+
+    Returns ``True`` to keep HbO only, ``False`` to keep HbR only,
+    ``None`` to skip oxygenation filtering and let mixed-haemoglobin
+    HRFs into the ROI.
+
+    Precedence (matches the v1.2 anchor+radius behaviour and extends
+    it for free-floating modes):
+
+    1. If a click-anchor is set, use the anchor's oxygenation.
+       Averaging mixed-haemoglobin traces is scientifically wrong --
+       same rationale as the original ``compute_roi_keys`` behaviour.
+    2. Else if the filter sub-tab's oxygenation is ``"hbo"`` or
+       ``"hbr"``, route the binary through.
+    3. Else (filter is ``"both"`` with no anchor), return None --
+       the user has explicitly opted into mixed visibility, and
+       silently filtering would surprise them.
+    """
+    anchor = state.library_selected_hrf
+    if anchor is not None and anchor.get("oxygenation") is not None:
+        return bool(anchor.get("oxygenation"))
+    if state.library_oxygenation == "hbo":
+        return True
+    if state.library_oxygenation == "hbr":
+        return False
+    return None
+
+
+def _build_current_shape(state: AppState) -> Optional[Shape]:
+    """Build the spatial-layer :class:`Shape` for the current Cluster mode.
+
+    Sphere mode:
+        Centre = ``(cluster_center_*_mm)``. Radius =
+        ``library_roi_radius_m * 1000``. Note that the cluster centre
+        is normally seeded from a clicked HRF (see the viz pane's
+        click handler), so in the legacy "click and adjust radius"
+        workflow the resulting sphere matches the v1.2 anchor-based
+        sphere.
+
+    Box mode:
+        Centre = ``(cluster_center_*_mm)``. Half-extents =
+        ``(cluster_box_half_*_mm)``. Always free-floating.
+
+    Returns None for unknown shape modes (defensive -- a stale state
+    value from a future / legacy build shouldn't crash the render).
+    """
+    if state.cluster_shape == SHAPE_BOX:
+        return Box(
+            center_mm=(
+                state.cluster_center_x_mm,
+                state.cluster_center_y_mm,
+                state.cluster_center_z_mm,
+            ),
+            half_extents_mm=(
+                state.cluster_box_half_x_mm,
+                state.cluster_box_half_y_mm,
+                state.cluster_box_half_z_mm,
+            ),
+        )
+    if state.cluster_shape == SHAPE_SPHERE:
+        return Sphere(
+            center_mm=(
+                state.cluster_center_x_mm,
+                state.cluster_center_y_mm,
+                state.cluster_center_z_mm,
+            ),
+            radius_mm=float(meters_to_mm(state.library_roi_radius_m)),
+        )
+    return None
 
 
 DataSource = Literal["library", "project", "both"]
@@ -411,21 +493,27 @@ def _render_filter_subtab(state: AppState) -> None:
 
 
 def _render_cluster_subtab(state: AppState) -> None:
-    """The Cluster sub-tab — commit-the-current-ROI actions.
+    """The Cluster sub-tab -- ROI shape selection + save action.
 
-    Today: one action, ``Save ROI average to workspace``. The Save
-    button used to live inside the detail pane's ROI-average section;
-    moved here in Phase 6 so the left pane owns actions and the right
-    pane is read-only "what am I looking at" content.
+    PR #49 expands this sub-tab from a single Save button into a full
+    shape selector:
 
-    Future: this tab is the natural home for clustering scripts
-    (k-means, hierarchical, etc.) that operate on the current ROI or
-    the visible filtered set. Add buttons here as scripts land.
+    - **Shape radio**: Sphere or Box. Sphere uses the radius slider on
+      the Filter sub-tab; Box gets its own per-axis half-extent
+      controls below.
+    - **Centre inputs**: three MNI-mm number inputs for x / y / z.
+      Auto-populated when the user clicks an HRF in the viz; can be
+      edited directly for free-floating selection.
+    - **MNI readout**: a copy-pasteable summary like
+      ``"Centre: (-30.0, 22.0, 5.0) mm  ·  Sphere r=20.0 mm"`` -- the
+      kind of line a researcher pastes into a methods section.
+    - **Save ROI average**: writes the averaged trace + shape metadata
+      to the workspace folder via :func:`save_roi_average`.
 
-    The Save button is enabled only when there's an ROI with at least
-    2 averageable same-oxygenation HRFs (otherwise there's nothing
-    meaningful to save). The match status updates via
-    ``hrtree_selection_changed`` and ``hrtree_filter_changed``.
+    Future: this sub-tab is the natural home for clustering scripts
+    (k-means, hierarchical, atlas-region membership). Add buttons
+    here as scripts land. The atlas-region option lands in the
+    follow-up PR.
     """
 
     @ui.refreshable
@@ -435,34 +523,118 @@ def _render_cluster_subtab(state: AppState) -> None:
                 "text-xs uppercase opacity-60 tracking-wide"
             )
             ui.label(
-                "Run cluster actions on the current ROI. Set the anchor "
-                "and radius in the Filter sub-tab first."
+                "Pick the ROI shape and adjust its position in MNI mm. "
+                "Click an HRF in the viz to seed the centre, or type "
+                "coordinates directly."
             ).classes("text-xs opacity-60")
 
-            anchor = state.library_selected_hrf
+            # --- Shape radio -----------------------------------------
+            def _on_shape_change(event) -> None:
+                state.cluster_shape = (
+                    event.value if event.value in SHAPE_MODES else SHAPE_SPHERE
+                )
+                state.publish("hrtree_filter_changed", state.library_filter)
+
+            ui.radio(
+                {SHAPE_SPHERE: "Sphere", SHAPE_BOX: "Box"},
+                value=state.cluster_shape,
+                on_change=_on_shape_change,
+            ).props("inline dense")
+
+            # --- Centre inputs (MNI mm) ------------------------------
+            ui.label("Centre (MNI mm)").classes(
+                "text-xs uppercase opacity-60 tracking-wide"
+            )
+
+            def _make_centre_input(axis: str, attr: str):
+                def _on_change(event) -> None:
+                    try:
+                        value = float(event.value or 0.0)
+                    except (TypeError, ValueError):
+                        return
+                    setattr(state, attr, value)
+                    state.publish("hrtree_filter_changed", state.library_filter)
+
+                return ui.number(
+                    label=axis,
+                    value=getattr(state, attr),
+                    step=1.0,
+                    format="%.1f",
+                    on_change=_on_change,
+                ).props("dense").classes("w-20")
+
+            with ui.row().classes("w-full gap-2"):
+                _make_centre_input("x", "cluster_center_x_mm")
+                _make_centre_input("y", "cluster_center_y_mm")
+                _make_centre_input("z", "cluster_center_z_mm")
+
+            # --- Box half-extents (only shown when box mode) ---------
+            if state.cluster_shape == SHAPE_BOX:
+                ui.label("Box half-extents (mm)").classes(
+                    "text-xs uppercase opacity-60 tracking-wide"
+                )
+
+                def _make_extent_input(axis: str, attr: str):
+                    def _on_change(event) -> None:
+                        try:
+                            value = float(event.value or 0.0)
+                        except (TypeError, ValueError):
+                            return
+                        if value < 0:
+                            value = 0.0
+                        setattr(state, attr, value)
+                        state.publish(
+                            "hrtree_filter_changed", state.library_filter
+                        )
+
+                    return ui.number(
+                        label=axis,
+                        value=getattr(state, attr),
+                        step=1.0,
+                        min=0.0,
+                        format="%.1f",
+                        on_change=_on_change,
+                    ).props("dense").classes("w-20")
+
+                with ui.row().classes("w-full gap-2"):
+                    _make_extent_input("x", "cluster_box_half_x_mm")
+                    _make_extent_input("y", "cluster_box_half_y_mm")
+                    _make_extent_input("z", "cluster_box_half_z_mm")
+            else:
+                # Sphere mode just consumes the radius slider on the
+                # Filter sub-tab. Surface a hint so users discover where
+                # to adjust it.
+                ui.label(
+                    f"Sphere radius: {state.library_roi_radius_m * 1000:.1f} mm "
+                    f"(adjust on the Filter sub-tab)."
+                ).classes("text-xs opacity-60 italic")
+
+            # --- MNI readout (copy-pasteable methods-section line) ---
+            ui.separator()
+            ui.label(_format_shape_readout(state)).classes(
+                "text-xs font-mono opacity-80 break-all"
+            )
+
+            # --- ROI status + Save button ----------------------------
             all_hrfs = gather_library_hrfs(state)
             matched = filter_by_oxygenation(
                 apply_filter(all_hrfs, state.library_filter),
                 state.library_oxygenation,
             )
-            roi_keys = compute_roi_keys(
-                matched,
-                anchor,
-                state.library_roi_radius_m,
-                state.library_roi_painted,
+            shape = _build_current_shape(state)
+            oxy_filter = _resolve_cluster_oxygenation(state)
+            roi_keys = compute_roi_keys_by_shape(
+                matched, shape, state.library_roi_painted,
+                oxygenation_filter=oxy_filter,
             )
             roi_result = compute_roi_average(matched, roi_keys)
-            can_save = anchor is not None and roi_result is not None
+            can_save = roi_result is not None
 
-            if anchor is None:
-                ui.label("No ROI anchor selected.").classes(
-                    "text-xs opacity-60 italic"
-                )
-            elif roi_result is None:
+            if roi_result is None:
                 ui.label(
-                    "ROI has fewer than 2 averageable HRFs at the "
-                    "current radius — widen the radius or paint more "
-                    "neighbors."
+                    "ROI has fewer than 2 averageable HRFs in the "
+                    "current shape -- widen the shape, paint more "
+                    "neighbours, or seed a different centre."
                 ).classes("text-xs opacity-60 italic")
             else:
                 _, _, n_used = roi_result
@@ -471,21 +643,19 @@ def _render_cluster_subtab(state: AppState) -> None:
                 ).classes("text-xs opacity-70")
 
             def _on_save_roi() -> None:
-                # Recompute at click-time so we save whatever the user
-                # sees right now (anchor + radius may have changed
-                # between mount and click).
-                _anchor = state.library_selected_hrf
-                if _anchor is None:
-                    ui.notify("No ROI anchor selected.", type="warning")
-                    return
+                # Recompute at click time so we save what the user sees
+                # right now (state may have changed between mount and
+                # click).
                 _matched = filter_by_oxygenation(
                     apply_filter(gather_library_hrfs(state),
                                  state.library_filter),
                     state.library_oxygenation,
                 )
-                _roi_keys = compute_roi_keys(
-                    _matched, _anchor, state.library_roi_radius_m,
-                    state.library_roi_painted,
+                _shape = _build_current_shape(state)
+                _oxy = _resolve_cluster_oxygenation(state)
+                _roi_keys = compute_roi_keys_by_shape(
+                    _matched, _shape, state.library_roi_painted,
+                    oxygenation_filter=_oxy,
                 )
                 _result = compute_roi_average(_matched, _roi_keys)
                 if _result is None:
@@ -495,20 +665,20 @@ def _render_cluster_subtab(state: AppState) -> None:
                     )
                     return
                 _mean, _std, _ = _result
-                _sfreq = float(_anchor.get("sfreq") or 1.0)
-                if _sfreq <= 0:
-                    _sfreq = 1.0
+                _anchor = state.library_selected_hrf
+                _sfreq = _resolve_roi_sfreq(_anchor, _matched, _roi_keys)
 
                 from ..workspace_io import save_roi_average, workspace_dir
                 try:
                     out_path = save_roi_average(
-                        anchor=_anchor,
                         roi_keys=_roi_keys,
                         hrf_mean=_mean,
                         hrf_std=_std,
                         sfreq=_sfreq,
-                        radius_m=state.library_roi_radius_m,
+                        shape=_shape,
+                        anchor=_anchor,
                         library_filter=state.library_filter,
+                        oxygenation_filter=_oxy,
                     )
                     ui.notify(
                         f"Saved ROI average to {out_path.name} "
@@ -537,6 +707,24 @@ def _render_cluster_subtab(state: AppState) -> None:
 
     state.subscribe("hrtree_selection_changed", _refresh)
     state.subscribe("hrtree_filter_changed", _refresh)
+
+
+def _format_shape_readout(state: AppState) -> str:
+    """One-line summary of the current Cluster shape, suitable for copy-paste."""
+    cx, cy, cz = (
+        state.cluster_center_x_mm,
+        state.cluster_center_y_mm,
+        state.cluster_center_z_mm,
+    )
+    centre = f"Centre: ({cx:.1f}, {cy:.1f}, {cz:.1f}) mm"
+    if state.cluster_shape == SHAPE_BOX:
+        hx = state.cluster_box_half_x_mm
+        hy = state.cluster_box_half_y_mm
+        hz = state.cluster_box_half_z_mm
+        dims = f"Box {hx * 2:.1f}x{hy * 2:.1f}x{hz * 2:.1f} mm"
+        return f"{centre}  ·  {dims}"
+    radius_mm = state.library_roi_radius_m * 1000.0
+    return f"{centre}  ·  Sphere r={radius_mm:.1f} mm"
 
 
 # ---------------------------------------------------------------------------
@@ -584,12 +772,13 @@ def _render_viz_pane(state: AppState) -> None:
         with ui.column().classes("w-full h-full p-3 gap-2 flex flex-col"):
             # Compute ROI keys now so the figure draws the highlight
             # halo and the label can report the count.
-            anchor = state.library_selected_hrf
-            roi_keys = compute_roi_keys(
+            shape = _build_current_shape(state)
+            oxy_filter = _resolve_cluster_oxygenation(state)
+            roi_keys = compute_roi_keys_by_shape(
                 matched,
-                anchor,
-                state.library_roi_radius_m,
+                shape,
                 state.library_roi_painted,
+                oxygenation_filter=oxy_filter,
             )
             roi_status = ""
             if roi_keys:
@@ -602,6 +791,7 @@ def _render_viz_pane(state: AppState) -> None:
                 show_brain=state.library_show_brain,
                 show_scalp=state.library_show_scalp,
                 roi_keys=roi_keys,
+                roi_shape=shape,
             )
             plot = ui.plotly(fig).classes("w-full flex-1 min-h-0")
 
@@ -616,10 +806,21 @@ def _render_viz_pane(state: AppState) -> None:
                 if hrf is None:
                     return
                 # Stash the key on the dict so the detail pane can show it.
-                # A plain click also resets the painted set — the user is
+                # A plain click also resets the painted set -- the user is
                 # picking a fresh anchor, so accumulated shift-hover paint
                 # from a prior anchor shouldn't carry over.
                 state.library_selected_hrf = {**hrf, "_key": hrf_key}
+                # Seed the Cluster sub-tab's shape centre from the clicked
+                # HRF so sphere mode's behaviour matches the v1.2 "click
+                # an HRF, sphere centres on it" workflow even though the
+                # spatial layer now drives the centre from state. Box mode
+                # uses the same centre so a click also re-centres the box.
+                # HRF locations are stored in meters; spatial layer is mm.
+                loc = hrf.get("location") or [0, 0, 0]
+                if len(loc) >= 3:
+                    state.cluster_center_x_mm = float(loc[0]) * 1000.0
+                    state.cluster_center_y_mm = float(loc[1]) * 1000.0
+                    state.cluster_center_z_mm = float(loc[2]) * 1000.0
                 state.library_roi_painted.clear()
                 state.publish("hrtree_selection_changed", hrf_key)
 
@@ -802,28 +1003,32 @@ def _render_roi_average(state: AppState) -> None:
     member count. The Save-to-workspace action lives in the Cluster
     sub-tab on the left (Phase 6); the detail pane is for viewing,
     not for committing state to disk.
+
+    Uses the Cluster sub-tab's current Shape (box or sphere) plus
+    the visible-filter context to compute ROI membership, so this
+    panel stays in sync with the cluster shape even when the user
+    has no anchor HRF clicked.
     """
-    anchor = state.library_selected_hrf
-    if anchor is None:
-        return
     all_hrfs = gather_library_hrfs(state)
     matched = filter_by_oxygenation(
         apply_filter(all_hrfs, state.library_filter),
         state.library_oxygenation,
     )
-    roi_keys = compute_roi_keys(
-        matched,
-        anchor,
-        state.library_roi_radius_m,
-        state.library_roi_painted,
+    shape = _build_current_shape(state)
+    oxy_filter = _resolve_cluster_oxygenation(state)
+    roi_keys = compute_roi_keys_by_shape(
+        matched, shape, state.library_roi_painted,
+        oxygenation_filter=oxy_filter,
     )
     result = compute_roi_average(matched, roi_keys)
     if result is None:
         return
     mean, std, n = result
-    sfreq = float(anchor.get("sfreq") or 1.0)
-    if sfreq <= 0:
-        sfreq = 1.0
+    # Sfreq: prefer the anchor's when present (legacy behaviour);
+    # otherwise default to the first ROI member's sfreq, falling back
+    # to 1.0 if even that's missing. The save flow does the same.
+    anchor = state.library_selected_hrf
+    sfreq = _resolve_roi_sfreq(anchor, matched, roi_keys)
     ui.separator()
     ui.label(
         f"ROI average ({n} HRFs)"
@@ -876,6 +1081,33 @@ def _kv(key: str, value: str) -> None:
     with ui.row().classes("w-full gap-4"):
         ui.label(key).classes("text-xs uppercase opacity-60 w-32")
         ui.label(value).classes("text-sm break-all")
+
+
+def _resolve_roi_sfreq(
+    anchor: Optional[Dict[str, Any]],
+    hrfs: Dict[str, Dict[str, Any]],
+    roi_keys: Any,
+) -> float:
+    """Pick the sample rate for an ROI-averaged trace.
+
+    Prefers the click-anchor's ``sfreq`` when there is one (matches the
+    v1.2 behaviour). For free-floating ROIs with no anchor, falls back
+    to the first ROI member's ``sfreq``. Final fallback is 1.0 Hz so
+    the time axis on the plot has *some* scale even when the HRFs are
+    missing rate metadata.
+    """
+    if anchor is not None:
+        anchor_sfreq = float(anchor.get("sfreq") or 0.0)
+        if anchor_sfreq > 0:
+            return anchor_sfreq
+    for key in roi_keys:
+        hrf = hrfs.get(key)
+        if hrf is None:
+            continue
+        member_sfreq = float(hrf.get("sfreq") or 0.0)
+        if member_sfreq > 0:
+            return member_sfreq
+    return 1.0
 
 
 # ---------------------------------------------------------------------------
@@ -1007,17 +1239,25 @@ def build_plotly_figure(
     show_brain: bool = False,
     show_scalp: bool = False,
     roi_keys: Optional[Any] = None,
+    roi_shape: Optional[Shape] = None,
 ):
     """Build the 3D scatter figure for the given HRF dict.
 
-    Up to five traces, ordered so the ROI highlight renders on top:
+    Up to six traces, ordered so the ROI highlight renders on top:
 
     - **Scalp** (``go.Mesh3d``, only when ``show_scalp=True``):
-      fsaverage outer-skin surface — anatomically where the optodes
+      fsaverage outer-skin surface -- anatomically where the optodes
       sit. Drawn first (outermost in 3D-painter order).
     - **Brain** (``go.Mesh3d``, only when ``show_brain=True``):
-      fsaverage pial cortical surface — where the neural activity
+      fsaverage pial cortical surface -- where the neural activity
       originates. Drawn inside the scalp.
+    - **ROI shape overlay** (``go.Mesh3d``, only when ``roi_shape``
+      is a :class:`~hrfunc.spatial.shapes.Box` or
+      :class:`~hrfunc.spatial.shapes.Sphere`): a translucent violet
+      cuboid / UV-sphere showing where the Cluster sub-tab's ROI
+      selector currently sits. The shape's centre/extent state is
+      converted from MNI mm to MNE-meter coordinates so it renders
+      in the same coordinate frame as the HRF scatter.
     - **HbO** (``go.Scatter3d``, red): oxygenated HRFs.
     - **HbR** (``go.Scatter3d``, blue): deoxygenated HRFs.
     - **ROI** (``go.Scatter3d``, gold, larger): every HRF whose key
@@ -1088,6 +1328,24 @@ def build_plotly_figure(
                     ambient=0.5, diffuse=0.6,
                 )
             )
+
+    # ROI shape overlay (PR #49 box/sphere). HRF coords are in meters;
+    # the spatial-layer shape is in mm, so we down-convert before
+    # building the trace -- the resulting Mesh3d is in meters and
+    # overlays directly on the HRF scatter.
+    if roi_shape is not None:
+        if isinstance(roi_shape, Box):
+            box_m = Box(
+                center_mm=(c / 1000.0 for c in roi_shape.center_mm),
+                half_extents_mm=(h / 1000.0 for h in roi_shape.half_extents_mm),
+            )
+            traces.append(make_box_overlay_trace(box_m))
+        elif isinstance(roi_shape, Sphere):
+            sphere_m = Sphere(
+                center_mm=(c / 1000.0 for c in roi_shape.center_mm),
+                radius_mm=roi_shape.radius_mm / 1000.0,
+            )
+            traces.append(make_sphere_overlay_trace(sphere_m))
 
     if hbo_x:
         traces.append(
@@ -1250,6 +1508,69 @@ def compute_roi_keys(
             if anchor_oxy is not None:
                 if hrfs[key].get("oxygenation") != anchor_oxy:
                     continue
+            out.add(key)
+
+    return out
+
+
+def compute_roi_keys_by_shape(
+    hrfs: Dict[str, Dict[str, Any]],
+    shape: Optional[Any],
+    painted: Optional[Any] = None,
+    *,
+    oxygenation_filter: Optional[bool] = None,
+) -> "set":
+    """Shape-based ROI membership for free-floating Box / Sphere modes.
+
+    Companion to :func:`compute_roi_keys`. The original anchor-based
+    API is preserved for the legacy click-anchor + radius workflow;
+    this function takes a fully-constructed :class:`hrfunc.spatial.Shape`
+    (typically a :class:`Box` or a free-floating :class:`Sphere`) plus
+    an explicit oxygenation filter and returns the matching keys.
+
+    Membership rules:
+
+    - If ``shape`` is not None, every HRF whose location (converted
+      meters->mm) is inside ``shape`` is included. HRFs without a
+      location are skipped.
+    - Every key in ``painted`` is included (filtered by
+      ``oxygenation_filter`` when set, so a stray paint on the
+      wrong haemoglobin doesn't contaminate the average).
+    - When ``oxygenation_filter`` is ``True`` / ``False``, only HRFs
+      with matching ``oxygenation`` survive the membership check.
+      ``None`` (the default) skips the oxygenation filter -- callers
+      that have already filtered upstream (e.g. via
+      ``library_oxygenation``) should leave this as None.
+
+    Module-level so tests can hit it without spinning up the GUI.
+    """
+    out: "set" = set()
+    if shape is None and not painted:
+        return out
+
+    if shape is not None:
+        for key, hrf in hrfs.items():
+            loc = hrf.get("location")
+            if loc is None or len(loc) < 3:
+                continue
+            if (
+                oxygenation_filter is not None
+                and bool(hrf.get("oxygenation")) != bool(oxygenation_filter)
+            ):
+                continue
+            loc_mm = meters_to_mm(loc[:3]).tolist()
+            if shape.contains(loc_mm):
+                out.add(key)
+
+    if painted:
+        for key in painted:
+            if key not in hrfs:
+                continue
+            if (
+                oxygenation_filter is not None
+                and bool(hrfs[key].get("oxygenation")) != bool(oxygenation_filter)
+            ):
+                continue
             out.add(key)
 
     return out

--- a/src/hrfunc/gui/state.py
+++ b/src/hrfunc/gui/state.py
@@ -197,6 +197,37 @@ class AppState:
     # doesn't follow into a fresh selection.
     library_roi_radius_m: float = 0.02
     library_roi_painted: set = field(default_factory=set)
+    # Cluster sub-tab shape selection (PR #49, v1.3 spatial/viz arc).
+    #
+    # The Cluster sub-tab supports two ROI-shape modes:
+    #
+    # - ``"sphere"`` (default) -- the existing anchor + radius workflow.
+    #   ``library_roi_radius_m`` is the sphere's radius; when an anchor
+    #   HRF is clicked, the sphere centres on it. When no anchor is
+    #   clicked, the sphere centres on ``cluster_center_*_mm`` for free-
+    #   floating selection.
+    # - ``"box"`` -- an axis-aligned bounding box with independent half-
+    #   extents on each axis. Always free-floating: the box's centre is
+    #   ``cluster_center_*_mm`` (seedable by clicking an HRF or typed
+    #   directly), and ``cluster_box_half_*_mm`` controls the dimensions.
+    #
+    # All cluster spatial state is in MNI mm (the spatial-layer
+    # convention from PR #46) -- the conversion from MNE-meter HRF
+    # locations happens once at the membership-check boundary.
+    cluster_shape: str = "sphere"
+    # Free-floating shape centre, MNI mm. Three separate fields so each
+    # binds cleanly to its own ``ui.number`` input; tuple-construct at
+    # use sites. Defaults to MNI origin (0, 0, 0); seeded by clicking
+    # an HRF in the viz pane.
+    cluster_center_x_mm: float = 0.0
+    cluster_center_y_mm: float = 0.0
+    cluster_center_z_mm: float = 0.0
+    # Box half-extents, MNI mm. Default 20 mm on each axis produces a
+    # 40 mm cube -- comparable to a 2 cm radius sphere by volume and
+    # in line with typical fNIRS short-separation neighbourhood sizes.
+    cluster_box_half_x_mm: float = 20.0
+    cluster_box_half_y_mm: float = 20.0
+    cluster_box_half_z_mm: float = 20.0
 
     def subscribe(self, event: str, callback: EventCallback) -> None:
         """Register ``callback`` to be called on ``publish(event, ...)``.
@@ -304,6 +335,13 @@ class AppState:
         self.library_oxygenation = "both"
         self.library_roi_radius_m = 0.02
         self.library_roi_painted.clear()
+        self.cluster_shape = "sphere"
+        self.cluster_center_x_mm = 0.0
+        self.cluster_center_y_mm = 0.0
+        self.cluster_center_z_mm = 0.0
+        self.cluster_box_half_x_mm = 20.0
+        self.cluster_box_half_y_mm = 20.0
+        self.cluster_box_half_z_mm = 20.0
         self.hrf_selected_channel = None
 
 

--- a/src/hrfunc/gui/workspace_io.py
+++ b/src/hrfunc/gui/workspace_io.py
@@ -65,13 +65,29 @@ def _safe_filename_fragment(name: str) -> str:
 
 def save_roi_average(
     *,
-    anchor: Dict[str, Any],
     roi_keys: Iterable[str],
     hrf_mean: Any,
     hrf_std: Any,
     sfreq: float,
-    radius_m: float,
+    # Anchor is optional in PR #49 to support free-floating shape ROIs.
+    # When a click-anchor IS set, its location / oxygenation / context
+    # ride into the saved JSON so the file matches the v1.2 schema and
+    # can still be re-loaded into ``hrfunc.tree``. When the anchor is
+    # None, the ROI's shape centre stands in as the saved location and
+    # the saved oxygenation comes from ``oxygenation_filter``.
+    anchor: Optional[Dict[str, Any]] = None,
+    # Spatial-layer Shape describing the ROI extent. Defaults to None
+    # to keep the v1.2 anchor + radius_m call sites compatible.
+    shape: Optional[Any] = None,
+    # Pre-PR-#49 legacy field. When the new ``shape`` is provided this
+    # is ignored for geometry but still recorded in the JSON as the
+    # ``roi_radius_m`` context key (v1.2 audit scripts read it).
+    radius_m: Optional[float] = None,
     library_filter: Optional[Dict[str, Any]] = None,
+    # Oxygenation that the membership computation filtered on (True for
+    # HbO, False for HbR, None for mixed). Used to set the saved
+    # ``oxygenation`` field when there's no anchor.
+    oxygenation_filter: Optional[bool] = None,
     workspace: Optional[Path] = None,
 ) -> Path:
     """Save an ROI-averaged HRF to the workspace folder.
@@ -80,14 +96,20 @@ def save_roi_average(
     be re-loaded into ``hrfunc.tree`` if desired) with ROI provenance
     fields so a researcher can audit what went into the average:
 
-    - ``hrf_mean`` / ``hrf_std`` — the averaged trace + per-sample std
-    - ``sfreq`` — sampling rate (same as the anchor)
-    - ``oxygenation`` — anchor's oxygenation (HbO or HbR)
-    - ``location`` — anchor's location (the spatial center of the ROI)
-    - ``context`` — extended with ROI metadata: anchor key, radius,
-      member keys, library filter that was active
+    - ``hrf_mean`` / ``hrf_std`` -- the averaged trace + per-sample std
+    - ``sfreq`` -- sampling rate
+    - ``oxygenation`` -- anchor's oxygenation when present; otherwise
+      the explicit ``oxygenation_filter``; falls back to ``None``
+      when neither is available.
+    - ``location`` -- anchor's location when present; otherwise the
+      shape's centre (converted from MNI mm into MNE-meter coords so
+      the saved JSON round-trips back into ``hrfunc.tree`` without
+      unit fixups).
+    - ``context`` -- extended with ROI metadata: anchor key (or
+      ``None`` for free-floating), shape descriptor, member keys,
+      library filter that was active.
 
-    File name: ``roi_<anchor_key_sanitized>_<YYYYMMDDTHHMMSSZ>.json``,
+    File name: ``roi_<anchor_or_shape_key>_<YYYYMMDDTHHMMSSZ>.json``,
     placed in the workspace folder. Returns the absolute Path.
 
     Module-level so tests can call it without the GUI.
@@ -100,26 +122,101 @@ def save_roi_average(
     mean_list = np.asarray(hrf_mean).tolist()
     std_list = np.asarray(hrf_std).tolist()
 
-    anchor_key = anchor.get("_key") or "unknown"
+    anchor_key: Optional[str] = (
+        anchor.get("_key") if anchor is not None else None
+    ) or None
+
+    # Compute the saved location:
+    # - With anchor: use anchor.location (meters; v1.2 schema).
+    # - Without anchor but with shape: use the shape centre converted
+    #   from mm to meters so downstream tree-loading code sees a value
+    #   in the same units as v1.2.
+    # - Otherwise: None (read-only output, won't round-trip into tree).
+    if anchor is not None:
+        location: Optional[list] = anchor.get("location")
+    elif shape is not None and hasattr(shape, "center_mm"):
+        cx, cy, cz = shape.center_mm
+        location = [cx / 1000.0, cy / 1000.0, cz / 1000.0]
+    else:
+        location = None
+
+    # Resolve oxygenation: anchor wins, then explicit filter, then None.
+    if anchor is not None and anchor.get("oxygenation") is not None:
+        oxygenation: Optional[bool] = bool(anchor.get("oxygenation"))
+    elif oxygenation_filter is not None:
+        oxygenation = bool(oxygenation_filter)
+    else:
+        oxygenation = None
+
+    # Shape descriptor for the saved JSON. Captures enough that a
+    # downstream reader can reconstruct the geometry exactly.
+    shape_descriptor: Optional[Dict[str, Any]] = None
+    if shape is not None:
+        if hasattr(shape, "half_extents_mm"):  # Box
+            shape_descriptor = {
+                "type": "box",
+                "center_mm": list(shape.center_mm),
+                "half_extents_mm": list(shape.half_extents_mm),
+            }
+        elif hasattr(shape, "radius_mm"):  # Sphere
+            shape_descriptor = {
+                "type": "sphere",
+                "center_mm": list(shape.center_mm),
+                "radius_mm": float(shape.radius_mm),
+            }
+    elif radius_m is not None:
+        # Legacy v1.2 call site (no shape passed). Record the radius as
+        # a sphere descriptor for forward-compat with v1.3+ readers.
+        shape_descriptor = {
+            "type": "sphere",
+            "radius_m": float(radius_m),
+        }
+
+    context_extra: Dict[str, Any] = {
+        "roi_average": True,
+        "roi_anchor_key": anchor_key,
+        "roi_shape": shape_descriptor,
+        "roi_member_keys": sorted(roi_keys),
+        "roi_library_filter": dict(library_filter or {}),
+        "saved_at": datetime.now(timezone.utc).isoformat(),
+    }
+    # Preserve the v1.2 ``roi_radius_m`` key when the call site is the
+    # legacy radius-based path, or when the new path uses a sphere.
+    # v1.2 audit scripts grep for this exact key; emit it whenever
+    # possible to keep them working.
+    if radius_m is not None:
+        context_extra["roi_radius_m"] = float(radius_m)
+    elif (
+        shape is not None
+        and hasattr(shape, "radius_mm")
+        and not hasattr(shape, "half_extents_mm")
+    ):
+        context_extra["roi_radius_m"] = float(shape.radius_mm) / 1000.0
+
     payload: Dict[str, Any] = {
         "hrf_mean": mean_list,
         "hrf_std": std_list,
         "sfreq": float(sfreq),
-        "oxygenation": bool(anchor.get("oxygenation")),
-        "location": anchor.get("location"),
+        "oxygenation": oxygenation,
+        "location": location,
         "context": {
-            **(anchor.get("context") or {}),
-            "roi_average": True,
-            "roi_anchor_key": anchor_key,
-            "roi_radius_m": float(radius_m),
-            "roi_member_keys": sorted(roi_keys),
-            "roi_library_filter": dict(library_filter or {}),
-            "saved_at": datetime.now(timezone.utc).isoformat(),
+            **((anchor or {}).get("context") or {}),
+            **context_extra,
         },
     }
 
     timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
-    fragment = _safe_filename_fragment(anchor_key)
+    # Filename fragment: anchor key first (v1.2 convention), else a
+    # shape-derived stand-in so free-floating saves still have a
+    # human-recognisable prefix.
+    if anchor_key:
+        fragment = _safe_filename_fragment(anchor_key)
+    elif shape_descriptor is not None:
+        fragment = _safe_filename_fragment(
+            f"freefloat_{shape_descriptor.get('type', 'shape')}"
+        )
+    else:
+        fragment = "freefloat_unknown"
     out_path = workspace / f"roi_{fragment}_{timestamp}.json"
 
     with open(out_path, "w", encoding="utf-8") as fh:

--- a/src/hrfunc/spatial/__init__.py
+++ b/src/hrfunc/spatial/__init__.py
@@ -31,9 +31,10 @@ Public surface:
 from .affine import apply_affine, identity_affine
 from .coords import meters_to_mm, mm_to_meters
 from .point import HRFPoint
-from .shapes import Shape, Sphere
+from .shapes import Box, Shape, Sphere
 
 __all__ = [
+    "Box",
     "HRFPoint",
     "Shape",
     "Sphere",

--- a/src/hrfunc/spatial/shapes.py
+++ b/src/hrfunc/spatial/shapes.py
@@ -2,14 +2,22 @@
 
 The :class:`Shape` abstract base defines a uniform predicate API:
 ``contains(xyz_mm)`` returns whether a single MNI-mm point is inside
-the region. Concrete shapes (sphere now; box, atlas-region next)
-implement the predicate. All shapes operate in **MNI millimeters**
-so callers never juggle unit conversions inside their selection
-logic.
+the region. Concrete shapes implement the predicate. All shapes
+operate in **MNI millimeters** so callers never juggle unit
+conversions inside their selection logic.
 
-PR #46 (this PR) ships only :class:`Sphere` and refactors the
-existing radius-based ROI selection on top of it. :class:`Box` lands
-in PR #47, :class:`AtlasRegion` in PR #48.
+Currently shipped:
+
+- :class:`Sphere` — closed-ball membership, used by the existing
+  radius-based ROI selection in the HRtree panel.
+- :class:`Box` — axis-aligned bounding box, used by the v1.3
+  Cluster sub-tab's box-mode ROI selection. Rotation is intentionally
+  excluded: it adds significant UX complexity (slider-based 3D
+  rotation is a usability trap) for negligible scientific benefit
+  (fNIRS publications axis-align to MNI by convention).
+
+Atlas-region membership lands in a follow-up PR with the Harvard-
+Oxford atlas integration.
 """
 
 from __future__ import annotations
@@ -90,3 +98,97 @@ class Sphere(Shape):
     def __repr__(self) -> str:
         cx, cy, cz = self.center_mm
         return f"Sphere(center_mm=({cx:.2f}, {cy:.2f}, {cz:.2f}), radius_mm={self.radius_mm:.2f})"
+
+
+class Box(Shape):
+    """An axis-aligned bounding box defined by centre + half-extents in mm.
+
+    Membership is closed on all three axes: a point is inside iff
+    ``|x - cx| <= hx`` and ``|y - cy| <= hy`` and ``|z - cz| <= hz``.
+    Closed semantics match :class:`Sphere` so boundary points behave
+    consistently across shape types -- which is the principle of
+    least surprise for researchers comparing ROIs.
+
+    Rotation is intentionally out of scope. fNIRS publication
+    conventions report ROIs in MNI axes (L/R, A/P, S/I); allowing
+    rotation would invite users to slip into non-standard reference
+    frames without realising it, and the slider-based 3D rotation UX
+    is itself a usability trap. Researchers who need rotated regions
+    are better served by atlas-defined regions (a follow-up PR).
+    """
+
+    __slots__ = ("center_mm", "half_extents_mm")
+
+    def __init__(
+        self,
+        center_mm: Sequence[float],
+        half_extents_mm: Sequence[float],
+    ):
+        center = tuple(float(c) for c in center_mm)
+        if len(center) != 3:
+            raise ValueError(f"center_mm must have 3 elements, got {len(center)}")
+        extents = tuple(float(h) for h in half_extents_mm)
+        if len(extents) != 3:
+            raise ValueError(
+                f"half_extents_mm must have 3 elements, got {len(extents)}"
+            )
+        if any(h < 0 for h in extents):
+            raise ValueError(
+                f"half_extents_mm must all be non-negative, got {extents}"
+            )
+        self.center_mm: Tuple[float, float, float] = center
+        self.half_extents_mm: Tuple[float, float, float] = extents
+
+    def contains(self, xyz_mm: Sequence[float]) -> bool:
+        cx, cy, cz = self.center_mm
+        hx, hy, hz = self.half_extents_mm
+        dx = abs(float(xyz_mm[0]) - cx)
+        dy = abs(float(xyz_mm[1]) - cy)
+        dz = abs(float(xyz_mm[2]) - cz)
+        return dx <= hx and dy <= hy and dz <= hz
+
+    def contains_batch(self, points_mm: np.ndarray) -> np.ndarray:
+        points = np.asarray(points_mm, dtype=np.float64)
+        if points.ndim != 2 or points.shape[1] != 3:
+            raise ValueError(
+                f"points_mm must be an (N, 3) array, got shape {points.shape}"
+            )
+        center = np.asarray(self.center_mm, dtype=np.float64)
+        extents = np.asarray(self.half_extents_mm, dtype=np.float64)
+        return np.all(np.abs(points - center) <= extents, axis=1)
+
+    def corners_mm(self) -> np.ndarray:
+        """Return the 8 corner vertices of the box as an ``(8, 3)`` array.
+
+        Used by the viz layer to render the translucent box overlay.
+        Corner order is the standard "binary count of sign flips":
+        ``(-x, -y, -z), (+x, -y, -z), (-x, +y, -z), (+x, +y, -z), ...``
+        so consumers can deterministically pick the right vertex when
+        building face triangles.
+        """
+        cx, cy, cz = self.center_mm
+        hx, hy, hz = self.half_extents_mm
+        signs = np.array(
+            [
+                [-1, -1, -1],
+                [+1, -1, -1],
+                [-1, +1, -1],
+                [+1, +1, -1],
+                [-1, -1, +1],
+                [+1, -1, +1],
+                [-1, +1, +1],
+                [+1, +1, +1],
+            ],
+            dtype=np.float64,
+        )
+        extents = np.array([hx, hy, hz], dtype=np.float64)
+        center = np.array([cx, cy, cz], dtype=np.float64)
+        return center + signs * extents
+
+    def __repr__(self) -> str:
+        cx, cy, cz = self.center_mm
+        hx, hy, hz = self.half_extents_mm
+        return (
+            f"Box(center_mm=({cx:.2f}, {cy:.2f}, {cz:.2f}), "
+            f"half_extents_mm=({hx:.2f}, {hy:.2f}, {hz:.2f}))"
+        )

--- a/src/hrfunc/viz/__init__.py
+++ b/src/hrfunc/viz/__init__.py
@@ -22,7 +22,11 @@ Public surface:
   anatomical-NIfTI viewer.
 """
 
-from .brain_scene import make_surface_trace
+from .brain_scene import (
+    make_box_overlay_trace,
+    make_sphere_overlay_trace,
+    make_surface_trace,
+)
 from .meshes import (
     MESH_CACHE,
     MESH_FILENAMES,
@@ -35,5 +39,7 @@ __all__ = [
     "MESH_FILENAMES",
     "load_brain_mesh",
     "load_mesh",
+    "make_box_overlay_trace",
+    "make_sphere_overlay_trace",
     "make_surface_trace",
 ]

--- a/src/hrfunc/viz/brain_scene.py
+++ b/src/hrfunc/viz/brain_scene.py
@@ -1,17 +1,22 @@
-"""Plotly trace builders for anatomical surfaces.
+"""Plotly trace builders for anatomical surfaces and ROI shape overlays.
 
-Today this module exposes :func:`make_surface_trace`, the helper used
-by the HRtree panel to render the fsaverage scalp + pial overlays.
-The same helper will be re-used by the v1.3.1 anatomical-NIfTI viewer
-once user-supplied surfaces enter the pipeline — the brain-scene
-layer doesn't care whether the verts came from a bundled fsaverage
-NPZ or a marching-cubes pass over a user image.
+Exposes three trace builders consumed by the HRtree panel:
 
-Kept deliberately thin in PR #46. As shape overlays (PR #47) and
-user anatomicals (PR #48) land, this module will grow a
-``BrainScene`` composer that owns ``add_surface`` / ``add_points``
-/ ``add_shape`` builder methods. For now, the figure assembly stays
-in the panel and only the per-trace construction lives here.
+- :func:`make_surface_trace` — the original anatomical-surface
+  builder. Used for the bundled fsaverage scalp / pial overlays;
+  will also be used by the v1.3.1 anatomical-NIfTI viewer once
+  user-supplied surfaces enter the pipeline. The brain-scene layer
+  doesn't care whether the verts came from a bundled NPZ or a
+  marching-cubes pass over a user image.
+- :func:`make_box_overlay_trace` — translucent cuboid for the
+  Cluster sub-tab's box-mode ROI shape.
+- :func:`make_sphere_overlay_trace` — translucent UV-sphere for
+  the Cluster sub-tab's sphere-mode ROI shape.
+
+All three return ``plotly.graph_objects.Mesh3d`` traces configured
+with ``hoverinfo="skip"`` and ``showlegend=False`` so the overlays
+don't steal hover events from the HRF scatter markers above them
+or clutter the legend.
 """
 
 from __future__ import annotations
@@ -19,6 +24,42 @@ from __future__ import annotations
 from typing import Any
 
 import numpy as np
+
+from ..spatial.shapes import Box, Sphere
+
+# Standard cuboid triangulation indices. Each of the 6 quad faces is
+# split into 2 triangles; 12 triangles total. The vertex order matches
+# :meth:`hrfunc.spatial.shapes.Box.corners_mm` (binary sign-flip count),
+# so face indices reference the same corner each time.
+#
+#       6 +-----------+ 7
+#        /|          /|
+#       / |         / |
+#    4 +-----------+ 5|
+#      |  |        |  |
+#      |  + 2 -----|--+ 3
+#      | /         | /
+#      |/          |/
+#    0 +-----------+ 1
+#
+# Corner indexing: bit 0 -> +x, bit 1 -> +y, bit 2 -> +z.
+_BOX_FACES = np.array(
+    [
+        # -z face (corners 0,1,2,3)
+        [0, 1, 3], [0, 3, 2],
+        # +z face (corners 4,5,6,7)
+        [4, 6, 7], [4, 7, 5],
+        # -y face (corners 0,1,4,5)
+        [0, 4, 5], [0, 5, 1],
+        # +y face (corners 2,3,6,7)
+        [2, 3, 7], [2, 7, 6],
+        # -x face (corners 0,2,4,6)
+        [0, 2, 6], [0, 6, 4],
+        # +x face (corners 1,3,5,7)
+        [1, 5, 7], [1, 7, 3],
+    ],
+    dtype=np.int64,
+)
 
 
 def make_surface_trace(
@@ -53,6 +94,154 @@ def make_surface_trace(
     """
     import plotly.graph_objects as go
 
+    return go.Mesh3d(
+        x=verts[:, 0],
+        y=verts[:, 1],
+        z=verts[:, 2],
+        i=faces[:, 0],
+        j=faces[:, 1],
+        k=faces[:, 2],
+        color=color,
+        opacity=opacity,
+        name=name,
+        hoverinfo="skip",
+        showlegend=False,
+        lighting=dict(ambient=ambient, diffuse=diffuse),
+    )
+
+
+def make_box_overlay_trace(
+    box: Box,
+    *,
+    color: str = "#a78bfa",
+    opacity: float = 0.18,
+    name: str = "ROI box",
+    ambient: float = 0.55,
+    diffuse: float = 0.55,
+) -> Any:
+    """Build a plotly ``Mesh3d`` cuboid for an axis-aligned ROI box.
+
+    The box's :meth:`~hrfunc.spatial.shapes.Box.corners_mm` is used
+    directly as the vertex array; the 12-triangle face table is the
+    module-level constant ``_BOX_FACES``. Default colour is a soft
+    violet that reads on both bright and dark fsaverage surfaces and
+    doesn't collide with the HbO red / HbR blue / ROI gold of the
+    existing scatter palette.
+    """
+    import plotly.graph_objects as go
+
+    verts = box.corners_mm()
+    return go.Mesh3d(
+        x=verts[:, 0],
+        y=verts[:, 1],
+        z=verts[:, 2],
+        i=_BOX_FACES[:, 0],
+        j=_BOX_FACES[:, 1],
+        k=_BOX_FACES[:, 2],
+        color=color,
+        opacity=opacity,
+        name=name,
+        hoverinfo="skip",
+        showlegend=False,
+        lighting=dict(ambient=ambient, diffuse=diffuse),
+        flatshading=True,
+    )
+
+
+def _uv_sphere_mesh(
+    centre: np.ndarray,
+    radius: float,
+    n_lat: int,
+    n_lon: int,
+) -> tuple[np.ndarray, np.ndarray]:
+    """UV-sphere triangulation: ``(verts, faces)`` for a sphere mesh.
+
+    Latitude rings are stacked along the z axis. ``n_lat`` controls
+    the number of latitude bands (more = smoother poles); ``n_lon``
+    controls longitude segments (more = smoother equator). The two
+    poles are shared single vertices so the triangulation closes
+    cleanly without gaps.
+    """
+    if n_lat < 2 or n_lon < 3:
+        raise ValueError(
+            f"UV sphere requires n_lat>=2, n_lon>=3; got {n_lat}, {n_lon}"
+        )
+
+    verts: list[list[float]] = []
+    # North pole.
+    verts.append([centre[0], centre[1], centre[2] + radius])
+
+    # Intermediate latitude rings (exclusive of poles).
+    for i in range(1, n_lat):
+        theta = np.pi * i / n_lat  # 0 at north, pi at south
+        z = radius * np.cos(theta)
+        ring_r = radius * np.sin(theta)
+        for j in range(n_lon):
+            phi = 2.0 * np.pi * j / n_lon
+            x = ring_r * np.cos(phi)
+            y = ring_r * np.sin(phi)
+            verts.append([centre[0] + x, centre[1] + y, centre[2] + z])
+
+    # South pole.
+    verts.append([centre[0], centre[1], centre[2] - radius])
+
+    faces: list[list[int]] = []
+    north = 0
+    south = 1 + (n_lat - 1) * n_lon
+
+    # Top cap: triangles between the north pole and the first ring.
+    for j in range(n_lon):
+        a = 1 + j
+        b = 1 + (j + 1) % n_lon
+        faces.append([north, a, b])
+
+    # Middle bands: each quad split into two triangles.
+    for i in range(n_lat - 2):
+        ring0 = 1 + i * n_lon
+        ring1 = 1 + (i + 1) * n_lon
+        for j in range(n_lon):
+            a = ring0 + j
+            b = ring0 + (j + 1) % n_lon
+            c = ring1 + j
+            d = ring1 + (j + 1) % n_lon
+            faces.append([a, c, d])
+            faces.append([a, d, b])
+
+    # Bottom cap: triangles between the last ring and the south pole.
+    last_ring = 1 + (n_lat - 2) * n_lon
+    for j in range(n_lon):
+        a = last_ring + j
+        b = last_ring + (j + 1) % n_lon
+        faces.append([south, b, a])
+
+    return np.asarray(verts, dtype=np.float64), np.asarray(faces, dtype=np.int64)
+
+
+def make_sphere_overlay_trace(
+    sphere: Sphere,
+    *,
+    color: str = "#a78bfa",
+    opacity: float = 0.18,
+    name: str = "ROI sphere",
+    n_lat: int = 12,
+    n_lon: int = 18,
+    ambient: float = 0.55,
+    diffuse: float = 0.55,
+) -> Any:
+    """Build a plotly ``Mesh3d`` UV-sphere for a sphere-mode ROI overlay.
+
+    The UV-sphere triangulation gives a clean visual sphere without
+    bringing in scipy/skimage just for icosphere subdivision. Default
+    ``n_lat=12, n_lon=18`` is ~200 verts / ~400 triangles -- well
+    inside plotly's interactive comfort zone alongside the fsaverage
+    overlays (~2.5k verts each). The default colour matches the
+    box overlay so users get visual consistency when switching
+    shape mode.
+    """
+    import plotly.graph_objects as go
+
+    centre = np.asarray(sphere.center_mm, dtype=np.float64)
+    verts, faces = _uv_sphere_mesh(centre, sphere.radius_mm, n_lat, n_lon)
     return go.Mesh3d(
         x=verts[:, 0],
         y=verts[:, 1],

--- a/tests/test_gui_library.py
+++ b/tests/test_gui_library.py
@@ -598,6 +598,121 @@ class TestStateLibraryROI:
         assert s.library_roi_painted == set()
 
 
+class TestStateClusterShape:
+    """PR #49 (v1.3): the Cluster sub-tab gains a shape selector. Each
+    field below defaults to a sensible MNI-mm starting point so a fresh
+    AppState renders a coherent free-floating shape without the user
+    typing anything."""
+
+    def test_defaults(self):
+        s = AppState()
+        assert s.cluster_shape == "sphere"
+        assert s.cluster_center_x_mm == 0.0
+        assert s.cluster_center_y_mm == 0.0
+        assert s.cluster_center_z_mm == 0.0
+        # 20 mm half-extent -> 40 mm box on each axis, comparable to
+        # the default 20 mm sphere radius by linear scale.
+        assert s.cluster_box_half_x_mm == 20.0
+        assert s.cluster_box_half_y_mm == 20.0
+        assert s.cluster_box_half_z_mm == 20.0
+
+    def test_reset_restores_defaults(self):
+        s = AppState()
+        s.cluster_shape = "box"
+        s.cluster_center_x_mm = -30.0
+        s.cluster_center_y_mm = 22.0
+        s.cluster_center_z_mm = 5.0
+        s.cluster_box_half_x_mm = 10.0
+        s.cluster_box_half_y_mm = 15.0
+        s.cluster_box_half_z_mm = 25.0
+        s.reset()
+        assert s.cluster_shape == "sphere"
+        assert s.cluster_center_x_mm == 0.0
+        assert s.cluster_center_y_mm == 0.0
+        assert s.cluster_center_z_mm == 0.0
+        assert s.cluster_box_half_x_mm == 20.0
+        assert s.cluster_box_half_y_mm == 20.0
+        assert s.cluster_box_half_z_mm == 20.0
+
+
+class TestComputeRoiKeysByShape:
+    """Shape-based ROI membership for free-floating Box/Sphere modes."""
+
+    def _hrfs(self):
+        # Coordinates in meters (matching the HRF storage convention);
+        # shape boundaries below are in mm.
+        return {
+            "hbo:a": {"location": [0.000, 0.000, 0.000], "oxygenation": True},
+            "hbo:b": {"location": [0.010, 0.000, 0.000], "oxygenation": True},  # 10 mm
+            "hbo:c": {"location": [0.050, 0.000, 0.000], "oxygenation": True},  # 50 mm
+            "hbr:d": {"location": [0.000, 0.000, 0.000], "oxygenation": False},
+            "hbo:loc_less": {"oxygenation": True},
+        }
+
+    def test_no_shape_no_painted_returns_empty(self):
+        hrfs = self._hrfs()
+        keys = library.compute_roi_keys_by_shape(hrfs, None, set())
+        assert keys == set()
+
+    def test_sphere_at_origin_radius_20mm(self):
+        from hrfunc.spatial.shapes import Sphere
+        hrfs = self._hrfs()
+        sphere = Sphere(center_mm=(0.0, 0.0, 0.0), radius_mm=20.0)
+        keys = library.compute_roi_keys_by_shape(hrfs, sphere)
+        # 20 mm radius -> a (0mm) and b (10mm) but not c (50mm).
+        # Also picks up hbr:d at distance 0 because no oxygenation filter.
+        assert "hbo:a" in keys
+        assert "hbo:b" in keys
+        assert "hbo:c" not in keys
+        assert "hbr:d" in keys
+        assert "hbo:loc_less" not in keys  # missing location skipped
+
+    def test_box_axis_aligned(self):
+        """Box that excludes b on the x axis while including a."""
+        from hrfunc.spatial.shapes import Box
+        hrfs = self._hrfs()
+        box = Box(center_mm=(0.0, 0.0, 0.0), half_extents_mm=(5.0, 50.0, 50.0))
+        keys = library.compute_roi_keys_by_shape(hrfs, box)
+        # x half-extent 5 mm -> a (0mm) and d (0mm) in; b (10mm) and c (50mm) out.
+        assert "hbo:a" in keys
+        assert "hbo:b" not in keys
+        assert "hbo:c" not in keys
+        assert "hbr:d" in keys
+
+    def test_oxygenation_filter_hbo(self):
+        from hrfunc.spatial.shapes import Sphere
+        hrfs = self._hrfs()
+        sphere = Sphere(center_mm=(0.0, 0.0, 0.0), radius_mm=20.0)
+        keys = library.compute_roi_keys_by_shape(
+            hrfs, sphere, oxygenation_filter=True,
+        )
+        # HbR points must be excluded by the filter.
+        assert "hbo:a" in keys
+        assert "hbo:b" in keys
+        assert "hbr:d" not in keys
+
+    def test_painted_unions_into_roi(self):
+        from hrfunc.spatial.shapes import Sphere
+        hrfs = self._hrfs()
+        sphere = Sphere(center_mm=(0.0, 0.0, 0.0), radius_mm=1.0)  # tiny
+        # Sphere alone matches only a (distance 0). Painting c adds it.
+        keys = library.compute_roi_keys_by_shape(
+            hrfs, sphere, painted={"hbo:c"},
+        )
+        assert "hbo:a" in keys
+        assert "hbo:c" in keys
+
+    def test_painted_respects_oxygenation_filter(self):
+        from hrfunc.spatial.shapes import Sphere
+        hrfs = self._hrfs()
+        sphere = Sphere(center_mm=(0.0, 0.0, 0.0), radius_mm=1.0)
+        # Even though hbr:d is in painted, the HbO filter drops it.
+        keys = library.compute_roi_keys_by_shape(
+            hrfs, sphere, painted={"hbr:d"}, oxygenation_filter=True,
+        )
+        assert "hbr:d" not in keys
+
+
 class TestBuildFigureWithRoi:
     def _hrfs(self):
         return {

--- a/tests/test_gui_workspace_io.py
+++ b/tests/test_gui_workspace_io.py
@@ -197,3 +197,145 @@ class TestSaveRoiAverage:
         )
         payload = json.loads(out.read_text())
         assert payload["context"]["roi_member_keys"] == ["hbo:a", "hbo:m", "hbo:z"]
+
+
+# ---------------------------------------------------------------------------
+# save_roi_average (PR #49): shape descriptor + free-floating ROIs
+# ---------------------------------------------------------------------------
+
+
+class TestSaveRoiAverageWithShape:
+    """PR #49 expanded ``save_roi_average`` to accept an optional shape
+    descriptor and made the anchor optional. These tests pin down the
+    extended schema."""
+
+    def _anchor(self):
+        return {
+            "_key": "hbo:s1_d1_hbo-temp",
+            "oxygenation": True,
+            "location": [0.01, 0.02, 0.03],
+            "context": {"task": "flanker"},
+        }
+
+    def test_box_shape_recorded_in_descriptor(self, tmp_path):
+        from hrfunc.spatial.shapes import Box
+        box = Box(center_mm=(10.0, 20.0, 30.0), half_extents_mm=(5.0, 5.0, 5.0))
+        out = save_roi_average(
+            anchor=self._anchor(),
+            roi_keys={"hbo:a", "hbo:b"},
+            hrf_mean=[1.0, 2.0],
+            hrf_std=[0.1, 0.2],
+            sfreq=10.0,
+            shape=box,
+            workspace=tmp_path,
+        )
+        payload = json.loads(out.read_text())
+        shape_desc = payload["context"]["roi_shape"]
+        assert shape_desc["type"] == "box"
+        assert shape_desc["center_mm"] == [10.0, 20.0, 30.0]
+        assert shape_desc["half_extents_mm"] == [5.0, 5.0, 5.0]
+
+    def test_sphere_shape_recorded_in_descriptor(self, tmp_path):
+        from hrfunc.spatial.shapes import Sphere
+        sphere = Sphere(center_mm=(0.0, 0.0, 0.0), radius_mm=15.0)
+        out = save_roi_average(
+            anchor=self._anchor(),
+            roi_keys={"hbo:a"},
+            hrf_mean=[1.0],
+            hrf_std=[0.1],
+            sfreq=10.0,
+            shape=sphere,
+            workspace=tmp_path,
+        )
+        payload = json.loads(out.read_text())
+        shape_desc = payload["context"]["roi_shape"]
+        assert shape_desc["type"] == "sphere"
+        assert shape_desc["center_mm"] == [0.0, 0.0, 0.0]
+        assert shape_desc["radius_mm"] == 15.0
+        # The legacy roi_radius_m key still appears for back-compat audit scripts.
+        assert payload["context"]["roi_radius_m"] == 0.015
+
+    def test_free_floating_no_anchor_uses_shape_centre_as_location(self, tmp_path):
+        """When the user has not clicked an anchor, the shape centre
+        stands in as the saved ``location`` -- converted from mm back
+        to meters so the saved JSON round-trips into ``hrfunc.tree``
+        without unit fixups."""
+        from hrfunc.spatial.shapes import Box
+        box = Box(center_mm=(15.0, 25.0, 35.0), half_extents_mm=(5.0, 5.0, 5.0))
+        out = save_roi_average(
+            roi_keys={"hbo:a"},
+            hrf_mean=[1.0],
+            hrf_std=[0.1],
+            sfreq=10.0,
+            shape=box,
+            oxygenation_filter=True,
+            workspace=tmp_path,
+        )
+        payload = json.loads(out.read_text())
+        # Centre 15 mm -> 0.015 m (matching v1.2 meter convention).
+        assert payload["location"] == [0.015, 0.025, 0.035]
+        # Oxygenation falls back to the explicit filter when no anchor.
+        assert payload["oxygenation"] is True
+
+    def test_free_floating_filename_prefix(self, tmp_path):
+        """Free-floating saves should still have a recognisable filename
+        prefix even without an anchor key to derive one from."""
+        from hrfunc.spatial.shapes import Box
+        out = save_roi_average(
+            roi_keys=set(),
+            hrf_mean=[0.0],
+            hrf_std=[0.0],
+            sfreq=1.0,
+            shape=Box(center_mm=(0.0, 0.0, 0.0), half_extents_mm=(1.0, 1.0, 1.0)),
+            workspace=tmp_path,
+        )
+        assert "freefloat_box" in out.name
+
+    def test_anchor_key_is_none_in_context_when_no_anchor(self, tmp_path):
+        from hrfunc.spatial.shapes import Sphere
+        sphere = Sphere(center_mm=(0.0, 0.0, 0.0), radius_mm=10.0)
+        out = save_roi_average(
+            roi_keys={"hbo:a"},
+            hrf_mean=[1.0],
+            hrf_std=[0.1],
+            sfreq=10.0,
+            shape=sphere,
+            workspace=tmp_path,
+        )
+        payload = json.loads(out.read_text())
+        assert payload["context"]["roi_anchor_key"] is None
+
+    def test_oxygenation_filter_none_means_mixed(self, tmp_path):
+        """When neither anchor nor oxygenation_filter is set, the saved
+        ``oxygenation`` is None -- signalling a mixed-haemoglobin ROI."""
+        from hrfunc.spatial.shapes import Box
+        box = Box(center_mm=(0.0, 0.0, 0.0), half_extents_mm=(5.0, 5.0, 5.0))
+        out = save_roi_average(
+            roi_keys={"a"},
+            hrf_mean=[1.0],
+            hrf_std=[0.1],
+            sfreq=10.0,
+            shape=box,
+            workspace=tmp_path,
+        )
+        payload = json.loads(out.read_text())
+        assert payload["oxygenation"] is None
+
+    def test_legacy_radius_m_only_call_still_works(self, tmp_path):
+        """v1.2 call sites that pass ``radius_m`` without ``shape`` keep
+        working unchanged; the saved JSON gets a synthetic sphere
+        descriptor + the ``roi_radius_m`` legacy key."""
+        out = save_roi_average(
+            anchor=self._anchor(),
+            roi_keys={"a"},
+            hrf_mean=[1.0],
+            hrf_std=[0.1],
+            sfreq=10.0,
+            radius_m=0.02,
+            workspace=tmp_path,
+        )
+        payload = json.loads(out.read_text())
+        assert payload["context"]["roi_radius_m"] == 0.02
+        shape_desc = payload["context"]["roi_shape"]
+        assert shape_desc["type"] == "sphere"
+        assert shape_desc["radius_m"] == 0.02

--- a/tests/test_spatial_shapes.py
+++ b/tests/test_spatial_shapes.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import numpy as np
 import pytest
 
-from hrfunc.spatial.shapes import Shape, Sphere
+from hrfunc.spatial.shapes import Box, Shape, Sphere
 
 
 class TestSphereConstruction:
@@ -110,3 +110,123 @@ class TestShapeABC:
         s = _OnlyContains()
         result = s.contains_batch(np.array([[1.0, 0.0, 0.0], [-1.0, 0.0, 0.0]]))
         np.testing.assert_array_equal(result, [True, False])
+
+
+class TestBoxConstruction:
+    def test_basic_construction(self):
+        box = Box(center_mm=(0.0, 0.0, 0.0), half_extents_mm=(10.0, 20.0, 30.0))
+        assert box.center_mm == (0.0, 0.0, 0.0)
+        assert box.half_extents_mm == (10.0, 20.0, 30.0)
+
+    def test_list_inputs_accepted(self):
+        box = Box(center_mm=[1.0, 2.0, 3.0], half_extents_mm=[5.0, 5.0, 5.0])
+        assert box.center_mm == (1.0, 2.0, 3.0)
+        assert box.half_extents_mm == (5.0, 5.0, 5.0)
+
+    def test_rejects_wrong_centre_dimensions(self):
+        with pytest.raises(ValueError, match="center_mm.*3 elements"):
+            Box(center_mm=(0.0, 0.0), half_extents_mm=(10.0, 10.0, 10.0))
+
+    def test_rejects_wrong_extent_dimensions(self):
+        with pytest.raises(ValueError, match="half_extents_mm.*3 elements"):
+            Box(center_mm=(0.0, 0.0, 0.0), half_extents_mm=(10.0, 10.0))
+
+    def test_rejects_negative_extents(self):
+        with pytest.raises(ValueError, match="non-negative"):
+            Box(center_mm=(0.0, 0.0, 0.0), half_extents_mm=(10.0, -1.0, 10.0))
+
+    def test_zero_extents_allowed(self):
+        """Degenerate point-box: only the centre is inside."""
+        box = Box(center_mm=(5.0, 5.0, 5.0), half_extents_mm=(0.0, 0.0, 0.0))
+        assert box.contains((5.0, 5.0, 5.0)) is True
+        assert box.contains((5.001, 5.0, 5.0)) is False
+
+
+class TestBoxContains:
+    def test_inside_point(self):
+        box = Box(center_mm=(0.0, 0.0, 0.0), half_extents_mm=(10.0, 10.0, 10.0))
+        assert box.contains((1.0, 2.0, 3.0)) is True
+
+    def test_outside_on_one_axis(self):
+        """Outside any single axis means outside the box."""
+        box = Box(center_mm=(0.0, 0.0, 0.0), half_extents_mm=(10.0, 10.0, 10.0))
+        assert box.contains((5.0, 5.0, 100.0)) is False
+
+    def test_boundary_is_inside(self):
+        """Membership is closed on every axis (matches Sphere semantics)."""
+        box = Box(center_mm=(0.0, 0.0, 0.0), half_extents_mm=(10.0, 10.0, 10.0))
+        assert box.contains((10.0, 10.0, 10.0)) is True
+        assert box.contains((-10.0, -10.0, -10.0)) is True
+
+    def test_anisotropic_extents(self):
+        """Asymmetric box: each axis has its own half-extent."""
+        box = Box(center_mm=(0.0, 0.0, 0.0), half_extents_mm=(5.0, 20.0, 100.0))
+        # Inside x (5), y (20), z (100) -- all within
+        assert box.contains((4.0, 19.0, 99.0)) is True
+        # Outside x (>5) -- excluded even though y, z are well inside
+        assert box.contains((6.0, 0.0, 0.0)) is False
+
+    def test_offset_centre(self):
+        box = Box(center_mm=(30.0, 20.0, 10.0), half_extents_mm=(5.0, 5.0, 5.0))
+        assert box.contains((30.0, 20.0, 10.0)) is True
+        assert box.contains((34.0, 24.0, 14.0)) is True
+        assert box.contains((36.0, 20.0, 10.0)) is False
+
+    def test_accepts_tuple_list_ndarray(self):
+        box = Box(center_mm=(0.0, 0.0, 0.0), half_extents_mm=(10.0, 10.0, 10.0))
+        assert box.contains((1.0, 2.0, 3.0)) is True
+        assert box.contains([1.0, 2.0, 3.0]) is True
+        assert box.contains(np.array([1.0, 2.0, 3.0])) is True
+
+
+class TestBoxBatch:
+    def test_basic_batch(self):
+        box = Box(center_mm=(0.0, 0.0, 0.0), half_extents_mm=(10.0, 10.0, 10.0))
+        points = np.array([
+            [0.0, 0.0, 0.0],     # inside
+            [10.0, 10.0, 10.0],  # boundary -- inside (closed)
+            [11.0, 0.0, 0.0],    # outside x
+            [5.0, 5.0, 100.0],   # outside z
+            [-5.0, -5.0, -5.0],  # inside
+        ])
+        result = box.contains_batch(points)
+        np.testing.assert_array_equal(result, [True, True, False, False, True])
+
+    def test_batch_matches_per_point(self):
+        """Vectorised must agree with per-point loop -- catches einsum-style slip-ups."""
+        rng = np.random.default_rng(seed=7)
+        points = rng.uniform(-50, 50, size=(100, 3))
+        box = Box(center_mm=(10.0, -5.0, 0.0), half_extents_mm=(15.0, 25.0, 35.0))
+        batch = box.contains_batch(points)
+        per_point = np.array([box.contains(p) for p in points])
+        np.testing.assert_array_equal(batch, per_point)
+
+    def test_batch_rejects_wrong_shape(self):
+        box = Box(center_mm=(0.0, 0.0, 0.0), half_extents_mm=(10.0, 10.0, 10.0))
+        with pytest.raises(ValueError, match=r"\(N, 3\)"):
+            box.contains_batch(np.array([1.0, 2.0, 3.0]))
+
+
+class TestBoxCorners:
+    def test_returns_eight_corners(self):
+        box = Box(center_mm=(0.0, 0.0, 0.0), half_extents_mm=(1.0, 2.0, 3.0))
+        corners = box.corners_mm()
+        assert corners.shape == (8, 3)
+
+    def test_corners_are_centre_plus_signed_extents(self):
+        box = Box(center_mm=(0.0, 0.0, 0.0), half_extents_mm=(1.0, 2.0, 3.0))
+        corners = box.corners_mm()
+        # Expected: every combination of (+/-1, +/-2, +/-3).
+        expected_set = {
+            (sx * 1.0, sy * 2.0, sz * 3.0)
+            for sx in (-1, 1) for sy in (-1, 1) for sz in (-1, 1)
+        }
+        actual_set = {tuple(row) for row in corners}
+        assert actual_set == expected_set
+
+    def test_corners_with_offset_centre(self):
+        box = Box(center_mm=(10.0, 20.0, 30.0), half_extents_mm=(1.0, 1.0, 1.0))
+        corners = box.corners_mm()
+        for corner in corners:
+            # Each corner sits at +/-1 from the centre on every axis.
+            assert all(abs(c - centre) == 1.0 for c, centre in zip(corner, (10.0, 20.0, 30.0)))

--- a/tests/test_viz_brain_scene.py
+++ b/tests/test_viz_brain_scene.py
@@ -13,7 +13,12 @@ import pytest
 
 pytest.importorskip("plotly")
 
-from hrfunc.viz.brain_scene import make_surface_trace  # noqa: E402
+from hrfunc.spatial.shapes import Box, Sphere  # noqa: E402
+from hrfunc.viz.brain_scene import (  # noqa: E402
+    make_box_overlay_trace,
+    make_sphere_overlay_trace,
+    make_surface_trace,
+)
 
 
 def _tiny_mesh():
@@ -79,3 +84,76 @@ class TestMakeSurfaceTrace:
         np.testing.assert_array_equal(trace.i, faces[:, 0])
         np.testing.assert_array_equal(trace.j, faces[:, 1])
         np.testing.assert_array_equal(trace.k, faces[:, 2])
+
+
+class TestMakeBoxOverlayTrace:
+    def _box(self):
+        return Box(center_mm=(10.0, 20.0, 30.0), half_extents_mm=(5.0, 5.0, 5.0))
+
+    def test_returns_mesh3d(self):
+        trace = make_box_overlay_trace(self._box())
+        assert trace.type == "mesh3d"
+
+    def test_eight_vertices_twelve_faces(self):
+        trace = make_box_overlay_trace(self._box())
+        assert len(trace.x) == 8
+        assert len(trace.i) == 12
+
+    def test_vertex_positions_at_corners(self):
+        """Verify every vertex sits at the box's centre +/- its half-extents."""
+        trace = make_box_overlay_trace(self._box())
+        for x, y, z in zip(trace.x, trace.y, trace.z):
+            assert abs(x - 10.0) == 5.0
+            assert abs(y - 20.0) == 5.0
+            assert abs(z - 30.0) == 5.0
+
+    def test_hidden_from_legend_and_hover(self):
+        trace = make_box_overlay_trace(self._box())
+        assert trace.showlegend is False
+        assert trace.hoverinfo == "skip"
+
+    def test_default_name(self):
+        trace = make_box_overlay_trace(self._box())
+        assert trace.name == "ROI box"
+
+
+class TestMakeSphereOverlayTrace:
+    def _sphere(self):
+        return Sphere(center_mm=(0.0, 0.0, 0.0), radius_mm=10.0)
+
+    def test_returns_mesh3d(self):
+        trace = make_sphere_overlay_trace(self._sphere())
+        assert trace.type == "mesh3d"
+
+    def test_vertices_lie_on_sphere(self):
+        """All UV-sphere verts must be within float epsilon of the radius."""
+        trace = make_sphere_overlay_trace(self._sphere())
+        # Skip plotly's tuple-of-tuples coords by routing through numpy.
+        verts = np.column_stack([trace.x, trace.y, trace.z])
+        distances = np.linalg.norm(verts, axis=1)
+        np.testing.assert_allclose(distances, 10.0, atol=1e-9)
+
+    def test_vertex_count_scales_with_resolution(self):
+        """Higher (n_lat, n_lon) -> more verts. Concretely: 2 poles plus
+        (n_lat-1) latitude rings each with n_lon longitudes."""
+        trace = make_sphere_overlay_trace(self._sphere(), n_lat=4, n_lon=6)
+        # 2 poles + 3 rings * 6 longitudes = 20 verts.
+        assert len(trace.x) == 20
+
+    def test_offset_centre(self):
+        sphere = Sphere(center_mm=(50.0, -20.0, 10.0), radius_mm=5.0)
+        trace = make_sphere_overlay_trace(sphere)
+        verts = np.column_stack([trace.x, trace.y, trace.z])
+        diffs = verts - np.array([50.0, -20.0, 10.0])
+        np.testing.assert_allclose(np.linalg.norm(diffs, axis=1), 5.0, atol=1e-9)
+
+    def test_rejects_too_few_resolution(self):
+        with pytest.raises(ValueError, match="n_lat>=2"):
+            make_sphere_overlay_trace(self._sphere(), n_lat=1, n_lon=10)
+        with pytest.raises(ValueError, match="n_lon>=3"):
+            make_sphere_overlay_trace(self._sphere(), n_lat=10, n_lon=2)
+
+    def test_hidden_from_legend_and_hover(self):
+        trace = make_sphere_overlay_trace(self._sphere())
+        assert trace.showlegend is False
+        assert trace.hoverinfo == "skip"


### PR DESCRIPTION
## Summary

- Adds the **Box** ROI shape to the Cluster sub-tab alongside the existing Sphere mode, with three MNI-mm centre inputs, three half-extent inputs, and a copy-pasteable MNI readout line.
- Decouples the anchor from the ROI -- clicking an HRF now *seeds* the cluster centre rather than gating selection. Free-floating MNI coordinate entry works without any prior click.
- Renders a translucent violet shape overlay (cuboid or UV-sphere) in the 3D viz so you can see exactly where your ROI sits relative to the scalp / pial / HRF scatter.
- Records full shape provenance in the saved ROI JSON. Backwards-compatible with the v1.2 `radius_m`-only call sites.

## Architecture summary

```
┌─────────────────────────┐         ┌─────────────────────────┐
│ hrfunc.spatial.shapes   │ <────── │ Cluster sub-tab UI       │
│   Sphere + Box (mm)     │         │   (shape radio, inputs)  │
└─────────────────────────┘         └────────────┬─────────────┘
                                                 │
                                                 v
┌─────────────────────────┐         ┌─────────────────────────┐
│ compute_roi_keys_by_    │ <────── │ _build_current_shape     │
│ shape (oxygenation +    │         │ + _resolve_cluster_oxy   │
│ painted union)          │         └─────────────┬───────────┘
└─────────────────────────┘                       │
            │                                     │
            v                                     v
┌─────────────────────────┐         ┌─────────────────────────┐
│ build_plotly_figure     │         │ save_roi_average         │
│ (+ roi_shape overlay)   │         │ (anchor optional, shape  │
└─────────────────────────┘         │  descriptor recorded)    │
                                    └─────────────────────────┘
```

The four ROI-key call sites (cluster sub-tab body, save handler, viz pane, detail pane average) all flow through `_build_current_shape` + `compute_roi_keys_by_shape`, so they can't drift out of sync.

## What changed

**Spatial layer** ([src/hrfunc/spatial/shapes.py](src/hrfunc/spatial/shapes.py))
- `Box(center_mm, half_extents_mm)` -- AABB with closed-membership `contains` and vectorised `contains_batch`. Exposes `corners_mm()` for viz consumers.
- Rotation explicitly out of scope (see class docstring + memory note on locked decisions).

**Viz layer** ([src/hrfunc/viz/brain_scene.py](src/hrfunc/viz/brain_scene.py))
- `make_box_overlay_trace` -- 12-triangle cuboid Mesh3d.
- `make_sphere_overlay_trace` -- UV-sphere Mesh3d (~200 verts default).
- Both default to soft-violet `#a78bfa` so they don't collide with the HbO red / HbR blue / ROI gold palette.

**GUI state** ([src/hrfunc/gui/state.py](src/hrfunc/gui/state.py))
- Six new fields: `cluster_shape`, `cluster_center_{x,y,z}_mm`, `cluster_box_half_{x,y,z}_mm`. All reset to defaults.

**HRtree panel** ([src/hrfunc/gui/components/hrtree_panel.py](src/hrfunc/gui/components/hrtree_panel.py))
- New `compute_roi_keys_by_shape` (shape-based companion to legacy `compute_roi_keys`).
- New `_build_current_shape` + `_resolve_cluster_oxygenation` + `_resolve_roi_sfreq` helpers.
- Cluster sub-tab fully rewritten: shape radio, centre inputs, half-extent inputs, MNI readout.
- `build_plotly_figure` accepts `roi_shape` and renders the overlay.
- Click handler seeds `cluster_center_*_mm` from the clicked HRF (meters -> mm).
- Detail-pane ROI average uses the shape-based path so it stays in sync with the Cluster sub-tab even with no anchor.

**Workspace save** ([src/hrfunc/gui/workspace_io.py](src/hrfunc/gui/workspace_io.py))
- `save_roi_average` now: `anchor` optional, `shape` optional, `oxygenation_filter` optional.
- New `roi_shape` context key carries a structured descriptor.
- Free-floating saves use the shape centre (mm -> meters) as the recorded `location`.
- Legacy `roi_radius_m` key still emitted for v1.2 audit-script back-compat.
- Filename fragment falls back to `freefloat_<shape_type>` when there's no anchor.

## Test plan

- [x] +39 new tests: 14 Box, 9 brain_scene overlays, 7 ROI-by-shape, 2 cluster state, 7 workspace_io shape paths
- [x] Full suite: **748 passed**, 0 failures, 0 errors (up from 703 baseline)
- [x] All 75 existing `test_gui_library.py` tests still pass
- [x] All 21 `test_gui_workspace_io.py` tests pass (14 existing + 7 new)
- [ ] Manual smoke (left to reviewer): launch GUI, switch shape to Box, drag centre + half-extent inputs, verify cuboid overlay tracks live; click an HRF and verify centre re-seeds; Save ROI average with free-floating box; reload saved JSON via `tree.load_hrfs` to confirm round-trip

## Locked decisions in the implementation

(From [project_v1_3_spatial_viz_compartmentalization.md](https://github.com/anthropics/claude-code))

- **Box is AABB only.** No rotation; explicit docstring note.
- **Atlas pre-bundled, not downloaded.** (Not in this PR -- next one.)
- **All spatial selection in MNI mm.** HRF locations stored in meters; conversion happens once at the membership-check boundary.
- **Anchor optional in Cluster tab.** This PR delivers it.
- **`save_roi_average` schema kept stable.** Anchor optional, `radius_m` still accepted, `oxygenation` becomes nullable when neither anchor nor explicit filter is set.

## Out of scope

- Box rotation -- intentionally excluded. Slider-based 3D rotation is a UX trap and fNIRS reports axis-align to MNI by convention.
- Harvard-Oxford atlas integration -- next PR.
- Anatomical NIfTI viewer -- v1.3.1 (PR #51).
- "Save button warns about mixed-oxygenation ROIs" -- left for a follow-up if it turns out to be a real footgun in practice.

## Notes for reviewers

- The legacy `compute_roi_keys(anchor, radius_m)` function is preserved unchanged for back-compat. New code paths use `compute_roi_keys_by_shape` instead. Both are exported from the panel module.
- The viz-pane click handler now mutates two state fields (`library_selected_hrf` *and* `cluster_center_*_mm`); the selection event is still the same `hrtree_selection_changed` so subscribers don't need to change.
- `_resolve_roi_sfreq` was added because the detail-pane render no longer has an anchor to lean on for sample rate when in free-floating mode.

Generated with [Claude Code](https://claude.com/claude-code)