### PR TITLE
fix: pywebview file_types filter syntax + early validation

### DIFF
--- a/src/hrfunc/gui/components/dataset_picker.py
+++ b/src/hrfunc/gui/components/dataset_picker.py
@@ -123,6 +123,26 @@ async def pick_file(
     from .._webview_compat import dialog_kind
     kwargs = {}
     if file_types:
+        # pywebview validates each filter string against
+        # ``description (*.ext1;*.ext2)`` -- semicolon-separated, NOT
+        # space-separated. Catch the malformed shape here so callers
+        # see the failing string rather than a stack trace from the
+        # multiprocessing feeder thread (which is hard to spot
+        # without a launching terminal).
+        try:
+            from webview.util import parse_file_type
+            for ft in file_types:
+                parse_file_type(ft)
+        except Exception as exc:  # noqa: BLE001
+            logger.exception(
+                "pick_file: invalid file_types entry: %s", exc
+            )
+            ui.notify(
+                f"Invalid file filter -- contact the developer "
+                f"({type(exc).__name__}: {exc})",
+                type="negative",
+            )
+            return None
         kwargs["file_types"] = tuple(file_types)
     result = window.create_file_dialog(
         dialog_kind(webview, "OPEN"), **kwargs

--- a/src/hrfunc/gui/components/hrtree_panel.py
+++ b/src/hrfunc/gui/components/hrtree_panel.py
@@ -1104,9 +1104,13 @@ def _render_roi_list(state: AppState, body_refreshable) -> None:
         sphere ROI per unique channel location (PR #57)."""
         from .dataset_picker import pick_file
 
+        # pywebview's file_types syntax: extensions are joined by
+        # semicolons inside the parens. Space-separated extensions
+        # (the natural-looking form) fail pywebview's filter regex
+        # with "is not a valid file filter".
         path = await pick_file(
             file_types=[
-                "fNIRS files (*.snirf *.fif *.hdr)",
+                "fNIRS files (*.snirf;*.fif;*.hdr)",
                 "All files (*.*)",
             ],
         )

--- a/tests/test_gui_dataset_picker.py
+++ b/tests/test_gui_dataset_picker.py
@@ -88,6 +88,93 @@ class TestPickFolderShape:
         assert inspect.iscoroutinefunction(pick_folder)
 
 
+class TestPickFileShape:
+    """PR #57 added :func:`pick_file` as the OPEN-dialog mirror of
+    :func:`pick_folder`. Same async-coroutine + pywebview shim contract."""
+
+    def test_pick_file_is_async(self):
+        from hrfunc.gui.components.dataset_picker import pick_file
+        assert inspect.iscoroutinefunction(pick_file)
+
+    def test_pick_file_accepts_file_types_kwarg(self):
+        """The ``file_types`` kwarg is the way callers narrow the
+        picker. Regression guard against the kwarg being renamed /
+        removed by a refactor."""
+        import inspect as _inspect
+        from hrfunc.gui.components.dataset_picker import pick_file
+        sig = _inspect.signature(pick_file)
+        assert "file_types" in sig.parameters
+
+
+class TestPywebviewFilterFormat:
+    """pywebview's file_type filter syntax: ``description (*.ext1;*.ext2)``
+    -- semicolon-separated, NOT space-separated. PR #57 originally shipped
+    space-separated filters in hrtree_panel and pywebview's
+    parse_file_type raised ``"<filter> is not a valid file filter"``,
+    crashing the picker. These tests pin the filter format we pass in
+    the Add-montage flow so the bug can't slip back."""
+
+    def test_hrtree_panel_montage_filter_parses(self):
+        """The exact filter string the Add-montage button passes
+        must round-trip through pywebview's parser."""
+        webview = pytest.importorskip("webview")
+        from webview.util import parse_file_type
+
+        # Mirror the strings in hrtree_panel._on_add_montage. If those
+        # change, the strings here must change in lockstep -- the
+        # in-process parse is the contract.
+        for ft in (
+            "fNIRS files (*.snirf;*.fif;*.hdr)",
+            "All files (*.*)",
+        ):
+            description, exts = parse_file_type(ft)
+            assert description
+            assert "*." in exts
+
+    def test_pick_file_validates_bad_filter_early(self, monkeypatch):
+        """``pick_file`` should reject malformed filter strings in-
+        process (with a clear notify) rather than letting them blow
+        up inside the multiprocessing feeder thread, where the
+        traceback is invisible without a launching terminal."""
+        pytest.importorskip("webview")
+        import asyncio
+        from hrfunc.gui.components import dataset_picker
+
+        # Stand up just enough of app.native for the helper to think
+        # we're in native mode. The validation should fire BEFORE the
+        # window.create_file_dialog call, so we never need to mock
+        # that side.
+        class _FakeWindow:
+            def create_file_dialog(self, *args, **kwargs):
+                raise AssertionError(
+                    "create_file_dialog should not be reached when "
+                    "the filter is invalid"
+                )
+
+        class _FakeNative:
+            main_window = _FakeWindow()
+
+        # ``ui.notify`` needs an active NiceGUI slot context. Standalone
+        # asyncio.run() doesn't provide one, so capture the notify call
+        # via monkeypatch to keep the test deterministic + slot-free.
+        notifies: list = []
+        monkeypatch.setattr(
+            dataset_picker.ui, "notify",
+            lambda msg, **kwargs: notifies.append((msg, kwargs)),
+        )
+        monkeypatch.setattr(dataset_picker.app, "native", _FakeNative())
+        result = asyncio.run(
+            dataset_picker.pick_file(
+                file_types=["fNIRS files (*.snirf *.fif)"],  # spaces -- invalid
+            )
+        )
+        # On bad filter, pick_file returns None instead of crashing,
+        # and a single notify carries the failure message.
+        assert result is None
+        assert len(notifies) == 1
+        assert "Invalid file filter" in notifies[0][0]
+
+
 class TestOpenProjectPath:
     def test_open_project_path_is_async(self):
         from hrfunc.gui.components.dataset_picker import open_project_path


### PR DESCRIPTION
## Summary

Hotfix on top of PR #57. A user hit `ValueError: fNIRS files (*.snirf *.fif *.hdr) is not a valid file filter` clicking **Add montage**.

## Root cause

pywebview's `parse_file_type` requires extensions joined by `;` inside the filter parens, not spaces. Its regex:

```
^([\w ]+)\((\*(?:\.(?:\w+|\*))*(?:;\*(?:\.(?:\w+|\*))*)*)\)$
```

PR #57 shipped the natural-looking space-separated form which fails the regex. The failure surfaced via the multiprocessing feeder thread's stderr, so the click handler appeared to silently no-op from the user's view — only visible when launched from a terminal (same diagnostic shape as Gotcha #5 in the `gui-async-gotchas` memory).

## Fixes

- `hrtree_panel._on_add_montage` — switch the filter to `"fNIRS files (*.snirf;*.fif;*.hdr)"` (semicolons).
- `dataset_picker.pick_file` — validate each `file_types` entry via `webview.util.parse_file_type` BEFORE the cross-process `create_file_dialog` call. A bad filter now surfaces in-process via `ui.notify` + `logger.exception` and `pick_file` returns None, rather than letting the failure disappear into the multiprocessing feeder.

## Tests

- +2 `TestPickFileShape` (helper surface)
- +2 `TestPywebviewFilterFormat` — the exact filter strings the Add-montage button passes must round-trip through `parse_file_type`; `pick_file` rejects malformed filters in-process.

Full suite: **894 passed** (+4 from #57's 890), 0 failures.

## Test plan

- [ ] Click **Add montage** → native file dialog opens (no traceback, no silent no-op)
- [ ] Picker shows the "fNIRS files" + "All files" filters
- [ ] Pick a .snirf or .fif file → ROIs land in the Cluster list

🤖 Generated with [Claude Code](https://claude.com/claude-code)
