### PR TITLE
feat: multi-ROI Cluster sub-tab + unified montage.json save schema

### DIFF
--- a/src/hrfunc/gui/components/hrtree_panel.py
+++ b/src/hrfunc/gui/components/hrtree_panel.py
@@ -624,6 +624,17 @@ def _render_cluster_subtab(state: AppState) -> None:
                 "without a default ROI applied."
             )
 
+            # --- Multi-ROI list (PR #55) ----------------------------
+            # The active ROI is what the shape / centre / radius / atlas
+            # widgets below operate on (proxy properties on AppState).
+            # ADD ROI appends a fresh slot at defaults; clicking a row
+            # switches the active index; the trash icon deletes the
+            # row (refusing to drop below one slot -- the proxy
+            # properties need a target). The list is scrollable so a
+            # large montage doesn't push the rest of the sub-tab off
+            # screen.
+            _render_roi_list(state, _body)
+
             # --- Shape radio -----------------------------------------
             shape_options = {SHAPE_SPHERE: "Sphere"}
             if atlas is not None:
@@ -745,14 +756,29 @@ def _render_cluster_subtab(state: AppState) -> None:
                 _render_atlas_alignment_section(state, _body)
 
             # --- Clear ROI button ------------------------------------
+            # PR #55: when there are 2+ ROIs in the list, CLEAR ROI
+            # deletes the active slot and advances to the prior one.
+            # When there's only one ROI left, it resets that slot to
+            # defaults rather than deleting it -- the proxy properties
+            # need at least one slot to point at, and "clear" on a
+            # fresh page shouldn't make the list disappear entirely.
+            # Library-side selection (``library_selected_hrf``) is
+            # also cleared so the detail pane returns to its empty
+            # state for the new active slot.
             def _on_clear_roi() -> None:
+                state.clear_active_roi()
                 state.library_selected_hrf = None
-                state.library_roi_painted.clear()
                 state.publish("hrtree_selection_changed", None)
                 state.publish("hrtree_filter_changed", state.library_filter)
+                _body.refresh()
 
+            clear_label = (
+                "Clear ROI"
+                if len(state.cluster_rois) <= 1
+                else "Delete active ROI"
+            )
             ui.button(
-                "Clear ROI", on_click=_on_clear_roi
+                clear_label, on_click=_on_clear_roi
             ).props("flat dense")
 
             # --- MNI + atlas readouts --------------------------------
@@ -818,68 +844,130 @@ def _render_cluster_subtab(state: AppState) -> None:
                     ).classes("text-xs opacity-50 italic")
 
             def _on_save_roi() -> None:
-                # Recompute at click time so we save what the user sees
-                # right now (state may have changed between mount and
-                # click).
+                # PR #55: walk every slot in cluster_rois, build a
+                # per-ROI entry for each one that has enough data to
+                # average, and write a single montage.json with the
+                # whole list. Slots that fail the averaging gate
+                # ("fewer than 2 subject estimates") are skipped --
+                # the notify at the end says how many were saved /
+                # skipped so the user knows nothing was silently lost.
                 _matched = filter_by_oxygenation(
                     apply_filter(gather_library_hrfs(state),
                                  state.library_filter),
                     state.library_oxygenation,
                 )
-                _shape = _build_current_shape(state)
-                _oxy = _resolve_cluster_oxygenation(state)
-                _alignment = _alignment_for_shape(state, _shape)
-                _roi_keys = compute_roi_keys_by_shape(
-                    _matched, _shape, state.library_roi_painted,
-                    oxygenation_filter=_oxy,
-                    alignment_affine=_alignment,
-                )
-                _result = compute_roi_average(_matched, _roi_keys)
-                if _result is None:
+
+                entries: list = []
+                skipped: list = []
+                original_index = state.cluster_active_index
+                original_anchor = state.library_selected_hrf
+                try:
+                    for i, slot in enumerate(state.cluster_rois):
+                        # Make the slot active so the proxy-based
+                        # helpers (_build_current_shape,
+                        # _resolve_cluster_oxygenation, etc.) read its
+                        # state. The save handler restores the original
+                        # active index in the finally block.
+                        state.cluster_active_index = i
+                        state.library_selected_hrf = slot.anchor
+
+                        _shape = _build_current_shape(state)
+                        if _shape is None:
+                            skipped.append((slot.name, "no shape"))
+                            continue
+                        _oxy = _resolve_cluster_oxygenation(state)
+                        _alignment = _alignment_for_shape(state, _shape)
+                        _roi_keys = compute_roi_keys_by_shape(
+                            _matched, _shape, slot.painted,
+                            oxygenation_filter=_oxy,
+                            alignment_affine=_alignment,
+                        )
+                        _result = compute_roi_average(_matched, _roi_keys)
+                        if _result is None:
+                            skipped.append(
+                                (slot.name, "insufficient estimates")
+                            )
+                            continue
+                        _mean, _std, _n_subjects, _n_channels = _result
+                        _sfreq = _resolve_roi_sfreq(
+                            slot.anchor, _matched, _roi_keys
+                        )
+                        from ..workspace_io import build_roi_entry
+                        entries.append(
+                            build_roi_entry(
+                                roi_keys=_roi_keys,
+                                hrf_mean=_mean,
+                                hrf_std=_std,
+                                sfreq=_sfreq,
+                                shape=_shape,
+                                anchor=slot.anchor,
+                                library_filter=state.library_filter,
+                                oxygenation_filter=_oxy,
+                                name=slot.name,
+                            )
+                        )
+                finally:
+                    state.cluster_active_index = original_index
+                    state.library_selected_hrf = original_anchor
+
+                if not entries:
                     ui.notify(
-                        "ROI has fewer than 2 averageable subject "
-                        "estimates.",
+                        "No ROI in the montage has enough data to "
+                        "average. Widen a shape, paint more neighbours, "
+                        "or seed a different centre.",
                         type="warning",
                     )
                     return
-                _mean, _std, _n_subjects, _n_channels = _result
-                _anchor = state.library_selected_hrf
-                _sfreq = _resolve_roi_sfreq(_anchor, _matched, _roi_keys)
 
-                from ..workspace_io import save_roi_average, workspace_dir
+                # Alignment is a global per-scan property of the HRF
+                # library's coord frame (locked decision 2026-05-14) --
+                # one block at the wrapper level for all ROIs.
+                from ..workspace_io import save_montage, workspace_dir
                 try:
-                    out_path = save_roi_average(
-                        roi_keys=_roi_keys,
-                        hrf_mean=_mean,
-                        hrf_std=_std,
-                        sfreq=_sfreq,
-                        shape=_shape,
-                        anchor=_anchor,
-                        library_filter=state.library_filter,
-                        oxygenation_filter=_oxy,
+                    out_path = save_montage(
+                        rois=entries,
+                        alignment_offset_mm=(
+                            float(state.cluster_atlas_offset_x_mm),
+                            float(state.cluster_atlas_offset_y_mm),
+                            float(state.cluster_atlas_offset_z_mm),
+                        ),
+                        alignment_affine=state.cluster_atlas_alignment_affine,
                     )
                     state.last_saved_roi_path = out_path
-                    ui.notify(
-                        f"Saved ROI average to {out_path.name} "
-                        f"({workspace_dir()})",
-                        type="positive",
+                    saved_msg = (
+                        f"Saved montage ({len(entries)} ROI"
+                        f"{'s' if len(entries) != 1 else ''}) to "
+                        f"{out_path.name} ({workspace_dir()})"
                     )
-                    # Re-render so the persistent "Last saved" label
-                    # below picks up the new path immediately.
+                    if skipped:
+                        names = ", ".join(name for name, _ in skipped)
+                        saved_msg += (
+                            f". Skipped {len(skipped)}: {names}"
+                        )
+                    ui.notify(saved_msg, type="positive")
                     _body.refresh()
                 except Exception as exc:  # noqa: BLE001
-                    logger.exception("save ROI average failed: %s", exc)
+                    logger.exception("save montage failed: %s", exc)
                     ui.notify(
                         f"Save failed: {type(exc).__name__}: {exc}",
                         type="negative",
                     )
 
+            save_label = (
+                "Save ROI average"
+                if len(state.cluster_rois) <= 1
+                else f"Save montage ({len(state.cluster_rois)} ROIs)"
+            )
             save_btn = ui.button(
-                "Save ROI average",
+                save_label,
                 icon="download",
                 on_click=_on_save_roi,
             ).props("color=primary dense")
-            if not can_save:
+            # Disable only when EVERY slot fails the averaging gate.
+            # With multiple ROIs we let the user click even if the
+            # active slot is invalid -- the iteration handles per-slot
+            # skips and the notify spells out what was saved.
+            if not can_save and len(state.cluster_rois) <= 1:
                 save_btn.props("disable")
 
             # --- Persistent "last saved" feedback (PR #54) ----------
@@ -980,6 +1068,132 @@ def _looks_out_of_mni(hrfs: Dict[str, Dict[str, Any]]) -> bool:
         if sampled >= 8:
             break
     return sampled >= 3 and over_threshold >= 3
+
+
+def _render_roi_list(state: AppState, body_refreshable) -> None:
+    """Render the multi-ROI list (PR #55).
+
+    Layout:
+        +-------------------------------------------+
+        | ROIs                              [+ ADD] |
+        | > [active] ROI 1                       x  |
+        |   ROI 2                                x  |
+        |   ROI 3                                x  |
+        +-------------------------------------------+
+
+    Clicking a row switches the active index; the trash icon deletes
+    that row. The list is scrollable (capped at ~8 rows visible)
+    so a long montage doesn't push the rest of the Cluster sub-tab
+    off screen.
+
+    ``body_refreshable`` is the cluster sub-tab's ``@ui.refreshable``
+    body so list mutations re-render the sub-tab and the shape
+    widgets pick up the new active slot.
+    """
+
+    def _refresh_all() -> None:
+        body_refreshable.refresh()
+        state.publish("hrtree_filter_changed", state.library_filter)
+
+    def _on_add() -> None:
+        state.add_roi()
+        _refresh_all()
+
+    def _on_select(index: int) -> None:
+        # Re-seed the library_selected_hrf from the slot's anchor so
+        # the detail pane + viz click-state mirror what the active
+        # ROI was last anchored on. None is fine -- detail pane shows
+        # its empty state.
+        state.set_active_roi(index)
+        state.library_selected_hrf = state.active_roi.anchor
+        state.publish(
+            "hrtree_selection_changed",
+            None if state.active_roi.anchor is None
+            else state.active_roi.anchor.get("_key"),
+        )
+        _refresh_all()
+
+    def _on_delete(index: int) -> None:
+        # Use clear_active_roi semantics, but delete the targeted
+        # index rather than always the active. Switch active there
+        # first so the helper's "remove active, walk back one" logic
+        # applies to the right slot.
+        state.set_active_roi(index)
+        state.clear_active_roi()
+        state.library_selected_hrf = state.active_roi.anchor
+        _refresh_all()
+
+    with ui.row().classes("w-full items-center justify-between"):
+        ui.label("ROIs").classes(
+            "text-xs uppercase opacity-60 tracking-wide"
+        )
+        ui.button(
+            "Add ROI", icon="add", on_click=_on_add,
+        ).props("flat dense color=primary")
+
+    # Cap the visible height so a long montage scrolls inside the
+    # sub-tab instead of stretching the page. ~8 rows at ~32px each.
+    with ui.column().classes(
+        "w-full gap-1 overflow-auto"
+    ).style("max-height: 256px"):
+        for i, slot in enumerate(state.cluster_rois):
+            is_active = i == state.cluster_active_index
+            row_classes = (
+                "w-full items-center gap-2 px-2 py-1 rounded cursor-pointer "
+                + (
+                    "bg-amber-50 dark:bg-amber-900/30 "
+                    "border border-amber-400"
+                    if is_active
+                    else "hover:bg-gray-100 dark:hover:bg-gray-800"
+                )
+            )
+            with ui.row().classes(row_classes).on(
+                "click", lambda _e=None, idx=i: _on_select(idx)
+            ):
+                # Active indicator + shape glyph + name.
+                shape_glyph = {
+                    SHAPE_SPHERE: "radio_button_unchecked",
+                    SHAPE_BOX: "crop_square",
+                    SHAPE_ATLAS_REGION: "map",
+                }.get(slot.shape, "radio_button_unchecked")
+                ui.icon(
+                    "arrow_right" if is_active else "circle",
+                    size="sm" if is_active else "xs",
+                ).classes(
+                    "opacity-80" if is_active else "opacity-30"
+                )
+                ui.icon(shape_glyph, size="sm").classes("opacity-70")
+                with ui.column().classes("flex-1 gap-0"):
+                    ui.label(slot.name).classes(
+                        "text-sm "
+                        + ("font-semibold" if is_active else "")
+                    )
+                    # Secondary line: shape-specific summary so the
+                    # user can tell ROIs apart without clicking.
+                    ui.label(_describe_slot(slot)).classes(
+                        "text-xs opacity-60 font-mono"
+                    )
+                # Stop propagation on the delete click so it doesn't
+                # also fire the row's _on_select.
+                ui.button(
+                    icon="delete_outline",
+                    on_click=lambda _e=None, idx=i: _on_delete(idx),
+                ).props("flat dense round size=sm").classes("opacity-60")
+
+
+def _describe_slot(slot) -> str:
+    """One-line summary of a ROISlot for the list secondary text."""
+    if slot.shape == SHAPE_ATLAS_REGION:
+        return slot.atlas_label or "(no region)"
+    centre = f"({slot.center_x_mm:.0f}, {slot.center_y_mm:.0f}, {slot.center_z_mm:.0f})"
+    if slot.shape == SHAPE_BOX:
+        return (
+            f"box {centre} ±"
+            f"({slot.box_half_x_mm:.0f},"
+            f"{slot.box_half_y_mm:.0f},"
+            f"{slot.box_half_z_mm:.0f}) mm"
+        )
+    return f"sphere {centre} r={slot.radius_mm:.0f} mm"
 
 
 def _render_atlas_alignment_section(state: AppState, body_refreshable) -> None:
@@ -1176,7 +1390,13 @@ def _render_viz_pane(state: AppState) -> None:
                 # A plain click also resets the painted set -- the user is
                 # picking a fresh anchor, so accumulated shift-hover paint
                 # from a prior anchor shouldn't carry over.
-                state.library_selected_hrf = {**hrf, "_key": hrf_key}
+                anchor_dict = {**hrf, "_key": hrf_key}
+                state.library_selected_hrf = anchor_dict
+                # PR #55: also stamp the anchor onto the *active* ROI
+                # slot so it travels with the slot (and into the saved
+                # montage). Pre-PR-#55 the anchor was a single global
+                # field; now each ROI keeps its own.
+                state.active_roi.anchor = anchor_dict
                 # Seed the Cluster sub-tab's shape centre from the clicked
                 # HRF so sphere mode's behaviour matches the v1.2 "click
                 # an HRF, sphere centres on it" workflow even though the

--- a/src/hrfunc/gui/state.py
+++ b/src/hrfunc/gui/state.py
@@ -87,7 +87,7 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any, Callable, Dict, List, Optional, Set, Tuple
 
 from ..io.manifest import Manifest, ScanEntry
 from ..io.raw_cache import RawCache
@@ -95,6 +95,82 @@ from ..io.raw_cache import RawCache
 logger = logging.getLogger(__name__)
 
 EventCallback = Callable[..., None]
+
+
+@dataclass
+class ROISlot:
+    """One ROI in the Cluster sub-tab's multi-ROI list (PR #55).
+
+    Holds everything that distinguishes one ROI from another: its shape
+    selection, geometry parameters, painted-key set, and the click-
+    anchor that seeded it (if any). Atlas alignment is NOT stored
+    here -- alignment is a property of the HRF library's coord frame,
+    not of any individual ROI, so it lives on AppState as a global
+    per scan/dataset (locked decision 2026-05-14).
+
+    The default-constructed slot reproduces the pre-PR-#55 single-ROI
+    starting state: sphere mode, free-floating centred at the MNI
+    origin with a 20 mm radius. The first slot in ``cluster_rois``
+    is therefore safe to leave at defaults if the user never opens
+    the Cluster sub-tab.
+    """
+
+    # Display name for the ROI list ("ROI 1", "ROI 2", ...). Auto-
+    # assigned by ``AppState.add_roi`` but mutable so future iterations
+    # can rename. Not included in the saved montage's per-ROI block
+    # unless renamed (see ``workspace_io``).
+    name: str = "ROI 1"
+
+    # Shape mode: "sphere" | "box" | "atlas_region". Matches the
+    # module-level SHAPE_* constants in hrtree_panel; kept as a string
+    # here so this module doesn't have to import the panel.
+    shape: str = "sphere"
+
+    # Free-floating shape centre, MNI mm. Three separate fields so each
+    # binds cleanly to its own ``ui.number`` input. Defaults to MNI
+    # origin (0, 0, 0); seeded by clicking an HRF in the viz pane.
+    center_x_mm: float = 0.0
+    center_y_mm: float = 0.0
+    center_z_mm: float = 0.0
+
+    # Box half-extents, MNI mm. Default 20 mm on each axis = a 40 mm
+    # cube, comparable to a 2 cm radius sphere by volume.
+    box_half_x_mm: float = 20.0
+    box_half_y_mm: float = 20.0
+    box_half_z_mm: float = 20.0
+
+    # Sphere radius, MNI mm. Pre-PR-#55 this lived on AppState as
+    # ``library_roi_radius_m`` (meters); the per-ROI move converts to
+    # mm to match the rest of the spatial-layer convention (MNI mm
+    # everywhere from PR #46). Default 20 mm = the legacy 0.02 m.
+    radius_mm: float = 20.0
+
+    # Atlas-region label when ``shape == "atlas_region"``. ``None``
+    # means "no region picked yet" and the save button disables.
+    atlas_label: Optional[str] = None
+
+    # Shift-hover painted keys (the lasso-like accumulation), filtered
+    # to the anchor's oxygenation when an anchor is set. Joins the
+    # ROI regardless of the shape geometry. Cleared on every new
+    # anchor click so paint from a prior anchor doesn't carry over.
+    painted: Set[str] = field(default_factory=set)
+
+    # Click-anchor HRF, if any. Same dict shape as
+    # ``state.library_selected_hrf`` (gathered HRF + ``_key``).
+    # When present, drives the saved JSON's location + oxygenation
+    # fields and the sphere's centre seed.
+    anchor: Optional[Dict[str, Any]] = None
+
+
+def _default_rois() -> List[ROISlot]:
+    """Factory for AppState.cluster_rois.
+
+    Always seeds with one default ROISlot so the active-index has
+    something to point at and the proxy properties never look at an
+    empty list. CLEAR ROI deletes the active slot but refuses to drop
+    below one entry (it resets the last slot instead).
+    """
+    return [ROISlot()]
 
 
 @dataclass
@@ -191,50 +267,21 @@ class AppState:
     # set, filtered to the anchor's oxygenation. The averaged trace
     # in the detail pane is computed from this union.
     #
-    # Radius default 0.02 m (2 cm) — a typical fNIRS short-separation
-    # neighbourhood. ``library_roi_painted`` is cleared on every new
-    # anchor click so the painted carryover from a prior anchor
-    # doesn't follow into a fresh selection.
-    library_roi_radius_m: float = 0.02
-    library_roi_painted: set = field(default_factory=set)
-    # Cluster sub-tab shape selection (PR #49, v1.3 spatial/viz arc).
+    # PR #55: per-ROI cluster state moved into ``cluster_rois``. The
+    # ``library_roi_radius_m`` / ``library_roi_painted`` /
+    # ``cluster_shape`` / ``cluster_center_*_mm`` / ``cluster_box_half_*_mm``
+    # / ``cluster_atlas_label`` names are now ``@property`` proxies
+    # onto ``cluster_rois[cluster_active_index]`` so existing panel
+    # bindings and tests keep working. See ``ROISlot``.
     #
-    # The Cluster sub-tab supports two ROI-shape modes:
-    #
-    # - ``"sphere"`` (default) -- the existing anchor + radius workflow.
-    #   ``library_roi_radius_m`` is the sphere's radius; when an anchor
-    #   HRF is clicked, the sphere centres on it. When no anchor is
-    #   clicked, the sphere centres on ``cluster_center_*_mm`` for free-
-    #   floating selection.
-    # - ``"box"`` -- an axis-aligned bounding box with independent half-
-    #   extents on each axis. Always free-floating: the box's centre is
-    #   ``cluster_center_*_mm`` (seedable by clicking an HRF or typed
-    #   directly), and ``cluster_box_half_*_mm`` controls the dimensions.
-    #
-    # All cluster spatial state is in MNI mm (the spatial-layer
-    # convention from PR #46) -- the conversion from MNE-meter HRF
-    # locations happens once at the membership-check boundary.
-    cluster_shape: str = "sphere"
-    # Free-floating shape centre, MNI mm. Three separate fields so each
-    # binds cleanly to its own ``ui.number`` input; tuple-construct at
-    # use sites. Defaults to MNI origin (0, 0, 0); seeded by clicking
-    # an HRF in the viz pane.
-    cluster_center_x_mm: float = 0.0
-    cluster_center_y_mm: float = 0.0
-    cluster_center_z_mm: float = 0.0
-    # Box half-extents, MNI mm. Default 20 mm on each axis produces a
-    # 40 mm cube -- comparable to a 2 cm radius sphere by volume and
-    # in line with typical fNIRS short-separation neighbourhood sizes.
-    cluster_box_half_x_mm: float = 20.0
-    cluster_box_half_y_mm: float = 20.0
-    cluster_box_half_z_mm: float = 20.0
-    # Atlas-region mode (PR #53). When ``cluster_shape == "atlas_region"``,
-    # the Cluster sub-tab uses an atlas-defined mask instead of a
-    # sphere / box. ``cluster_atlas_label`` is the selected region
-    # name; ``None`` means "no region picked yet" and the save button
-    # disables. The atlas itself is loaded lazily on first atlas-mode
-    # render via ``hrfunc.spatial.load_harvard_oxford_cortical``.
-    cluster_atlas_label: Optional[str] = None
+    # Multi-ROI list (PR #55). Always at least one entry -- CLEAR ROI
+    # on the last slot resets it instead of removing it, so the
+    # proxy properties never index an empty list. The active index
+    # picks which slot the proxies read/write. UI exposes ADD ROI to
+    # append, click-to-switch on the list, and CLEAR ROI on the
+    # current active slot.
+    cluster_rois: List[ROISlot] = field(default_factory=_default_rois)
+    cluster_active_index: int = 0
     # PR #54: cluster ROI active toggle (default off). When False, the
     # cluster shape doesn't contribute to ROI membership at all -- the
     # viz pane shows raw HRFs with no halo, the detail-pane ROI-average
@@ -269,6 +316,173 @@ class AppState:
     # below the save button so users can confirm the file went out
     # even after navigating away and back.
     last_saved_roi_path: Optional[Path] = None
+
+    # ------------------------------------------------------------------
+    # PR #55: proxy properties onto the active ROI slot.
+    # ------------------------------------------------------------------
+    # These exist so the Cluster sub-tab UI (which binds widgets to
+    # ``state.cluster_shape``, ``state.cluster_center_x_mm``, etc.) and
+    # the existing test suite see the per-ROI fields under their pre-
+    # PR-#55 names. The actual storage lives in
+    # ``cluster_rois[cluster_active_index]``.
+    #
+    # Switching the active ROI changes which slot the proxies read /
+    # write -- callers re-render after touching ``cluster_active_index``
+    # to pick up the new values. The proxies fall back to the first
+    # slot when the index is out of range; ``cluster_rois`` is also
+    # never empty (CLEAR ROI resets the last slot rather than removing
+    # it), so the fallback is defensive against bad external state, not
+    # an expected code path.
+
+    @property
+    def active_roi(self) -> ROISlot:
+        """The currently-active ROI slot. Always returns a slot --
+        if the list is empty (shouldn't happen under normal flow) one
+        is created. If the index is out of range it clamps to 0."""
+        if not self.cluster_rois:
+            self.cluster_rois.append(ROISlot())
+            self.cluster_active_index = 0
+            return self.cluster_rois[0]
+        if not (0 <= self.cluster_active_index < len(self.cluster_rois)):
+            self.cluster_active_index = 0
+        return self.cluster_rois[self.cluster_active_index]
+
+    @property
+    def cluster_shape(self) -> str:
+        return self.active_roi.shape
+
+    @cluster_shape.setter
+    def cluster_shape(self, value: str) -> None:
+        self.active_roi.shape = value
+
+    @property
+    def cluster_center_x_mm(self) -> float:
+        return self.active_roi.center_x_mm
+
+    @cluster_center_x_mm.setter
+    def cluster_center_x_mm(self, value: float) -> None:
+        self.active_roi.center_x_mm = float(value)
+
+    @property
+    def cluster_center_y_mm(self) -> float:
+        return self.active_roi.center_y_mm
+
+    @cluster_center_y_mm.setter
+    def cluster_center_y_mm(self, value: float) -> None:
+        self.active_roi.center_y_mm = float(value)
+
+    @property
+    def cluster_center_z_mm(self) -> float:
+        return self.active_roi.center_z_mm
+
+    @cluster_center_z_mm.setter
+    def cluster_center_z_mm(self, value: float) -> None:
+        self.active_roi.center_z_mm = float(value)
+
+    @property
+    def cluster_box_half_x_mm(self) -> float:
+        return self.active_roi.box_half_x_mm
+
+    @cluster_box_half_x_mm.setter
+    def cluster_box_half_x_mm(self, value: float) -> None:
+        self.active_roi.box_half_x_mm = float(value)
+
+    @property
+    def cluster_box_half_y_mm(self) -> float:
+        return self.active_roi.box_half_y_mm
+
+    @cluster_box_half_y_mm.setter
+    def cluster_box_half_y_mm(self, value: float) -> None:
+        self.active_roi.box_half_y_mm = float(value)
+
+    @property
+    def cluster_box_half_z_mm(self) -> float:
+        return self.active_roi.box_half_z_mm
+
+    @cluster_box_half_z_mm.setter
+    def cluster_box_half_z_mm(self, value: float) -> None:
+        self.active_roi.box_half_z_mm = float(value)
+
+    @property
+    def cluster_atlas_label(self) -> Optional[str]:
+        return self.active_roi.atlas_label
+
+    @cluster_atlas_label.setter
+    def cluster_atlas_label(self, value: Optional[str]) -> None:
+        self.active_roi.atlas_label = value
+
+    @property
+    def library_roi_radius_m(self) -> float:
+        """Sphere radius in meters (legacy unit). The per-ROI storage
+        is in mm to match the spatial-layer convention -- the meter
+        view is kept for back-compat with pre-PR-#55 panel code and
+        tests that compute ``radius_m * 1000`` at the boundary."""
+        return self.active_roi.radius_mm / 1000.0
+
+    @library_roi_radius_m.setter
+    def library_roi_radius_m(self, value: float) -> None:
+        self.active_roi.radius_mm = float(value) * 1000.0
+
+    @property
+    def library_roi_painted(self) -> Set[str]:
+        """Painted-key set for the active ROI. Returned by reference so
+        callers that do ``state.library_roi_painted.add(...)`` or
+        ``.clear()`` mutate the active slot's set directly -- matches
+        the pre-PR-#55 contract where this attribute *was* a mutable
+        set on AppState."""
+        return self.active_roi.painted
+
+    @library_roi_painted.setter
+    def library_roi_painted(self, value: Set[str]) -> None:
+        self.active_roi.painted = set(value)
+
+    # ------------------------------------------------------------------
+    # PR #55: ROI list manipulation helpers.
+    # ------------------------------------------------------------------
+
+    def add_roi(self) -> ROISlot:
+        """Append a fresh ROI to ``cluster_rois`` and make it active.
+
+        The new ROI inherits no state from the previous active slot --
+        it starts at the dataclass defaults. Auto-names it
+        "ROI <n>" where n is the new length of the list.
+
+        Returns the new slot so callers can stamp additional state
+        onto it before publishing the change.
+        """
+        name = f"ROI {len(self.cluster_rois) + 1}"
+        slot = ROISlot(name=name)
+        self.cluster_rois.append(slot)
+        self.cluster_active_index = len(self.cluster_rois) - 1
+        return slot
+
+    def set_active_roi(self, index: int) -> None:
+        """Switch the active ROI index. No-op if out of range."""
+        if 0 <= index < len(self.cluster_rois):
+            self.cluster_active_index = index
+
+    def clear_active_roi(self) -> None:
+        """Reset the active ROI to default geometry (CLEAR ROI button).
+
+        If there are 2+ ROIs, removes the active slot and advances the
+        active index to the previous slot (or 0 if we removed slot 0).
+        If there's exactly one ROI, resets its fields to defaults
+        rather than removing it -- the proxy properties always need
+        at least one slot to point at, and "clear" on a fresh project
+        shouldn't disappear the list entirely.
+        """
+        if len(self.cluster_rois) <= 1:
+            self.cluster_rois[0] = ROISlot()
+            self.cluster_active_index = 0
+            return
+        del self.cluster_rois[self.cluster_active_index]
+        self.cluster_active_index = max(0, self.cluster_active_index - 1)
+        # Renumber default names so the list stays in "ROI 1 ... ROI N"
+        # order. Custom-named slots (once renaming lands) would be
+        # detected by checking against the auto-name pattern; for now
+        # every name is auto so a simple re-stamp is correct.
+        for i, slot in enumerate(self.cluster_rois):
+            slot.name = f"ROI {i + 1}"
 
     def subscribe(self, event: str, callback: EventCallback) -> None:
         """Register ``callback`` to be called on ``publish(event, ...)``.
@@ -374,16 +588,10 @@ class AppState:
         self.library_show_brain = True
         self.library_show_scalp = True
         self.library_oxygenation = "both"
-        self.library_roi_radius_m = 0.02
-        self.library_roi_painted.clear()
-        self.cluster_shape = "sphere"
-        self.cluster_center_x_mm = 0.0
-        self.cluster_center_y_mm = 0.0
-        self.cluster_center_z_mm = 0.0
-        self.cluster_box_half_x_mm = 20.0
-        self.cluster_box_half_y_mm = 20.0
-        self.cluster_box_half_z_mm = 20.0
-        self.cluster_atlas_label = None
+        # PR #55: per-ROI cluster state lives in ``cluster_rois``;
+        # reset to the default-single-slot list.
+        self.cluster_rois = _default_rois()
+        self.cluster_active_index = 0
         self.cluster_roi_active = False
         self.cluster_atlas_alignment_affine = None
         self.cluster_atlas_offset_x_mm = 0.0

--- a/src/hrfunc/gui/workspace_io.py
+++ b/src/hrfunc/gui/workspace_io.py
@@ -26,9 +26,16 @@ import os
 import re
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, Iterable, Optional
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
 
 logger = logging.getLogger(__name__)
+
+# Schema version for the montage.json file. Bump when the wrapper or
+# per-ROI block changes shape in a way readers need to detect. ROIs
+# inside the list keep the per-ROI single-file schema that pre-PR-#55
+# audit scripts already understand (anchor / location / hrf_mean /
+# context.roi_*), so most consumers can skim past the wrapper.
+MONTAGE_SCHEMA_VERSION = "1.3"
 
 
 def workspace_dir() -> Path:
@@ -63,60 +70,31 @@ def _safe_filename_fragment(name: str) -> str:
     return sanitized.strip("._") or "untitled"
 
 
-def save_roi_average(
+def build_roi_entry(
     *,
     roi_keys: Iterable[str],
     hrf_mean: Any,
     hrf_std: Any,
     sfreq: float,
-    # Anchor is optional in PR #49 to support free-floating shape ROIs.
-    # When a click-anchor IS set, its location / oxygenation / context
-    # ride into the saved JSON so the file matches the v1.2 schema and
-    # can still be re-loaded into ``hrfunc.tree``. When the anchor is
-    # None, the ROI's shape centre stands in as the saved location and
-    # the saved oxygenation comes from ``oxygenation_filter``.
     anchor: Optional[Dict[str, Any]] = None,
-    # Spatial-layer Shape describing the ROI extent. Defaults to None
-    # to keep the v1.2 anchor + radius_m call sites compatible.
     shape: Optional[Any] = None,
-    # Pre-PR-#49 legacy field. When the new ``shape`` is provided this
-    # is ignored for geometry but still recorded in the JSON as the
-    # ``roi_radius_m`` context key (v1.2 audit scripts read it).
     radius_m: Optional[float] = None,
     library_filter: Optional[Dict[str, Any]] = None,
-    # Oxygenation that the membership computation filtered on (True for
-    # HbO, False for HbR, None for mixed). Used to set the saved
-    # ``oxygenation`` field when there's no anchor.
     oxygenation_filter: Optional[bool] = None,
-    workspace: Optional[Path] = None,
-) -> Path:
-    """Save an ROI-averaged HRF to the workspace folder.
+    name: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Build the per-ROI block of a montage.json file.
 
-    The output JSON extends the standard HRF entry schema (so it can
-    be re-loaded into ``hrfunc.tree`` if desired) with ROI provenance
-    fields so a researcher can audit what went into the average:
+    Pure -- no I/O, no clocks except for the ``saved_at`` timestamp
+    that's stamped at construction time. Same content as the pre-PR-#55
+    single-file ``roi_*.json`` payload (anchor / location / hrf_mean /
+    context.roi_*), plus an optional ``name`` field for the per-ROI
+    display label in the multi-ROI list.
 
-    - ``hrf_mean`` / ``hrf_std`` -- the averaged trace + per-sample std
-    - ``sfreq`` -- sampling rate
-    - ``oxygenation`` -- anchor's oxygenation when present; otherwise
-      the explicit ``oxygenation_filter``; falls back to ``None``
-      when neither is available.
-    - ``location`` -- anchor's location when present; otherwise the
-      shape's centre (converted from MNI mm into MNE-meter coords so
-      the saved JSON round-trips back into ``hrfunc.tree`` without
-      unit fixups).
-    - ``context`` -- extended with ROI metadata: anchor key (or
-      ``None`` for free-floating), shape descriptor, member keys,
-      library filter that was active.
-
-    File name: ``roi_<anchor_or_shape_key>_<YYYYMMDDTHHMMSSZ>.json``,
-    placed in the workspace folder. Returns the absolute Path.
-
-    Module-level so tests can call it without the GUI.
+    Extracted from ``save_roi_average`` so ``save_montage`` can build
+    each ROI's block via the same path. Keeping it pure also lets
+    tests inspect the entry shape without exercising disk I/O.
     """
-    if workspace is None:
-        workspace = workspace_dir()
-
     import numpy as np
 
     mean_list = np.asarray(hrf_mean).tolist()
@@ -238,7 +216,7 @@ def save_roi_average(
     ):
         context_extra["roi_radius_m"] = float(shape.radius_mm) / 1000.0
 
-    payload: Dict[str, Any] = {
+    entry: Dict[str, Any] = {
         "hrf_mean": mean_list,
         "hrf_std": std_list,
         "sfreq": float(sfreq),
@@ -249,23 +227,184 @@ def save_roi_average(
             **context_extra,
         },
     }
+    if name:
+        entry["name"] = name
+    return entry
+
+
+def _entry_filename_fragment(entry: Dict[str, Any]) -> str:
+    """Pick a recognisable filename fragment for a single ROI entry.
+
+    Preference order matches the pre-PR-#55 ``save_roi_average``
+    convention: anchor key first, then a ``freefloat_<shape>`` stand-
+    in derived from the shape descriptor, then ``freefloat_unknown``.
+    """
+    anchor_key = entry.get("context", {}).get("roi_anchor_key")
+    if anchor_key:
+        return _safe_filename_fragment(anchor_key)
+    shape_desc = entry.get("context", {}).get("roi_shape") or {}
+    shape_type = shape_desc.get("type") if isinstance(shape_desc, dict) else None
+    if shape_type:
+        return _safe_filename_fragment(f"freefloat_{shape_type}")
+    return "freefloat_unknown"
+
+
+def _build_alignment_block(
+    alignment_offset_mm: Optional[Tuple[float, float, float]],
+    alignment_affine: Optional[Any],
+) -> Dict[str, Any]:
+    """Build the wrapper's ``alignment`` block.
+
+    Alignment is a property of the HRF library's coord frame, not of
+    any individual ROI (locked decision 2026-05-14 -- see the
+    v1-3-spatial-viz-compartmentalization memory). The wrapper carries
+    it once for the whole montage.
+
+    ``offset_mm`` is always present (zeros when unset) so readers
+    don't have to special-case its absence. ``affine`` is null when
+    the user hasn't loaded one.
+    """
+    import numpy as np
+
+    offset = alignment_offset_mm or (0.0, 0.0, 0.0)
+    if alignment_affine is None:
+        affine_block: Optional[List[List[float]]] = None
+    else:
+        affine_block = np.asarray(alignment_affine, dtype=np.float64).tolist()
+    return {
+        "offset_mm": [float(v) for v in offset],
+        "affine": affine_block,
+    }
+
+
+def save_montage(
+    *,
+    rois: Sequence[Dict[str, Any]],
+    alignment_offset_mm: Optional[Tuple[float, float, float]] = None,
+    alignment_affine: Optional[Any] = None,
+    workspace: Optional[Path] = None,
+) -> Path:
+    """Write a multi-ROI montage to the workspace as a single JSON.
+
+    Schema:
+
+    .. code-block:: json
+
+        {
+          "version": "1.3",
+          "alignment": {
+            "offset_mm": [dx, dy, dz],
+            "affine": [[...], ...] | null
+          },
+          "rois": [<per-ROI entry>, ...]
+        }
+
+    Each per-ROI entry is the pre-PR-#55 single-file payload (anchor
+    metadata + ROI provenance under ``context.roi_*``). Build entries
+    with :func:`build_roi_entry`. Caller is responsible for excluding
+    ROIs that don't average (the canonical guard is
+    ``compute_roi_average() is None``).
+
+    Filename: ``montage_<descriptor>_<YYYYMMDDTHHMMSSZ>.json``. The
+    descriptor is the first ROI's anchor key (or shape stand-in) so
+    single-ROI montages keep the recognisable filename shape of the
+    legacy single-file save; multi-ROI montages get the first ROI's
+    fragment plus a ``_plus<N-1>`` suffix.
+    """
+    if not rois:
+        raise ValueError("save_montage requires at least one ROI entry")
+
+    if workspace is None:
+        workspace = workspace_dir()
+
+    payload: Dict[str, Any] = {
+        "version": MONTAGE_SCHEMA_VERSION,
+        "alignment": _build_alignment_block(
+            alignment_offset_mm, alignment_affine
+        ),
+        "rois": list(rois),
+    }
 
     timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
-    # Filename fragment: anchor key first (v1.2 convention), else a
-    # shape-derived stand-in so free-floating saves still have a
-    # human-recognisable prefix.
-    if anchor_key:
-        fragment = _safe_filename_fragment(anchor_key)
-    elif shape_descriptor is not None:
-        fragment = _safe_filename_fragment(
-            f"freefloat_{shape_descriptor.get('type', 'shape')}"
-        )
-    else:
-        fragment = "freefloat_unknown"
-    out_path = workspace / f"roi_{fragment}_{timestamp}.json"
+    head_fragment = _entry_filename_fragment(rois[0])
+    if len(rois) > 1:
+        head_fragment = f"{head_fragment}_plus{len(rois) - 1}"
+    out_path = workspace / f"montage_{head_fragment}_{timestamp}.json"
 
     with open(out_path, "w", encoding="utf-8") as fh:
         json.dump(payload, fh, indent=2)
 
-    logger.info("Saved ROI average to %s", out_path)
+    logger.info("Saved montage (%d ROIs) to %s", len(rois), out_path)
     return out_path
+
+
+def save_roi_average(
+    *,
+    roi_keys: Iterable[str],
+    hrf_mean: Any,
+    hrf_std: Any,
+    sfreq: float,
+    # Anchor is optional in PR #49 to support free-floating shape ROIs.
+    # When a click-anchor IS set, its location / oxygenation / context
+    # ride into the saved JSON so the file matches the v1.2 schema and
+    # can still be re-loaded into ``hrfunc.tree``. When the anchor is
+    # None, the ROI's shape centre stands in as the saved location and
+    # the saved oxygenation comes from ``oxygenation_filter``.
+    anchor: Optional[Dict[str, Any]] = None,
+    # Spatial-layer Shape describing the ROI extent. Defaults to None
+    # to keep the v1.2 anchor + radius_m call sites compatible.
+    shape: Optional[Any] = None,
+    # Pre-PR-#49 legacy field. When the new ``shape`` is provided this
+    # is ignored for geometry but still recorded in the JSON as the
+    # ``roi_radius_m`` context key (v1.2 audit scripts read it).
+    radius_m: Optional[float] = None,
+    library_filter: Optional[Dict[str, Any]] = None,
+    # Oxygenation that the membership computation filtered on (True for
+    # HbO, False for HbR, None for mixed). Used to set the saved
+    # ``oxygenation`` field when there's no anchor.
+    oxygenation_filter: Optional[bool] = None,
+    name: Optional[str] = None,
+    # PR #55: alignment is now a wrapper-level property of the
+    # montage, not of any single ROI. ``save_roi_average`` accepts it
+    # for callers that want to write a single-ROI montage with the
+    # alignment already known; defaults to identity / zeros so existing
+    # callers keep producing alignment=None / zero-offset montages.
+    alignment_offset_mm: Optional[Tuple[float, float, float]] = None,
+    alignment_affine: Optional[Any] = None,
+    workspace: Optional[Path] = None,
+) -> Path:
+    """Save a single-ROI average to the workspace as a 1-ROI montage.
+
+    PR #55 unified the on-disk format: every save -- single ROI or
+    multi-ROI montage -- writes the same wrapper schema with a list
+    of ROI entries. ``save_roi_average`` builds a 1-entry list and
+    calls :func:`save_montage`. The pre-PR-#55 ``roi_<key>_<ts>.json``
+    filename is replaced by ``montage_<key>_<ts>.json`` (same
+    descriptive fragment, new prefix) and the trace data moves under
+    ``rois[0]`` instead of sitting at the top level.
+
+    Use this when you have a single ROI's averaged trace already
+    computed (e.g. the legacy single-save flow). Use
+    :func:`save_montage` directly when you have multiple pre-built
+    ROI entries to write to one file (the multi-ROI list flow).
+
+    Module-level so tests can call it without the GUI.
+    """
+    entry = build_roi_entry(
+        roi_keys=roi_keys,
+        hrf_mean=hrf_mean,
+        hrf_std=hrf_std,
+        sfreq=sfreq,
+        anchor=anchor,
+        shape=shape,
+        radius_m=radius_m,
+        library_filter=library_filter,
+        oxygenation_filter=oxygenation_filter,
+        name=name,
+    )
+    return save_montage(
+        rois=[entry],
+        alignment_offset_mm=alignment_offset_mm,
+        alignment_affine=alignment_affine,
+        workspace=workspace,
+    )

--- a/tests/test_gui_foundation.py
+++ b/tests/test_gui_foundation.py
@@ -216,6 +216,175 @@ class TestAppStateReset:
         assert len(s.raw_cache) == 0
 
 
+class TestClusterMultiROI:
+    """PR #55 introduced per-ROI state via ``cluster_rois: list[ROISlot]``.
+    The pre-existing ``cluster_*`` / ``library_roi_*`` field names now
+    proxy onto the active slot so existing panel bindings keep working.
+
+    These tests pin down the proxy semantics, list mutation helpers,
+    and reset behaviour.
+    """
+
+    def test_default_state_has_one_roi_slot(self):
+        from hrfunc.gui.state import AppState, ROISlot
+
+        s = AppState()
+        assert len(s.cluster_rois) == 1
+        assert s.cluster_active_index == 0
+        assert isinstance(s.cluster_rois[0], ROISlot)
+        # Default slot matches the pre-PR-#55 defaults so callers that
+        # never touch the multi-ROI helpers see the same starting state.
+        assert s.cluster_shape == "sphere"
+        assert s.cluster_center_x_mm == 0.0
+        assert s.cluster_box_half_x_mm == 20.0
+        assert s.library_roi_radius_m == 0.02
+        assert s.library_roi_painted == set()
+
+    def test_each_app_state_has_independent_roi_list(self):
+        """The list uses ``field(default_factory=...)`` so two AppStates
+        don't share the same list. Mirrors the raw_cache guarantee."""
+        from hrfunc.gui.state import AppState
+
+        a = AppState()
+        b = AppState()
+        assert a.cluster_rois is not b.cluster_rois
+        a.add_roi()
+        assert len(b.cluster_rois) == 1
+
+    def test_proxy_setter_writes_to_active_slot(self):
+        from hrfunc.gui.state import AppState
+
+        s = AppState()
+        s.cluster_center_x_mm = 12.5
+        s.cluster_shape = "atlas_region"
+        s.cluster_atlas_label = "Frontal Pole"
+        s.library_roi_radius_m = 0.03
+        s.library_roi_painted.add("hbo:s1_d1_hbo-temp")
+
+        slot = s.cluster_rois[0]
+        assert slot.center_x_mm == 12.5
+        assert slot.shape == "atlas_region"
+        assert slot.atlas_label == "Frontal Pole"
+        # Storage is in mm; the meters proxy converts at the boundary.
+        assert slot.radius_mm == 30.0
+        assert slot.painted == {"hbo:s1_d1_hbo-temp"}
+
+    def test_painted_set_returned_by_reference(self):
+        """Pre-PR-#55 panels did ``state.library_roi_painted.clear()``
+        and ``.add(...)`` -- the proxy must return the same set so those
+        mutations land on the active slot."""
+        from hrfunc.gui.state import AppState
+
+        s = AppState()
+        s.library_roi_painted.add("k1")
+        assert s.library_roi_painted is s.cluster_rois[0].painted
+        s.library_roi_painted.clear()
+        assert s.cluster_rois[0].painted == set()
+
+    def test_add_roi_appends_and_activates(self):
+        from hrfunc.gui.state import AppState
+
+        s = AppState()
+        s.cluster_center_x_mm = 5.0
+        slot2 = s.add_roi()
+
+        assert len(s.cluster_rois) == 2
+        assert s.cluster_active_index == 1
+        assert slot2.name == "ROI 2"
+        # New slot starts at defaults -- not inheriting from the prior.
+        assert slot2.center_x_mm == 0.0
+        # The prior slot is unaffected by writes through the proxy.
+        s.cluster_center_x_mm = -3.0
+        assert s.cluster_rois[0].center_x_mm == 5.0
+        assert s.cluster_rois[1].center_x_mm == -3.0
+
+    def test_set_active_roi_switches_proxy_view(self):
+        from hrfunc.gui.state import AppState
+
+        s = AppState()
+        s.cluster_center_x_mm = 1.0
+        s.add_roi()
+        s.cluster_center_x_mm = 2.0
+
+        s.set_active_roi(0)
+        assert s.cluster_center_x_mm == 1.0
+        s.set_active_roi(1)
+        assert s.cluster_center_x_mm == 2.0
+
+    def test_set_active_roi_ignores_out_of_range(self):
+        from hrfunc.gui.state import AppState
+
+        s = AppState()
+        s.set_active_roi(99)  # should be a no-op, not raise
+        assert s.cluster_active_index == 0
+        s.set_active_roi(-1)
+        assert s.cluster_active_index == 0
+
+    def test_clear_active_roi_resets_last_slot(self):
+        """With only one ROI in the list, CLEAR ROI resets it in place
+        rather than removing it -- the proxy properties need at least
+        one slot to point at."""
+        from hrfunc.gui.state import AppState
+
+        s = AppState()
+        s.cluster_shape = "atlas_region"
+        s.cluster_center_x_mm = 50.0
+        s.library_roi_painted.add("k1")
+
+        s.clear_active_roi()
+
+        assert len(s.cluster_rois) == 1
+        assert s.cluster_shape == "sphere"
+        assert s.cluster_center_x_mm == 0.0
+        assert s.library_roi_painted == set()
+
+    def test_clear_active_roi_drops_active_when_multiple(self):
+        from hrfunc.gui.state import AppState
+
+        s = AppState()
+        s.add_roi()
+        s.add_roi()
+        # 3 slots: ROI 1 / ROI 2 / ROI 3 (active is the last)
+        assert [r.name for r in s.cluster_rois] == ["ROI 1", "ROI 2", "ROI 3"]
+        assert s.cluster_active_index == 2
+
+        s.clear_active_roi()
+        # Drop the third -> 2 remaining, active falls back to index 1.
+        assert len(s.cluster_rois) == 2
+        assert s.cluster_active_index == 1
+        # Names re-stamped so the list stays "ROI 1 ... ROI N" in order.
+        assert [r.name for r in s.cluster_rois] == ["ROI 1", "ROI 2"]
+
+    def test_active_roi_recovers_from_out_of_range_index(self):
+        """Defensive: if external state lands the index out of range,
+        the property clamps to 0 rather than raising."""
+        from hrfunc.gui.state import AppState
+
+        s = AppState()
+        s.cluster_active_index = 99
+        slot = s.active_roi
+        assert slot is s.cluster_rois[0]
+        assert s.cluster_active_index == 0
+
+    def test_reset_returns_to_one_default_slot(self):
+        from hrfunc.gui.state import AppState
+
+        s = AppState()
+        s.add_roi()
+        s.add_roi()
+        s.cluster_shape = "atlas_region"
+        s.cluster_atlas_label = "Frontal Pole"
+        s.cluster_roi_active = True
+
+        s.reset()
+
+        assert len(s.cluster_rois) == 1
+        assert s.cluster_active_index == 0
+        assert s.cluster_shape == "sphere"
+        assert s.cluster_atlas_label is None
+        assert s.cluster_roi_active is False
+
+
 class TestSetBusy:
     """``set_busy`` toggles the flag and publishes ``busy_changed``.
 

--- a/tests/test_gui_workspace_io.py
+++ b/tests/test_gui_workspace_io.py
@@ -16,10 +16,29 @@ import pytest
 
 
 from hrfunc.gui.workspace_io import (
+    MONTAGE_SCHEMA_VERSION,
     _safe_filename_fragment,
+    build_roi_entry,
+    save_montage,
     save_roi_average,
     workspace_dir,
 )
+
+
+def _read_single_roi(out_path):
+    """Helper: open a montage.json and return ``payload["rois"][0]``.
+
+    PR #55 unified the on-disk format -- every save_roi_average call
+    now writes a 1-entry montage. Tests that pre-date the schema
+    change asserted the trace shape at the top level; this helper
+    centralises the ``payload["rois"][0]`` indirection so each call
+    site stays terse.
+    """
+    payload = json.loads(out_path.read_text())
+    assert payload["version"] == MONTAGE_SCHEMA_VERSION
+    assert "alignment" in payload
+    assert len(payload["rois"]) == 1
+    return payload, payload["rois"][0]
 
 
 # ---------------------------------------------------------------------------
@@ -129,8 +148,10 @@ class TestSaveRoiAverage:
             radius_m=0.0,
             workspace=tmp_path,
         )
-        # Sanitized anchor key + timestamp pattern
-        assert out.name.startswith("roi_")
+        # PR #55: filename prefix is "montage_" (every save writes the
+        # wrapper schema, even for a single-ROI montage). The anchor
+        # key still rides in the filename for discoverability.
+        assert out.name.startswith("montage_")
         assert "hbo_s1_d1_hbo-temp" in out.name
         # ISO basic format includes a 'T' separator
         assert "T" in out.name
@@ -148,13 +169,13 @@ class TestSaveRoiAverage:
             library_filter={"task": "flanker"},
             workspace=tmp_path,
         )
-        payload = json.loads(out.read_text())
-        assert payload["hrf_mean"] == [1.5, 2.5]
-        assert payload["hrf_std"] == [0.5, 0.5]
-        assert payload["sfreq"] == 7.8125
-        assert payload["oxygenation"] is True
-        assert payload["location"] == [0.01, 0.02, 0.03]
-        ctx = payload["context"]
+        _, roi = _read_single_roi(out)
+        assert roi["hrf_mean"] == [1.5, 2.5]
+        assert roi["hrf_std"] == [0.5, 0.5]
+        assert roi["sfreq"] == 7.8125
+        assert roi["oxygenation"] is True
+        assert roi["location"] == [0.01, 0.02, 0.03]
+        ctx = roi["context"]
         # Anchor's original context preserved
         assert ctx["task"] == "flanker"
         assert ctx["doi"] == "doi/A"
@@ -179,9 +200,9 @@ class TestSaveRoiAverage:
             radius_m=0.02,
             workspace=tmp_path,
         )
-        payload = json.loads(out.read_text())
+        _, roi = _read_single_roi(out)
         # Floats decode to plain Python floats
-        assert all(isinstance(x, float) for x in payload["hrf_mean"])
+        assert all(isinstance(x, float) for x in roi["hrf_mean"])
 
     def test_member_keys_sorted_for_determinism(self, tmp_path):
         """Set iteration order is unpredictable; ROI member keys in the
@@ -195,8 +216,8 @@ class TestSaveRoiAverage:
             radius_m=0.0,
             workspace=tmp_path,
         )
-        payload = json.loads(out.read_text())
-        assert payload["context"]["roi_member_keys"] == ["hbo:a", "hbo:m", "hbo:z"]
+        _, roi = _read_single_roi(out)
+        assert roi["context"]["roi_member_keys"] == ["hbo:a", "hbo:m", "hbo:z"]
 
 
 # ---------------------------------------------------------------------------
@@ -229,8 +250,8 @@ class TestSaveRoiAverageWithShape:
             shape=box,
             workspace=tmp_path,
         )
-        payload = json.loads(out.read_text())
-        shape_desc = payload["context"]["roi_shape"]
+        _, roi = _read_single_roi(out)
+        shape_desc = roi["context"]["roi_shape"]
         assert shape_desc["type"] == "box"
         assert shape_desc["center_mm"] == [10.0, 20.0, 30.0]
         assert shape_desc["half_extents_mm"] == [5.0, 5.0, 5.0]
@@ -247,13 +268,13 @@ class TestSaveRoiAverageWithShape:
             shape=sphere,
             workspace=tmp_path,
         )
-        payload = json.loads(out.read_text())
-        shape_desc = payload["context"]["roi_shape"]
+        _, roi = _read_single_roi(out)
+        shape_desc = roi["context"]["roi_shape"]
         assert shape_desc["type"] == "sphere"
         assert shape_desc["center_mm"] == [0.0, 0.0, 0.0]
         assert shape_desc["radius_mm"] == 15.0
         # The legacy roi_radius_m key still appears for back-compat audit scripts.
-        assert payload["context"]["roi_radius_m"] == 0.015
+        assert roi["context"]["roi_radius_m"] == 0.015
 
     def test_free_floating_no_anchor_uses_shape_centre_as_location(self, tmp_path):
         """When the user has not clicked an anchor, the shape centre
@@ -271,11 +292,11 @@ class TestSaveRoiAverageWithShape:
             oxygenation_filter=True,
             workspace=tmp_path,
         )
-        payload = json.loads(out.read_text())
+        _, roi = _read_single_roi(out)
         # Centre 15 mm -> 0.015 m (matching v1.2 meter convention).
-        assert payload["location"] == [0.015, 0.025, 0.035]
+        assert roi["location"] == [0.015, 0.025, 0.035]
         # Oxygenation falls back to the explicit filter when no anchor.
-        assert payload["oxygenation"] is True
+        assert roi["oxygenation"] is True
 
     def test_free_floating_filename_prefix(self, tmp_path):
         """Free-floating saves should still have a recognisable filename
@@ -302,8 +323,8 @@ class TestSaveRoiAverageWithShape:
             shape=sphere,
             workspace=tmp_path,
         )
-        payload = json.loads(out.read_text())
-        assert payload["context"]["roi_anchor_key"] is None
+        _, roi = _read_single_roi(out)
+        assert roi["context"]["roi_anchor_key"] is None
 
     def test_oxygenation_filter_none_means_mixed(self, tmp_path):
         """When neither anchor nor oxygenation_filter is set, the saved
@@ -318,8 +339,8 @@ class TestSaveRoiAverageWithShape:
             shape=box,
             workspace=tmp_path,
         )
-        payload = json.loads(out.read_text())
-        assert payload["oxygenation"] is None
+        _, roi = _read_single_roi(out)
+        assert roi["oxygenation"] is None
 
     def test_legacy_radius_m_only_call_still_works(self, tmp_path):
         """v1.2 call sites that pass ``radius_m`` without ``shape`` keep
@@ -334,9 +355,9 @@ class TestSaveRoiAverageWithShape:
             radius_m=0.02,
             workspace=tmp_path,
         )
-        payload = json.loads(out.read_text())
-        assert payload["context"]["roi_radius_m"] == 0.02
-        shape_desc = payload["context"]["roi_shape"]
+        _, roi = _read_single_roi(out)
+        assert roi["context"]["roi_radius_m"] == 0.02
+        shape_desc = roi["context"]["roi_shape"]
         assert shape_desc["type"] == "sphere"
         assert shape_desc["radius_m"] == 0.02
 
@@ -367,7 +388,8 @@ class TestSaveRoiAverageBoxOrientation:
             shape=box,
             workspace=tmp_path,
         )
-        shape_desc = json.loads(out.read_text())["context"]["roi_shape"]
+        _, roi = _read_single_roi(out)
+        shape_desc = roi["context"]["roi_shape"]
         assert shape_desc["type"] == "box"
         # Pre-PR-#52 readers parse this descriptor unchanged.
         assert "orientation_mm" not in shape_desc
@@ -394,7 +416,8 @@ class TestSaveRoiAverageBoxOrientation:
             shape=box,
             workspace=tmp_path,
         )
-        shape_desc = json.loads(out.read_text())["context"]["roi_shape"]
+        _, roi = _read_single_roi(out)
+        shape_desc = roi["context"]["roi_shape"]
         assert shape_desc["type"] == "box"
         assert "orientation_mm" in shape_desc
         # The matrix round-trips through json as a list-of-lists.
@@ -428,7 +451,8 @@ class TestSaveRoiAverageBoxOrientation:
             oxygenation_filter=True,
             workspace=tmp_path,
         )
-        shape_desc = json.loads(out.read_text())["context"]["roi_shape"]
+        _, roi = _read_single_roi(out)
+        shape_desc = roi["context"]["roi_shape"]
         assert shape_desc["type"] == "atlas_region"
         assert shape_desc["atlas"] == "synthetic-test"
         assert shape_desc["region_name"] == "Region_A"
@@ -462,10 +486,10 @@ class TestSaveRoiAverageBoxOrientation:
             shape=region,
             workspace=tmp_path,
         )
-        payload = json.loads(out.read_text())
+        _, roi = _read_single_roi(out)
         # Region_A occupies voxels (i, 1, k) for i, k in [0, 3) -- the
         # centroid is voxel (1, 1, 1) -> MNI (10, 10, 10) mm = 0.01 m.
-        loc = payload["location"]
+        loc = roi["location"]
         assert loc == pytest.approx([0.01, 0.01, 0.01], abs=1e-9)
 
     def test_atlas_region_filename_prefix(self, tmp_path):
@@ -519,7 +543,8 @@ class TestSaveRoiAverageBoxOrientation:
             shape=original,
             workspace=tmp_path,
         )
-        shape_desc = json.loads(out.read_text())["context"]["roi_shape"]
+        _, roi = _read_single_roi(out)
+        shape_desc = roi["context"]["roi_shape"]
         rebuilt = Box(
             center_mm=tuple(shape_desc["center_mm"]),
             half_extents_mm=tuple(shape_desc["half_extents_mm"]),
@@ -531,3 +556,174 @@ class TestSaveRoiAverageBoxOrientation:
             original.contains_batch(points),
             rebuilt.contains_batch(points),
         )
+
+
+# ---------------------------------------------------------------------------
+# PR #55: save_montage wrapper schema + multi-ROI lists
+# ---------------------------------------------------------------------------
+
+
+class TestSaveMontage:
+    """The new save_montage writer is the canonical on-disk path; the
+    legacy save_roi_average delegates to it. These tests pin down the
+    wrapper schema, alignment block, filename convention, and
+    multi-ROI behaviour."""
+
+    def _entry(self, name="ROI 1"):
+        return build_roi_entry(
+            roi_keys={"hbo:a"},
+            hrf_mean=[1.0, 2.0],
+            hrf_std=[0.1, 0.2],
+            sfreq=10.0,
+            anchor={
+                "_key": "hbo:s1_d1_hbo-temp",
+                "oxygenation": True,
+                "location": [0.01, 0.02, 0.03],
+                "context": {"task": "flanker"},
+            },
+            radius_m=0.02,
+            name=name,
+        )
+
+    def test_wrapper_keys_and_version(self, tmp_path):
+        out = save_montage(
+            rois=[self._entry()],
+            workspace=tmp_path,
+        )
+        payload = json.loads(out.read_text())
+        assert payload["version"] == MONTAGE_SCHEMA_VERSION
+        assert set(payload) == {"version", "alignment", "rois"}
+
+    def test_alignment_block_defaults(self, tmp_path):
+        """Without explicit alignment, the wrapper still records the
+        block -- offset_mm zeros, affine null. Readers don't have to
+        special-case the absence."""
+        out = save_montage(
+            rois=[self._entry()],
+            workspace=tmp_path,
+        )
+        payload = json.loads(out.read_text())
+        assert payload["alignment"]["offset_mm"] == [0.0, 0.0, 0.0]
+        assert payload["alignment"]["affine"] is None
+
+    def test_alignment_offset_round_trips(self, tmp_path):
+        out = save_montage(
+            rois=[self._entry()],
+            alignment_offset_mm=(1.5, -2.5, 3.0),
+            workspace=tmp_path,
+        )
+        payload = json.loads(out.read_text())
+        assert payload["alignment"]["offset_mm"] == [1.5, -2.5, 3.0]
+
+    def test_alignment_affine_round_trips(self, tmp_path):
+        import numpy as np
+        affine = np.array(
+            [[1.0, 0.0, 0.0, 5.0],
+             [0.0, 1.0, 0.0, -3.0],
+             [0.0, 0.0, 1.0, 1.5],
+             [0.0, 0.0, 0.0, 1.0]],
+            dtype=np.float64,
+        )
+        out = save_montage(
+            rois=[self._entry()],
+            alignment_affine=affine,
+            workspace=tmp_path,
+        )
+        payload = json.loads(out.read_text())
+        recovered = np.asarray(payload["alignment"]["affine"])
+        np.testing.assert_allclose(recovered, affine)
+
+    def test_rois_list_preserves_order_and_names(self, tmp_path):
+        out = save_montage(
+            rois=[self._entry("Pole"), self._entry("OFC"), self._entry("PFC")],
+            workspace=tmp_path,
+        )
+        payload = json.loads(out.read_text())
+        assert [r["name"] for r in payload["rois"]] == ["Pole", "OFC", "PFC"]
+
+    def test_filename_single_roi_has_no_plus_suffix(self, tmp_path):
+        """Single-ROI montages keep the descriptive fragment-only
+        filename so they read like the pre-PR-#55 single-file saves."""
+        out = save_montage(
+            rois=[self._entry()],
+            workspace=tmp_path,
+        )
+        assert out.name.startswith("montage_hbo_s1_d1_hbo-temp_")
+        assert "_plus" not in out.name
+
+    def test_filename_multi_roi_has_plus_suffix(self, tmp_path):
+        """Multi-ROI montages tag the filename with how many extra
+        ROIs ride alongside the first, so a directory listing surfaces
+        the size without having to open the file."""
+        out = save_montage(
+            rois=[self._entry(), self._entry("ROI 2"), self._entry("ROI 3")],
+            workspace=tmp_path,
+        )
+        assert "_plus2_" in out.name
+
+    def test_empty_rois_list_rejected(self, tmp_path):
+        with pytest.raises(ValueError):
+            save_montage(rois=[], workspace=tmp_path)
+
+    def test_save_roi_average_writes_single_entry_montage(self, tmp_path):
+        """The legacy single-save shim writes the same wrapper schema
+        with a 1-entry rois list -- one writer, one reader."""
+        out = save_roi_average(
+            anchor={
+                "_key": "hbo:k",
+                "oxygenation": True,
+                "location": [0.0, 0.0, 0.0],
+                "context": {},
+            },
+            roi_keys={"hbo:a"},
+            hrf_mean=[1.0],
+            hrf_std=[0.1],
+            sfreq=10.0,
+            radius_m=0.02,
+            workspace=tmp_path,
+        )
+        payload = json.loads(out.read_text())
+        assert payload["version"] == MONTAGE_SCHEMA_VERSION
+        assert len(payload["rois"]) == 1
+        assert payload["rois"][0]["hrf_mean"] == [1.0]
+
+
+class TestBuildRoiEntry:
+    """build_roi_entry is the pure helper that turns ROI inputs into
+    one block of the rois list. Same content as the legacy single-save
+    payload, with an optional ``name`` field for the multi-ROI list
+    display label."""
+
+    def test_name_omitted_when_not_provided(self):
+        entry = build_roi_entry(
+            roi_keys={"a"},
+            hrf_mean=[1.0],
+            hrf_std=[0.1],
+            sfreq=10.0,
+        )
+        assert "name" not in entry
+
+    def test_name_included_when_provided(self):
+        entry = build_roi_entry(
+            roi_keys={"a"},
+            hrf_mean=[1.0],
+            hrf_std=[0.1],
+            sfreq=10.0,
+            name="Visual Cortex",
+        )
+        assert entry["name"] == "Visual Cortex"
+
+    def test_pure_no_io(self, tmp_path):
+        """Build the entry without touching the filesystem so callers
+        can build a montage in memory before deciding where to save."""
+        # No workspace argument -- this must not create files anywhere.
+        entry = build_roi_entry(
+            roi_keys={"a"},
+            hrf_mean=[1.0],
+            hrf_std=[0.1],
+            sfreq=10.0,
+        )
+        assert isinstance(entry, dict)
+        # tmp_path should remain empty since build_roi_entry doesn't
+        # write -- we only pass it to confirm no surprise mkdir/write.
+        assert list(tmp_path.iterdir()) == []


### PR DESCRIPTION
## Summary

Adds per-ROI state + UI to the Cluster sub-tab so users can build a *montage* of multiple ROIs in one session, and unifies the on-disk format so every save — single or multi-ROI — writes the same wrapper schema.

Foundation for **PR #56** (ADD MONTAGE per-channel auto-create) and **PR #57** (free-draw lasso). Locked architectural decision from the planning round: atlas alignment stays GLOBAL per scan/dataset, not per-ROI (alignment is a property of the HRF library's coord frame, not of any individual ROI).

## UI changes

- New **ADD ROI** button + scrollable ROI list in the Cluster sub-tab, above the shape controls. Each row shows shape glyph + name + (sphere centre / box dims / atlas region) summary.
- Active ROI highlighted (amber background + arrow indicator); the shape / centre / radius / atlas widgets below operate on whichever slot is active. Click a row to switch.
- Each row has a trash icon. With 2+ slots it removes that slot and walks active back by one; with a single slot it falls back to in-place reset (the proxy properties always need one slot to point at).
- **CLEAR ROI** button label changes to "Delete active ROI" when 2+ slots exist, so the destructive action reads honestly.
- **Save** button label: "Save ROI average" with one slot, "Save montage (N ROIs)" with more.

## State changes

- New `ROISlot` dataclass: name, shape, centre, box halves, sphere radius (mm), atlas label, painted set, anchor.
- `AppState.cluster_rois: list[ROISlot]` (always ≥ 1 entry).
- `AppState.cluster_active_index: int`.
- `AppState.add_roi()` / `set_active_roi()` / `clear_active_roi()` / `active_roi` helpers.
- The pre-existing scalar names (`cluster_shape`, `cluster_center_*_mm`, `cluster_box_half_*_mm`, `cluster_atlas_label`, `library_roi_radius_m`, `library_roi_painted`) are now `@property` proxies onto the active slot — panel bindings and pre-PR-#55 tests keep working unchanged. Full removal of the indirection is v2.0 cleanup.
- Atlas alignment (`cluster_atlas_offset_*_mm` + `cluster_atlas_alignment_affine`) stays **GLOBAL** per scan/dataset (locked 2026-05-14).
- `reset()` returns `cluster_rois` to a single default slot.

## Save flow / on-disk schema

- New `save_montage(rois=[...], alignment_offset_mm=..., alignment_affine=...)` writes the unified wrapper:

```json
{
  "version": "1.3",
  "alignment": {
    "offset_mm": [dx, dy, dz],
    "affine": [[...], ...] | null
  },
  "rois": [<per-ROI entry>, ...]
}
```

- Per-ROI entries are produced by the new pure helper `build_roi_entry` — same content as the pre-PR-#55 single-file payload (`hrf_mean` / `location` / `context.roi_*`), plus an optional `name` for the multi-ROI list display label.
- Legacy `save_roi_average` becomes a thin shim that builds a 1-entry list and calls `save_montage` — **one writer, one reader**, on-disk format consistent regardless of how many ROIs.
- Filename prefix: `montage_<anchor-or-shape>_<timestamp>.json`. Multi-ROI saves tag the descriptor with `_plusN` so a directory listing surfaces the size without opening the file.
- The panel's save handler walks every slot in `cluster_rois`, builds an entry for each that passes the averaging gate (≥ 2 subject estimates), and writes the whole list in one `save_montage` call. Slots that fail the gate are skipped; the notify spells out how many were saved and which were skipped so nothing is silently lost.

## Tests

- **+12 multi-ROI state tests** in `test_gui_foundation.py`: default list shape, instance isolation, proxy read/write, painted-set reference semantics, `add_roi` / `set_active_roi` / `clear_active_roi` semantics (single-slot reset + multi-slot drop + name re-stamping), out-of-range index recovery, reset.
- **+12 wrapper-schema tests** in `test_gui_workspace_io.py`: version + key shape, alignment defaults / offset / affine round-trip, ROI list order + names, filename single vs multi (`_plusN` suffix), empty-list rejection, `save_roi_average` → 1-entry montage shim, `build_roi_entry` purity + optional name.
- **Updated 15 pre-existing single-ROI tests** to read trace data via `payload["rois"][0]` (the `_read_single_roi` helper centralises the indirection).

Full suite: **856 passed**, 0 failures, 0 errors.

## Test plan

- [ ] Open the Cluster sub-tab; confirm the default single ROI list row renders + is auto-active.
- [ ] Click **Add ROI**; confirm a second row appears, becomes active (amber highlight), and the centre / shape / radius widgets reset to defaults.
- [ ] Switch active by clicking the first row; widgets snap back to its values.
- [ ] Click an HRF in the viz; confirm the active ROI's centre seeds + anchor + detail pane all update.
- [ ] Set up two ROIs with different shapes (sphere + atlas region), enable ROI mode, click **Save montage (2 ROIs)**; open the resulting `montage_<...>_plus1_<ts>.json` and verify wrapper schema + both ROIs present.
- [ ] Save with one ROI; verify filename has no `_plus` suffix and `rois` has one entry.
- [ ] Delete the active row when 2+ exist; confirm active falls back one and names re-stamp `ROI 1`, `ROI 2`, …
- [ ] Delete the last remaining ROI; confirm it resets in place rather than disappearing.
- [ ] **Round-trip**: pick one ROI's saved trace via `hrfunc.tree.load_hrfs` to confirm the per-ROI block still satisfies the v1.2 schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)