### PR TITLE
feat: ADD MONTAGE per-channel auto-create in Cluster sub-tab

### DIFF
--- a/src/hrfunc/gui/components/dataset_picker.py
+++ b/src/hrfunc/gui/components/dataset_picker.py
@@ -84,6 +84,58 @@ async def pick_folder() -> Optional[Path]:
     return Path(paths[0])
 
 
+async def pick_file(
+    *,
+    file_types: Optional[List[str]] = None,
+) -> Optional[Path]:
+    """Open the native OS file-open picker.
+
+    PR #57 helper for the Cluster sub-tab's "Add montage" button, which
+    needs to read an MNE-compatible fNIRS file (SNIRF / NIRX header /
+    FIF) and turn its channels into per-channel sphere ROIs. Mirrors
+    :func:`pick_folder` exactly -- same pywebview-≥5 async return-type
+    handling and same picklable-enum shim -- but uses the OPEN dialog
+    kind so the user picks a file instead of a folder.
+
+    ``file_types``: optional list of pywebview file-type filter strings
+    (e.g. ``["SNIRF files (*.snirf)", "All files (*.*)"]``). Ignored on
+    non-native launches.
+
+    Returns the chosen Path, or None on cancel / non-native launch.
+    """
+    try:
+        import webview
+    except ImportError:
+        ui.notify("pywebview not installed", type="negative")
+        return None
+
+    window = getattr(app, "native", None) and app.native.main_window
+    if window is None:
+        ui.notify(
+            "File picker requires native window mode. "
+            "Launch with `hrfunc` (not via browser).",
+            type="warning",
+        )
+        return None
+
+    import inspect
+
+    from .._webview_compat import dialog_kind
+    kwargs = {}
+    if file_types:
+        kwargs["file_types"] = tuple(file_types)
+    result = window.create_file_dialog(
+        dialog_kind(webview, "OPEN"), **kwargs
+    )
+    if inspect.isawaitable(result):
+        paths = await result
+    else:
+        paths = result
+    if not paths:
+        return None
+    return Path(paths[0])
+
+
 def list_recent_manifests(limit: int = 10) -> List[Manifest]:
     """Enumerate cached manifests from the XDG cache directory.
 

--- a/src/hrfunc/gui/components/hrtree_panel.py
+++ b/src/hrfunc/gui/components/hrtree_panel.py
@@ -1099,6 +1099,73 @@ def _render_roi_list(state: AppState, body_refreshable) -> None:
         state.add_roi()
         _refresh_all()
 
+    async def _on_add_montage() -> None:
+        """Open a file picker, load the chosen scan, and emit one
+        sphere ROI per unique channel location (PR #57)."""
+        from .dataset_picker import pick_file
+
+        path = await pick_file(
+            file_types=[
+                "fNIRS files (*.snirf *.fif *.hdr)",
+                "All files (*.*)",
+            ],
+        )
+        if path is None:
+            return  # user cancelled
+
+        # Load on the event loop -- MNE's read_raw_* is sync. For
+        # typical fNIRS files this is fast enough (< 1 s); larger
+        # recordings could move to a worker thread later. The path
+        # discrimination mirrors RawCache._load_from_path so the
+        # picker accepts the same set of formats the project loader
+        # already understands.
+        try:
+            raw = _load_raw_for_montage(path)
+        except Exception as exc:  # noqa: BLE001 -- surface, don't crash
+            logger.exception(
+                "add montage: failed to load %s: %s", path, exc
+            )
+            ui.notify(
+                f"Couldn't read {path.name}: {type(exc).__name__}: {exc}",
+                type="negative",
+            )
+            return
+
+        # Filter to the current haemoglobin so a HbO-only library
+        # doesn't get HbR channel locations slipped in. ``None`` /
+        # ``"both"`` means "emit a sphere per source-detector pair
+        # regardless" (the dedupe still collapses the HbO/HbR pair
+        # at the same xyz).
+        if state.library_oxygenation == "hbo":
+            oxy_filter: Optional[bool] = True
+        elif state.library_oxygenation == "hbr":
+            oxy_filter = False
+        else:
+            oxy_filter = None
+
+        new_slots = rois_from_raw(raw, library_oxygenation=oxy_filter)
+        if not new_slots:
+            ui.notify(
+                f"No channels with locations found in {path.name}.",
+                type="warning",
+            )
+            return
+
+        # Append all new slots and activate the last one so the user
+        # can immediately tweak it. ``add_roi`` is the per-slot
+        # appender; we bypass it here for the bulk append to avoid
+        # publishing "filter_changed" N times in a row, then publish
+        # once at the end via _refresh_all.
+        for slot in new_slots:
+            state.cluster_rois.append(slot)
+        state.cluster_active_index = len(state.cluster_rois) - 1
+        ui.notify(
+            f"Added {len(new_slots)} ROI"
+            f"{'s' if len(new_slots) != 1 else ''} from {path.name}.",
+            type="positive",
+        )
+        _refresh_all()
+
     def _on_select(index: int) -> None:
         # Re-seed the library_selected_hrf from the slot's anchor so
         # the detail pane + viz click-state mirror what the active
@@ -1127,9 +1194,23 @@ def _render_roi_list(state: AppState, body_refreshable) -> None:
         ui.label("ROIs").classes(
             "text-xs uppercase opacity-60 tracking-wide"
         )
-        ui.button(
-            "Add ROI", icon="add", on_click=_on_add,
-        ).props("flat dense color=primary")
+        with ui.row().classes("items-center gap-1"):
+            ui.button(
+                "Add ROI", icon="add", on_click=_on_add,
+            ).props("flat dense color=primary")
+            # PR #57: auto-create one sphere ROI per unique channel
+            # location from an MNE-compatible file. The handler is
+            # async (file picker + load), so it must be passed as a
+            # coroutine-function -- a sync lambda wrapping the async
+            # call would silently no-op (see gui-async-gotchas memory).
+            ui.button(
+                "Add montage",
+                icon="device_hub",
+                on_click=_on_add_montage,
+            ).props("flat dense").tooltip(
+                "Pick a SNIRF / NIRX / FIF file and add a sphere ROI "
+                "per unique channel location."
+            )
 
     # Cap the visible height so a long montage scrolls inside the
     # sub-tab instead of stretching the page. ~8 rows at ~32px each.
@@ -1179,6 +1260,173 @@ def _render_roi_list(state: AppState, body_refreshable) -> None:
                     icon="delete_outline",
                     on_click=lambda _e=None, idx=i: _on_delete(idx),
                 ).props("flat dense round size=sm").classes("opacity-60")
+
+
+# ---------------------------------------------------------------------------
+# PR #57: ADD MONTAGE per-channel auto-create
+# ---------------------------------------------------------------------------
+
+
+# Default sphere radius (mm) for ROIs auto-created from channel locations.
+# A typical fNIRS source-detector pair covers roughly 1.5 cm of cortex
+# directly beneath the midpoint, so 15 mm is a sensible default. Mirrors
+# the ``ROISlot.radius_mm`` default of 20 mm tuned slightly tighter
+# because per-channel montages tend to be denser than free-floating ROIs.
+DEFAULT_PER_CHANNEL_RADIUS_MM = 15.0
+
+
+def _strip_oxygenation_suffix(ch_name: str) -> str:
+    """Drop the trailing hbo/hbr/760/850 suffix from a channel name.
+
+    Per-channel ROIs are scientifically one-per-source-detector pair
+    (HbO and HbR for the same pair share the optode location), so the
+    ROI name should not duplicate the haemoglobin distinction. Returns
+    the input unchanged when no recognised suffix is found.
+
+    Pattern: matches ``"... hbo"``, ``"... hbr"``, ``"... 760"``,
+    ``"... 850"`` with any whitespace / underscore / hyphen separator.
+    """
+    import re
+
+    # Trailing oxygenation/wavelength + optional separator before it.
+    m = re.match(
+        r"^(.*?)[\s_\-]*(hbo|hbr|760|850|760nm|850nm)$",
+        ch_name.strip(),
+        flags=re.IGNORECASE,
+    )
+    return m.group(1).rstrip(" _-") if m else ch_name.strip()
+
+
+def _load_raw_for_montage(path: "Path"):
+    """Read a NIRX / SNIRF / FIF file just for its info structure.
+
+    PR #57 helper for the "Add montage" picker -- we only need the
+    channel locations, so we preload data (cheap for SNIRF / NIRX
+    headers, single fseek for FIF). The loader matches the format
+    detection used by ``hrfunc.io.raw_cache._load_from_path`` so the
+    picker accepts whatever the project loader does.
+
+    Raises whatever MNE raises on a malformed file; the GUI click
+    handler catches and surfaces.
+    """
+    import mne
+
+    suffix = path.suffix.lower()
+    if suffix == ".snirf":
+        return mne.io.read_raw_snirf(str(path), verbose="ERROR")
+    if suffix == ".fif":
+        return mne.io.read_raw_fif(str(path), verbose="ERROR")
+    # NIRX directories use ``*.hdr`` as the recognisable file in the
+    # tree; if the user pointed at a .hdr, MNE wants the parent dir.
+    if suffix == ".hdr":
+        return mne.io.read_raw_nirx(str(path.parent), verbose="ERROR")
+    # Folder fallback (user picked the NIRX directory directly).
+    return mne.io.read_raw_nirx(str(path), verbose="ERROR")
+
+
+def rois_from_raw(
+    raw,
+    *,
+    radius_mm: float = DEFAULT_PER_CHANNEL_RADIUS_MM,
+    library_oxygenation: Optional[bool] = None,
+) -> "List":
+    """Build a list of ROISlots, one per unique channel location.
+
+    PR #57 helper. fNIRS channels naturally come in HbO / HbR pairs
+    (or 760 nm / 850 nm pairs in OD space) that share the same
+    source-detector midpoint. The naive "one ROI per channel"
+    interpretation would emit duplicate spheres at every location;
+    the right behaviour is "one ROI per unique optode location" so
+    a 40-channel cap turns into 20 ROIs.
+
+    Deduplication is on the rounded mm location to absorb floating-
+    point jitter in the MNE info structure (channels often co-locate
+    within microns rather than exactly).
+
+    Channel names are normalised to drop the oxygenation suffix
+    ("S1_D1 hbo" → "S1_D1") so each ROI carries the source-detector
+    label, not a hemoglobin distinction.
+
+    ``library_oxygenation``: when set (True for HbO, False for HbR),
+    only channels matching that hemoglobin contribute to the ROI
+    locations. None means "use both" and lets HbO+HbR contribute the
+    same midpoint (still deduped).
+
+    Returns a fresh list of ROISlots; the caller is responsible for
+    appending them to ``state.cluster_rois``. Each slot is named
+    "Montage: <ch_name>" so the multi-ROI list visually groups them.
+
+    Module-level + pure so the per-channel logic is testable without
+    the GUI.
+    """
+    from ..state import ROISlot
+    from ...spatial.coords import meters_to_mm
+
+    slots: List = []
+    seen_keys: Dict[Tuple[int, int, int], int] = {}
+
+    # MNE locations are in meters; we round to a small mm grid for the
+    # dedupe key so micron-scale jitter between HbO/HbR doesn't make
+    # them look like different channels. 0.1 mm is finer than any
+    # realistic fNIRS placement uncertainty.
+    DEDUPE_GRID_MM = 0.1
+
+    for channel in raw.info["chs"]:
+        ch_name = channel.get("ch_name") or ""
+        if not ch_name or ch_name.lower() == "canonical":
+            continue
+
+        # Honour the haemoglobin filter when set.
+        if library_oxygenation is not None:
+            from ..._utils import _is_oxygenated
+
+            try:
+                is_hbo = _is_oxygenated(ch_name.lower())
+            except (ValueError, LookupError):
+                # Channel without an oxygenation suffix -- include it
+                # only when the caller hasn't asked to filter.
+                continue
+            if is_hbo != library_oxygenation:
+                continue
+
+        loc = channel.get("loc")
+        if loc is None or len(loc) < 3:
+            continue
+        x_m, y_m, z_m = float(loc[0]), float(loc[1]), float(loc[2])
+        # MNE channels without a recorded location report (0, 0, 0).
+        # Emitting a sphere at the origin would be meaningless and
+        # pile every such channel on top of each other.
+        if x_m == 0.0 and y_m == 0.0 and z_m == 0.0:
+            continue
+
+        x_mm = meters_to_mm(x_m)
+        y_mm = meters_to_mm(y_m)
+        z_mm = meters_to_mm(z_m)
+
+        dedupe_key = (
+            int(round(x_mm / DEDUPE_GRID_MM)),
+            int(round(y_mm / DEDUPE_GRID_MM)),
+            int(round(z_mm / DEDUPE_GRID_MM)),
+        )
+        if dedupe_key in seen_keys:
+            # Same location as a previous channel (most commonly its
+            # HbO or HbR partner). Skip so we emit one sphere per
+            # source-detector pair.
+            continue
+        seen_keys[dedupe_key] = len(slots)
+
+        display = _strip_oxygenation_suffix(ch_name)
+        slots.append(
+            ROISlot(
+                name=f"Montage: {display}",
+                shape=SHAPE_SPHERE,
+                center_x_mm=x_mm,
+                center_y_mm=y_mm,
+                center_z_mm=z_mm,
+                radius_mm=float(radius_mm),
+            )
+        )
+    return slots
 
 
 def _describe_slot(slot) -> str:

--- a/tests/test_gui_library.py
+++ b/tests/test_gui_library.py
@@ -1376,3 +1376,189 @@ async def test_filter_count_annotates_missing_location_hrfs(user: User):
     await user.open("/_test_hrtree")
     # Both HRFs match the (empty) filter; one lacks location.
     await user.should_see("not visualizable: missing location")
+
+
+# ---------------------------------------------------------------------------
+# PR #57: ADD MONTAGE per-channel auto-create
+# ---------------------------------------------------------------------------
+
+
+def _make_fake_raw_with_locations(channel_specs):
+    """Build a synthetic MNE Raw with per-channel locations stamped on.
+
+    ``channel_specs`` is a list of ``(ch_name, (x_m, y_m, z_m))`` tuples.
+    The constructor uses ``mne.create_info`` (which produces zero
+    locations by default) and then writes the requested coords into
+    each channel's ``info['chs'][i]['loc'][:3]``. Other ``loc`` indices
+    (the optode positions for fNIRS, normal vectors for MEG) are left
+    at zero -- ``rois_from_raw`` only reads the first three slots.
+    """
+    import mne
+    import numpy as np
+
+    ch_names = [name for name, _ in channel_specs]
+    info = mne.create_info(
+        ch_names=ch_names, sfreq=10.0, ch_types="misc"
+    )
+    raw = mne.io.RawArray(
+        np.zeros((len(ch_names), 5)), info, verbose="ERROR"
+    )
+    for i, (_, loc) in enumerate(channel_specs):
+        raw.info["chs"][i]["loc"][:3] = list(loc)
+    return raw
+
+
+class TestStripOxygenationSuffix:
+    """``_strip_oxygenation_suffix`` normalises a per-channel name into
+    its source-detector label for the auto-created montage ROIs."""
+
+    def test_drops_trailing_hbo(self):
+        assert library._strip_oxygenation_suffix("S1_D1 hbo") == "S1_D1"
+
+    def test_drops_trailing_hbr(self):
+        assert library._strip_oxygenation_suffix("S1_D1 hbr") == "S1_D1"
+
+    def test_drops_trailing_wavelength(self):
+        assert library._strip_oxygenation_suffix("S2_D3 760") == "S2_D3"
+        assert library._strip_oxygenation_suffix("S2_D3 850nm") == "S2_D3"
+
+    def test_underscore_separator(self):
+        assert library._strip_oxygenation_suffix("S1_D1_hbo") == "S1_D1"
+
+    def test_hyphen_separator(self):
+        assert library._strip_oxygenation_suffix("S1_D1-hbo") == "S1_D1"
+
+    def test_case_insensitive(self):
+        assert library._strip_oxygenation_suffix("S1_D1 HBO") == "S1_D1"
+
+    def test_no_suffix_passes_through(self):
+        assert library._strip_oxygenation_suffix("canonical") == "canonical"
+
+
+class TestRoisFromRaw:
+    """``rois_from_raw`` is the pure helper behind the Cluster sub-tab's
+    "Add montage" button -- it iterates an MNE Raw's channel locations
+    and emits one sphere ROI per unique source-detector pair."""
+
+    def test_basic_dedupe_of_hbo_hbr_pair(self):
+        """HbO + HbR for the same source-detector midpoint collapse
+        to a single sphere -- not two duplicate spheres at the same
+        xyz."""
+        raw = _make_fake_raw_with_locations([
+            ("S1_D1 hbo", (0.01, 0.02, 0.03)),
+            ("S1_D1 hbr", (0.01, 0.02, 0.03)),
+            ("S2_D1 hbo", (0.04, 0.02, 0.03)),
+            ("S2_D1 hbr", (0.04, 0.02, 0.03)),
+        ])
+        slots = library.rois_from_raw(raw)
+        assert len(slots) == 2
+        assert {s.name for s in slots} == {
+            "Montage: S1_D1", "Montage: S2_D1",
+        }
+
+    def test_meters_converted_to_mm(self):
+        raw = _make_fake_raw_with_locations([
+            ("S1_D1 hbo", (0.025, -0.030, 0.012)),
+        ])
+        slots = library.rois_from_raw(raw)
+        assert len(slots) == 1
+        slot = slots[0]
+        # 0.025 m -> 25.0 mm, etc.
+        assert slot.center_x_mm == 25.0
+        assert slot.center_y_mm == -30.0
+        assert slot.center_z_mm == 12.0
+
+    def test_default_radius_is_per_channel_constant(self):
+        raw = _make_fake_raw_with_locations([
+            ("S1_D1 hbo", (0.01, 0.02, 0.03)),
+        ])
+        slots = library.rois_from_raw(raw)
+        assert slots[0].radius_mm == library.DEFAULT_PER_CHANNEL_RADIUS_MM
+
+    def test_custom_radius_respected(self):
+        raw = _make_fake_raw_with_locations([
+            ("S1_D1 hbo", (0.01, 0.02, 0.03)),
+        ])
+        slots = library.rois_from_raw(raw, radius_mm=7.5)
+        assert slots[0].radius_mm == 7.5
+
+    def test_zero_location_channels_skipped(self):
+        """MNE channels without a recorded location report (0, 0, 0).
+        Emitting a sphere at the origin would be meaningless and pile
+        every such channel on top of each other -- skip them."""
+        raw = _make_fake_raw_with_locations([
+            ("S1_D1 hbo", (0.0, 0.0, 0.0)),
+            ("S2_D1 hbo", (0.04, 0.02, 0.03)),
+        ])
+        slots = library.rois_from_raw(raw)
+        assert len(slots) == 1
+        assert slots[0].name == "Montage: S2_D1"
+
+    def test_canonical_channel_skipped(self):
+        """The bundled library uses ``canonical`` as a sentinel
+        channel name; per-channel ROIs should not emit a sphere for
+        it (it has no real anatomical location)."""
+        raw = _make_fake_raw_with_locations([
+            ("canonical", (0.01, 0.02, 0.03)),
+            ("S1_D1 hbo", (0.04, 0.05, 0.06)),
+        ])
+        slots = library.rois_from_raw(raw)
+        assert [s.name for s in slots] == ["Montage: S1_D1"]
+
+    def test_oxygenation_filter_hbo_only(self):
+        """When the caller pins oxygenation to HbO, only HbO channels
+        contribute (used when the /library viz is in HbO-only mode
+        so the resulting montage matches the visible HRFs)."""
+        raw = _make_fake_raw_with_locations([
+            ("S1_D1 hbo", (0.01, 0.02, 0.03)),
+            ("S1_D1 hbr", (0.01, 0.02, 0.03)),
+            ("S2_D1 hbo", (0.04, 0.02, 0.03)),
+        ])
+        slots = library.rois_from_raw(raw, library_oxygenation=True)
+        assert {s.name for s in slots} == {
+            "Montage: S1_D1", "Montage: S2_D1",
+        }
+
+    def test_oxygenation_filter_hbr_only(self):
+        raw = _make_fake_raw_with_locations([
+            ("S1_D1 hbo", (0.01, 0.02, 0.03)),
+            ("S1_D1 hbr", (0.01, 0.02, 0.03)),
+            ("S2_D1 hbo", (0.04, 0.02, 0.03)),
+        ])
+        slots = library.rois_from_raw(raw, library_oxygenation=False)
+        # Only the s1_d1 hbr channel matches (s2_d1 has no hbr counterpart
+        # in this synthetic raw).
+        assert len(slots) == 1
+        assert slots[0].name == "Montage: S1_D1"
+
+    def test_micron_jitter_collapsed_by_dedupe(self):
+        """HbO and HbR sometimes report locations that differ by
+        microns due to MNE info-structure jitter. The dedupe key
+        rounds to 0.1 mm so the pair still collapses to one sphere."""
+        raw = _make_fake_raw_with_locations([
+            ("S1_D1 hbo", (0.0100001, 0.0200001, 0.0300001)),
+            ("S1_D1 hbr", (0.0100000, 0.0200000, 0.0300000)),
+        ])
+        slots = library.rois_from_raw(raw)
+        assert len(slots) == 1
+
+    def test_empty_raw_returns_empty_list(self):
+        """A Raw with channels but no locations (every channel at the
+        zero sentinel) produces no ROIs at all."""
+        raw = _make_fake_raw_with_locations([
+            ("S1_D1 hbo", (0.0, 0.0, 0.0)),
+            ("S1_D1 hbr", (0.0, 0.0, 0.0)),
+        ])
+        slots = library.rois_from_raw(raw)
+        assert slots == []
+
+    def test_all_slots_default_to_sphere(self):
+        """The "Add montage" feature only emits spheres (the natural
+        per-channel ROI shape). The user can switch a specific slot
+        to box / atlas mode afterwards if they want."""
+        raw = _make_fake_raw_with_locations([
+            ("S1_D1 hbo", (0.01, 0.02, 0.03)),
+            ("S2_D1 hbo", (0.04, 0.02, 0.03)),
+        ])
+        slots = library.rois_from_raw(raw)
+        assert all(s.shape == library.SHAPE_SPHERE for s in slots)


### PR DESCRIPTION
## Summary

Builds on PR #55's multi-ROI model. Adds an **Add montage** button beside Add ROI in the Cluster sub-tab — it opens a native file picker for a SNIRF / NIRX / FIF scan and emits one sphere ROI per unique channel location. The natural follow-on to multi-ROI: researchers can now reach the whole-cap analysis workflow ("ROI per optode") in two clicks.

## UI

- **Add montage** button (next to Add ROI) opens an OPEN file dialog, loads the picked file via `mne.io.read_raw_*`, and emits one `ROISlot` per source-detector pair.
- HbO and HbR for the same s_d pair are deduped (they share the optode xyz), so a 40-channel cap turns into ~20 ROIs.
- Names strip the oxygenation suffix: `"S1_D1 hbo"` → `"Montage: S1_D1"`.
- Each slot defaults to a 15 mm sphere (the new `DEFAULT_PER_CHANNEL_RADIUS_MM` — slightly tighter than the free-floating ROI default since per-channel montages are denser).
- The newly-appended slots are added in iteration order; the last one becomes active so the user can immediately tweak it.

## New helpers

- `dataset_picker.pick_file(file_types=...)` — OPEN-dialog mirror of `pick_folder`. Same pywebview-compat shim + awaitable-result handling.
- `hrtree_panel.rois_from_raw(raw, *, radius_mm, library_oxygenation)` — pure helper that turns an MNE Raw's channels into a list of `ROISlot`s. Skips `(0,0,0)` locations, skips the bundled-library `canonical` sentinel, dedupes on a 0.1 mm grid, converts meters → mm at the spatial-layer boundary.
- `hrtree_panel._strip_oxygenation_suffix(ch_name)` — drops trailing `hbo` / `hbr` / `760` / `850` so the ROI name is the s_d label.
- `hrtree_panel._load_raw_for_montage(path)` — thin file-type dispatch matching `raw_cache._load_from_path`.

## Tests

- +7 `TestStripOxygenationSuffix`
- +11 `TestRoisFromRaw` — dedupe, units, naming, zero-location skip, canonical skip, oxygenation filter, micron jitter, empty input, all-spheres invariant

Full suite: **890 passed** (was 872 after #56, +18 new), 0 failures.

## Test plan

- [ ] Click **Add montage** → confirm native file picker opens
- [ ] Pick a SNIRF file → confirm N ROIs appear in the list (where N = unique s_d pairs), each named `Montage: <s_d>`, each a sphere
- [ ] Pick a NIRX `.hdr` → confirm same behavior
- [ ] Cancel the picker → confirm no-op (no slots added, no toast)
- [ ] Pick a file MNE can't read → confirm error toast, no slots added
- [ ] Switch the /library viz to HbO-only, then Add montage → confirm only HbO-derived locations contribute
- [ ] Verify the auto-added ROIs work with the existing Save montage flow (output `montage.json` contains all N ROIs)

## Numbering note

This is the renumbered "PR #56 ADD MONTAGE per-channel" from the v1.3 plan. After PR #56 (bulk actions, originally planned as `#55a`) shifted the GitHub numbering by one, this PR lands as GitHub #57.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
