### PR TITLE
feat: per-ROI visibility toggle + drop pristine default on Add Montage

### DIFF
--- a/src/hrfunc/gui/components/hrtree_panel.py
+++ b/src/hrfunc/gui/components/hrtree_panel.py
@@ -256,6 +256,109 @@ def _alignment_for_shape(state: AppState, shape: Optional[Shape]) -> "Optional[n
     return _build_atlas_alignment_affine(state)
 
 
+def _build_shape_for_slot(state: AppState, slot) -> Optional[Shape]:
+    """Build the spatial-layer Shape for a specific ROI slot.
+
+    Sibling to :func:`_build_shape_unconditional` but reads from the
+    given slot rather than the active proxy. Used by the multi-ROI
+    visibility flow to render every visible slot's overlay
+    simultaneously on the viz.
+
+    Returns ``None`` for slots whose shape can't be built (atlas mode
+    without a region picked, or atlas mode when the bundled atlas
+    failed to load).
+    """
+    if slot.shape == SHAPE_BOX:
+        return Box(
+            center_mm=(slot.center_x_mm, slot.center_y_mm, slot.center_z_mm),
+            half_extents_mm=(
+                slot.box_half_x_mm, slot.box_half_y_mm, slot.box_half_z_mm,
+            ),
+        )
+    if slot.shape == SHAPE_ATLAS_REGION:
+        if not slot.atlas_label:
+            return None
+        atlas = load_harvard_oxford_cortical()
+        if atlas is None:
+            return None
+        try:
+            return AtlasRegion(atlas, slot.atlas_label)
+        except ValueError:
+            return None
+    if slot.shape == SHAPE_SPHERE:
+        return Sphere(
+            center_mm=(slot.center_x_mm, slot.center_y_mm, slot.center_z_mm),
+            radius_mm=float(slot.radius_mm),
+        )
+    return None
+
+
+def _visible_shapes(state: AppState) -> "List[Tuple[Any, Shape]]":
+    """Collect every visible ROI's (slot, Shape) pair (PR follow-up).
+
+    Returns an empty list when the cluster ROI master toggle is off,
+    or when no ROI is both visible and has a buildable shape. Each
+    visible slot whose shape can't be constructed (atlas mode without
+    a region selected, etc.) is silently dropped so the viz still
+    renders the others.
+
+    Used by both the viz pane (multi-overlay rendering) and the
+    Cluster sub-tab's ROI-status / save handler (iterate every
+    visible slot's membership).
+    """
+    if not state.cluster_roi_active:
+        return []
+    pairs: List = []
+    for slot in state.cluster_rois:
+        if not slot.visible:
+            continue
+        shape = _build_shape_for_slot(state, slot)
+        if shape is None:
+            continue
+        pairs.append((slot, shape))
+    return pairs
+
+
+def _visible_roi_keys(
+    state: AppState,
+    matched: Dict[str, Dict[str, Any]],
+) -> Tuple[set, "List[Tuple[Any, Shape]]"]:
+    """Compute the union of roi_keys across every visible ROI.
+
+    Returns ``(union_keys, visible_pairs)`` so callers can reuse the
+    ``[(slot, shape)]`` list for the multi-overlay viz without rebuilding.
+
+    Each pair's membership is computed with that pair's shape's
+    alignment affine (atlas mode needs it; sphere / box mode does
+    not). Per-slot oxygenation filter follows
+    :func:`_resolve_cluster_oxygenation` -- the slot's anchor wins
+    when present, otherwise the panel-level filter applies. Painted
+    keys come from the slot's own ``painted`` set.
+    """
+    pairs = _visible_shapes(state)
+    if not pairs:
+        return set(), []
+    union: set = set()
+    for slot, shape in pairs:
+        anchor = slot.anchor
+        if anchor is not None and anchor.get("oxygenation") is not None:
+            oxy: Optional[bool] = bool(anchor.get("oxygenation"))
+        elif state.library_oxygenation == "hbo":
+            oxy = True
+        elif state.library_oxygenation == "hbr":
+            oxy = False
+        else:
+            oxy = None
+        alignment = _alignment_for_shape(state, shape)
+        slot_keys = compute_roi_keys_by_shape(
+            matched, shape, slot.painted,
+            oxygenation_filter=oxy,
+            alignment_affine=alignment,
+        )
+        union |= set(slot_keys)
+    return union, pairs
+
+
 DataSource = Literal["library", "project", "both"]
 
 
@@ -805,6 +908,10 @@ def _render_cluster_subtab(state: AppState) -> None:
                 )
 
             # --- ROI status + Save button ----------------------------
+            # The status line reflects the ACTIVE ROI (which the user
+            # is currently editing in the right panel). It still
+            # serves as the "is the current shape valid?" check, but
+            # the save button reports across every visible slot.
             all_hrfs = gather_library_hrfs(state)
             matched = filter_by_oxygenation(
                 apply_filter(all_hrfs, state.library_filter),
@@ -824,15 +931,16 @@ def _render_cluster_subtab(state: AppState) -> None:
 
             if roi_result is None:
                 ui.label(
-                    "ROI has fewer than 2 averageable subject estimates "
-                    "in the current shape. Either widen the shape, paint "
-                    "more neighbours, or seed a different centre. (Note: "
-                    "HRFs without per-subject estimates are excluded.)"
+                    "Active ROI has fewer than 2 averageable subject "
+                    "estimates in the current shape. Either widen the "
+                    "shape, paint more neighbours, or seed a different "
+                    "centre. (Note: HRFs without per-subject estimates "
+                    "are excluded.)"
                 ).classes("text-xs opacity-60 italic")
             else:
                 _, _, n_subjects, n_channels = roi_result
                 ui.label(
-                    f"Current ROI: averaging {n_subjects} subject "
+                    f"Active ROI: averaging {n_subjects} subject "
                     f"estimates across {n_channels} channel"
                     f"{'s' if n_channels != 1 else ''}."
                 ).classes("text-xs opacity-70")
@@ -842,6 +950,19 @@ def _render_cluster_subtab(state: AppState) -> None:
                         f"{'s' if excluded_count != 1 else ''} excluded "
                         f"for lacking subject-level estimates.)"
                     ).classes("text-xs opacity-50 italic")
+
+            # Visibility summary for the multi-ROI case so the user
+            # knows the save button reflects fewer than the list shows.
+            visible_count = sum(
+                1 for s in state.cluster_rois if s.visible
+            )
+            hidden_count = len(state.cluster_rois) - visible_count
+            if hidden_count > 0:
+                ui.label(
+                    f"  ({hidden_count} ROI"
+                    f"{'s' if hidden_count != 1 else ''} hidden -- "
+                    f"will be excluded from save and viz)"
+                ).classes("text-xs opacity-50 italic")
 
             def _on_save_roi() -> None:
                 # PR #55: walk every slot in cluster_rois, build a
@@ -863,6 +984,12 @@ def _render_cluster_subtab(state: AppState) -> None:
                 original_anchor = state.library_selected_hrf
                 try:
                     for i, slot in enumerate(state.cluster_rois):
+                        # Hidden slots ride the layer-toggle semantics
+                        # -- excluded from BOTH viz AND save. They
+                        # don't even count as "skipped" in the failure
+                        # bucket since they were deliberately omitted.
+                        if not slot.visible:
+                            continue
                         # Make the slot active so the proxy-based
                         # helpers (_build_current_shape,
                         # _resolve_cluster_oxygenation, etc.) read its
@@ -1151,6 +1278,20 @@ def _render_roi_list(state: AppState, body_refreshable) -> None:
             )
             return
 
+        # When the only ROI in the list is the pristine default (sphere
+        # at MNI origin, never edited), drop it before appending the
+        # new montage slots. Without this, Add Montage on a fresh
+        # project leaves an orphan "ROI 1" at (0, 0, 0) cluttering the
+        # list above all the per-channel spheres. Conservative: a
+        # single field edit (centre move, radius tweak, anchor click,
+        # visibility toggle) keeps the slot in place.
+        dropped_default = (
+            len(state.cluster_rois) == 1
+            and state.cluster_rois[0].is_pristine_default()
+        )
+        if dropped_default:
+            state.cluster_rois.clear()
+
         # Append all new slots and activate the last one so the user
         # can immediately tweak it. ``add_roi`` is the per-slot
         # appender; we bypass it here for the bulk append to avoid
@@ -1159,11 +1300,13 @@ def _render_roi_list(state: AppState, body_refreshable) -> None:
         for slot in new_slots:
             state.cluster_rois.append(slot)
         state.cluster_active_index = len(state.cluster_rois) - 1
-        ui.notify(
+        toast = (
             f"Added {len(new_slots)} ROI"
-            f"{'s' if len(new_slots) != 1 else ''} from {path.name}.",
-            type="positive",
+            f"{'s' if len(new_slots) != 1 else ''} from {path.name}."
         )
+        if dropped_default:
+            toast += " Replaced the unused default ROI."
+        ui.notify(toast, type="positive")
         _refresh_all()
 
     def _on_select(index: int) -> None:
@@ -1189,6 +1332,18 @@ def _render_roi_list(state: AppState, body_refreshable) -> None:
         state.clear_active_roi()
         state.library_selected_hrf = state.active_roi.anchor
         _refresh_all()
+
+    def _on_toggle_visible(index: int) -> None:
+        """Flip a slot's ``visible`` flag (true layer-toggle).
+
+        Visibility gates BOTH viz rendering AND save inclusion. The
+        user can edit a hidden ROI's parameters without it appearing
+        on the viz -- active state is independent of visibility.
+        """
+        if 0 <= index < len(state.cluster_rois):
+            slot = state.cluster_rois[index]
+            slot.visible = not slot.visible
+            _refresh_all()
 
     with ui.row().classes("w-full items-center justify-between"):
         ui.label("ROIs").classes(
@@ -1227,6 +1382,7 @@ def _render_roi_list(state: AppState, body_refreshable) -> None:
                     if is_active
                     else "hover:bg-gray-100 dark:hover:bg-gray-800"
                 )
+                + ("" if slot.visible else " opacity-60")
             )
             with ui.row().classes(row_classes).on(
                 "click", lambda _e=None, idx=i: _on_select(idx)
@@ -1254,6 +1410,27 @@ def _render_roi_list(state: AppState, body_refreshable) -> None:
                     ui.label(_describe_slot(slot)).classes(
                         "text-xs opacity-60 font-mono"
                     )
+                # Visibility toggle (eye / eye-off). Mirrors a layers
+                # panel: clicking hides the ROI from the viz AND from
+                # the saved montage.json. Re-clicking restores it.
+                # The button click bubbles up to the row's _on_select
+                # handler -- intentional, since toggling a slot's
+                # visibility usually means the user is focused on
+                # that slot anyway.
+                vis_icon = (
+                    "visibility" if slot.visible else "visibility_off"
+                )
+                vis_opacity = "opacity-80" if slot.visible else "opacity-40"
+                ui.button(
+                    icon=vis_icon,
+                    on_click=lambda _e=None, idx=i: _on_toggle_visible(idx),
+                ).props("flat dense round size=sm").classes(
+                    vis_opacity
+                ).tooltip(
+                    "Hide from viz + save"
+                    if slot.visible
+                    else "Show on viz + include in save"
+                )
                 # Stop propagation on the delete click so it doesn't
                 # also fire the row's _on_select.
                 ui.button(
@@ -1597,21 +1774,22 @@ def _render_viz_pane(state: AppState) -> None:
         # Use a flex column so the plotly viz can claim flex-1 and the
         # overlay-toggles row sits underneath at content-height.
         with ui.column().classes("w-full h-full p-3 gap-2 flex flex-col"):
-            # Compute ROI keys now so the figure draws the highlight
-            # halo and the label can report the count.
-            shape = _build_current_shape(state)
-            oxy_filter = _resolve_cluster_oxygenation(state)
-            alignment = _alignment_for_shape(state, shape)
-            roi_keys = compute_roi_keys_by_shape(
-                matched,
-                shape,
-                state.library_roi_painted,
-                oxygenation_filter=oxy_filter,
-                alignment_affine=alignment,
+            # Compute the union of ROI keys across every VISIBLE ROI
+            # so the figure highlights everything currently in scope
+            # (multi-ROI visibility flow). Each visible slot's shape
+            # overlay also renders independently below.
+            union_roi_keys, visible_pairs = _visible_roi_keys(
+                state, matched,
             )
+            visible_shapes = [shape for _slot, shape in visible_pairs]
             roi_status = ""
-            if roi_keys:
-                roi_status = f"  •  ROI: {len(roi_keys)} highlighted"
+            if union_roi_keys:
+                n_visible = len(visible_pairs)
+                roi_status = (
+                    f"  •  ROI: {len(union_roi_keys)} highlighted "
+                    f"across {n_visible} visible ROI"
+                    f"{'s' if n_visible != 1 else ''}"
+                )
             ui.label(
                 f"{len(matched)} HRFs shown{roi_status}"
             ).classes("text-sm opacity-70")
@@ -1619,8 +1797,8 @@ def _render_viz_pane(state: AppState) -> None:
                 matched,
                 show_brain=state.library_show_brain,
                 show_scalp=state.library_show_scalp,
-                roi_keys=roi_keys,
-                roi_shape=shape,
+                roi_keys=union_roi_keys,
+                roi_shapes=visible_shapes,
             )
             plot = ui.plotly(fig).classes("w-full flex-1 min-h-0")
 
@@ -2089,6 +2267,7 @@ def build_plotly_figure(
     show_scalp: bool = False,
     roi_keys: Optional[Any] = None,
     roi_shape: Optional[Shape] = None,
+    roi_shapes: Optional[List[Shape]] = None,
 ):
     """Build the 3D scatter figure for the given HRF dict.
 
@@ -2182,17 +2361,27 @@ def build_plotly_figure(
     # the spatial-layer shape is in mm, so we down-convert before
     # building the trace -- the resulting Mesh3d is in meters and
     # overlays directly on the HRF scatter.
-    if roi_shape is not None:
-        if isinstance(roi_shape, Box):
+    #
+    # Two parameter forms: ``roi_shape`` (legacy single-shape, kept
+    # for back-compat) and ``roi_shapes`` (list, used by the multi-
+    # ROI visibility flow). Internally normalised into one list and
+    # rendered with one overlay trace per shape.
+    shape_list: List[Shape] = []
+    if roi_shapes:
+        shape_list.extend(roi_shapes)
+    elif roi_shape is not None:
+        shape_list.append(roi_shape)
+    for one_shape in shape_list:
+        if isinstance(one_shape, Box):
             box_m = Box(
-                center_mm=(c / 1000.0 for c in roi_shape.center_mm),
-                half_extents_mm=(h / 1000.0 for h in roi_shape.half_extents_mm),
+                center_mm=(c / 1000.0 for c in one_shape.center_mm),
+                half_extents_mm=(h / 1000.0 for h in one_shape.half_extents_mm),
             )
             traces.append(make_box_overlay_trace(box_m))
-        elif isinstance(roi_shape, Sphere):
+        elif isinstance(one_shape, Sphere):
             sphere_m = Sphere(
-                center_mm=(c / 1000.0 for c in roi_shape.center_mm),
-                radius_mm=roi_shape.radius_mm / 1000.0,
+                center_mm=(c / 1000.0 for c in one_shape.center_mm),
+                radius_mm=one_shape.radius_mm / 1000.0,
             )
             traces.append(make_sphere_overlay_trace(sphere_m))
 

--- a/src/hrfunc/gui/state.py
+++ b/src/hrfunc/gui/state.py
@@ -161,6 +161,50 @@ class ROISlot:
     # fields and the sphere's centre seed.
     anchor: Optional[Dict[str, Any]] = None
 
+    # PR #59 (originally planned as part of the v1.3 montage UX
+    # follow-up): per-ROI visibility toggle. A "layer" checkbox in the
+    # multi-ROI list -- when False, the ROI:
+    #   - is hidden from the viz (no shape overlay, no gold halo for
+    #     its member HRFs),
+    #   - is excluded from the saved montage.json,
+    #   - is excluded from the ROI-status summary in the Cluster
+    #     sub-tab.
+    # Active state (which slot's controls render in the right panel)
+    # is independent of visibility -- the user can edit a hidden ROI's
+    # parameters without it appearing on the viz. Defaults to True so
+    # newly-added ROIs (manual or via Add Montage) show up immediately.
+    visible: bool = True
+
+    def is_pristine_default(self) -> bool:
+        """True when this slot is identical to a fresh ``ROISlot()``.
+
+        Used by the Add-Montage flow to decide whether to drop the
+        list's single starting ROI (the one created by
+        ``_default_rois()``) before appending the per-channel slots.
+        Without this drop, a user clicking Add Montage on a fresh
+        project ends up with an orphan "ROI 1" at MNI (0, 0, 0)
+        cluttering the list above all the per-channel spheres.
+
+        The ``name`` field is ignored because a freshly-added ROI
+        could end up with any auto-name ("ROI 1", "ROI 5"). All
+        other fields must match the dataclass defaults.
+        """
+        default = ROISlot()
+        return (
+            self.shape == default.shape
+            and self.center_x_mm == default.center_x_mm
+            and self.center_y_mm == default.center_y_mm
+            and self.center_z_mm == default.center_z_mm
+            and self.box_half_x_mm == default.box_half_x_mm
+            and self.box_half_y_mm == default.box_half_y_mm
+            and self.box_half_z_mm == default.box_half_z_mm
+            and self.radius_mm == default.radius_mm
+            and self.atlas_label == default.atlas_label
+            and self.painted == default.painted
+            and self.anchor == default.anchor
+            and self.visible == default.visible
+        )
+
 
 def _default_rois() -> List[ROISlot]:
     """Factory for AppState.cluster_rois.

--- a/tests/test_gui_foundation.py
+++ b/tests/test_gui_foundation.py
@@ -389,6 +389,84 @@ class TestClusterMultiROI:
         assert s.cluster_roi_active is False
 
 
+class TestROISlotVisibility:
+    """Per-ROI visibility (layer-toggle) added after PR #57. A
+    visibility=False slot is excluded from BOTH the viz and the
+    saved montage, but its parameters stay editable in the right
+    panel -- "active" and "visible" are independent."""
+
+    def test_visible_defaults_true(self):
+        from hrfunc.gui.state import ROISlot
+        assert ROISlot().visible is True
+
+    def test_visible_independent_of_other_fields(self):
+        from hrfunc.gui.state import ROISlot
+
+        a = ROISlot()
+        b = ROISlot()
+        b.visible = False
+        # Toggling visibility doesn't perturb any other defaults.
+        assert b.shape == a.shape
+        assert b.center_x_mm == a.center_x_mm
+        assert b.radius_mm == a.radius_mm
+        assert b.painted == a.painted
+
+
+class TestROISlotIsPristineDefault:
+    """``is_pristine_default()`` drives the Add-Montage drop-default
+    behaviour: a freshly-spawned default ROI 1 is replaced by the
+    per-channel slots rather than left as an orphan above them."""
+
+    def test_fresh_slot_is_pristine(self):
+        from hrfunc.gui.state import ROISlot
+        assert ROISlot().is_pristine_default() is True
+
+    def test_name_difference_alone_still_pristine(self):
+        """Auto-naming (`ROI 1` vs `ROI 5`) shouldn't make a slot
+        look "edited" -- only the parameter fields define pristine."""
+        from hrfunc.gui.state import ROISlot
+        slot = ROISlot(name="ROI 5")
+        assert slot.is_pristine_default() is True
+
+    def test_edited_centre_breaks_pristine(self):
+        from hrfunc.gui.state import ROISlot
+        slot = ROISlot()
+        slot.center_x_mm = 5.0
+        assert slot.is_pristine_default() is False
+
+    def test_edited_shape_breaks_pristine(self):
+        from hrfunc.gui.state import ROISlot
+        slot = ROISlot()
+        slot.shape = "atlas_region"
+        assert slot.is_pristine_default() is False
+
+    def test_edited_radius_breaks_pristine(self):
+        from hrfunc.gui.state import ROISlot
+        slot = ROISlot()
+        slot.radius_mm = 10.0
+        assert slot.is_pristine_default() is False
+
+    def test_painted_addition_breaks_pristine(self):
+        from hrfunc.gui.state import ROISlot
+        slot = ROISlot()
+        slot.painted.add("hbo:s1_d1_hbo-temp")
+        assert slot.is_pristine_default() is False
+
+    def test_anchor_set_breaks_pristine(self):
+        from hrfunc.gui.state import ROISlot
+        slot = ROISlot()
+        slot.anchor = {"_key": "hbo:s1_d1_hbo-temp"}
+        assert slot.is_pristine_default() is False
+
+    def test_visibility_toggle_breaks_pristine(self):
+        """Visibility counts as an intentional edit -- a user who
+        hid the default ROI doesn't want it silently replaced."""
+        from hrfunc.gui.state import ROISlot
+        slot = ROISlot()
+        slot.visible = False
+        assert slot.is_pristine_default() is False
+
+
 class TestBulkIterateState:
     """PR #55a added ``checked_scan_paths`` (set) and ``bulk_progress``
     (tuple) to AppState so Preprocess / HRF / Activity action buttons

--- a/tests/test_gui_library.py
+++ b/tests/test_gui_library.py
@@ -1562,3 +1562,170 @@ class TestRoisFromRaw:
         ])
         slots = library.rois_from_raw(raw)
         assert all(s.shape == library.SHAPE_SPHERE for s in slots)
+
+
+# ---------------------------------------------------------------------------
+# PR follow-up: multi-ROI visibility flow
+# ---------------------------------------------------------------------------
+
+
+class TestBuildPlotlyFigureRoiShapes:
+    """``build_plotly_figure`` accepts both legacy ``roi_shape=`` (single)
+    and the new ``roi_shapes=`` (list) parameters. The multi-ROI
+    visibility flow uses the list form to render every visible slot's
+    overlay simultaneously."""
+
+    def test_single_shape_via_legacy_kwarg(self):
+        from hrfunc.spatial.shapes import Sphere
+
+        sphere = Sphere(center_mm=(0.0, 0.0, 0.0), radius_mm=15.0)
+        fig = library.build_plotly_figure(
+            {}, roi_shape=sphere,
+        )
+        # No HRFs to scatter, but one Mesh3d overlay should be present.
+        mesh_traces = [t for t in fig.data if type(t).__name__ == "Mesh3d"]
+        assert len(mesh_traces) == 1
+
+    def test_multiple_shapes_via_list_kwarg(self):
+        from hrfunc.spatial.shapes import Box, Sphere
+
+        s1 = Sphere(center_mm=(0.0, 0.0, 0.0), radius_mm=10.0)
+        s2 = Sphere(center_mm=(20.0, 0.0, 0.0), radius_mm=10.0)
+        b = Box(
+            center_mm=(0.0, 20.0, 0.0),
+            half_extents_mm=(5.0, 5.0, 5.0),
+        )
+        fig = library.build_plotly_figure(
+            {}, roi_shapes=[s1, s2, b],
+        )
+        mesh_traces = [t for t in fig.data if type(t).__name__ == "Mesh3d"]
+        assert len(mesh_traces) == 3
+
+    def test_roi_shapes_wins_when_both_provided(self):
+        """If both kwargs are passed, ``roi_shapes`` takes precedence
+        -- the single-shape form is back-compat shim only."""
+        from hrfunc.spatial.shapes import Sphere
+
+        single = Sphere(center_mm=(0.0, 0.0, 0.0), radius_mm=10.0)
+        multi = [
+            Sphere(center_mm=(10.0, 0.0, 0.0), radius_mm=5.0),
+            Sphere(center_mm=(20.0, 0.0, 0.0), radius_mm=5.0),
+        ]
+        fig = library.build_plotly_figure(
+            {}, roi_shape=single, roi_shapes=multi,
+        )
+        mesh_traces = [t for t in fig.data if type(t).__name__ == "Mesh3d"]
+        # The list wins (2 overlays), the single is ignored.
+        assert len(mesh_traces) == 2
+
+    def test_empty_roi_shapes_no_overlay(self):
+        from hrfunc.spatial.shapes import Sphere
+
+        fig = library.build_plotly_figure({}, roi_shapes=[])
+        mesh_traces = [t for t in fig.data if type(t).__name__ == "Mesh3d"]
+        assert mesh_traces == []
+
+
+class TestVisibleShapes:
+    """``_visible_shapes(state)`` underpins the multi-ROI viz: only
+    slots with ``visible=True`` AND a buildable shape contribute."""
+
+    def test_empty_when_cluster_roi_active_false(self):
+        from hrfunc.gui.state import AppState
+
+        s = AppState()
+        s.cluster_roi_active = False
+        # Even with a real shape in slot 0, the master toggle gates everything.
+        assert library._visible_shapes(s) == []
+
+    def test_returns_only_visible_slots(self):
+        from hrfunc.gui.state import AppState
+
+        s = AppState()
+        s.cluster_roi_active = True
+        # Add a second slot, hide the first.
+        s.add_roi()
+        s.set_active_roi(0)
+        s.cluster_rois[0].visible = False
+        s.cluster_rois[1].visible = True
+
+        pairs = library._visible_shapes(s)
+        # Only the second slot contributes.
+        assert len(pairs) == 1
+        assert pairs[0][0] is s.cluster_rois[1]
+
+    def test_drops_slots_with_no_buildable_shape(self):
+        """A slot in atlas mode with no region picked has no shape.
+        It's silently dropped so the viz still renders the others."""
+        from hrfunc.gui.state import AppState
+
+        s = AppState()
+        s.cluster_roi_active = True
+        s.cluster_rois[0].shape = library.SHAPE_ATLAS_REGION
+        s.cluster_rois[0].atlas_label = None
+        s.add_roi()  # second slot stays at sphere defaults
+
+        pairs = library._visible_shapes(s)
+        assert len(pairs) == 1
+        # The remaining pair is the sphere slot (index 1).
+        assert pairs[0][0] is s.cluster_rois[1]
+
+
+class TestVisibleRoiKeysUnion:
+    """``_visible_roi_keys`` computes the UNION of every visible
+    slot's ROI membership. The viz uses this union for the gold halo
+    (one halo, every visible ROI's HRFs)."""
+
+    def _hbo_hrf(self, key, loc_mm):
+        return {
+            key: {
+                "oxygenation": True,
+                "location": [c / 1000.0 for c in loc_mm],  # mm -> meters
+            }
+        }
+
+    def test_union_across_two_disjoint_spheres(self):
+        from hrfunc.gui.state import AppState
+
+        # Two HRFs far apart; each sphere should match one of them.
+        matched = {}
+        matched.update(self._hbo_hrf("a", (0.0, 0.0, 0.0)))
+        matched.update(self._hbo_hrf("b", (50.0, 0.0, 0.0)))
+
+        s = AppState()
+        s.cluster_roi_active = True
+        s.cluster_rois[0].shape = library.SHAPE_SPHERE
+        s.cluster_rois[0].center_x_mm = 0.0
+        s.cluster_rois[0].radius_mm = 10.0
+        new = s.add_roi()
+        new.shape = library.SHAPE_SPHERE
+        new.center_x_mm = 50.0
+        new.center_y_mm = 0.0
+        new.center_z_mm = 0.0
+        new.radius_mm = 10.0
+
+        union_keys, pairs = library._visible_roi_keys(s, matched)
+        assert union_keys == {"a", "b"}
+        assert len(pairs) == 2
+
+    def test_hidden_slot_excluded_from_union(self):
+        from hrfunc.gui.state import AppState
+
+        matched = {}
+        matched.update(self._hbo_hrf("a", (0.0, 0.0, 0.0)))
+        matched.update(self._hbo_hrf("b", (50.0, 0.0, 0.0)))
+
+        s = AppState()
+        s.cluster_roi_active = True
+        s.cluster_rois[0].shape = library.SHAPE_SPHERE
+        s.cluster_rois[0].center_x_mm = 0.0
+        s.cluster_rois[0].radius_mm = 10.0
+        new = s.add_roi()
+        new.shape = library.SHAPE_SPHERE
+        new.center_x_mm = 50.0
+        new.radius_mm = 10.0
+        new.visible = False  # hide the second
+
+        union_keys, pairs = library._visible_roi_keys(s, matched)
+        assert union_keys == {"a"}
+        assert len(pairs) == 1


### PR DESCRIPTION
## Summary

Two UX follow-ups on the multi-ROI / Add Montage flow:

1. **Add Montage drops the pristine default ROI.** Conservative: only when the list has exactly one slot AND every field still matches `ROISlot()` defaults. A single edit (centre / radius / anchor / visibility) keeps it in place.
2. **Per-ROI visibility checkbox** — a true layer-toggle. Unchecking hides the ROI from the 3D viz AND excludes it from the saved montage.json. Re-checking restores it. The viz now renders all visible ROIs' shape overlays + halos simultaneously.

Visibility is independent of "active" — the user can still edit a hidden slot's parameters in the right panel.

## State additions

- `ROISlot.visible: bool = True`
- `ROISlot.is_pristine_default()` — used by Add Montage to decide whether to drop the starting slot. Ignores `name` (auto-numbering shouldn't make a slot look edited).

## UI

- ROI list rows gain an eye / eye-off button before the delete button. Hidden rows dim to `opacity-60`.
- Multi-ROI viz: every visible slot's shape overlay renders simultaneously; the gold halo is the union of all visible slots' member HRFs. Status reads "ROI: N highlighted across M visible ROIs".
- Cluster sub-tab status now distinguishes "Active ROI: ..." (driven by the slot whose controls are in the right panel) from a hidden-count summary "(N ROIs hidden -- will be excluded from save and viz)".

## New helpers

- `_build_shape_for_slot(state, slot)` — builds a Shape from a specific slot.
- `_visible_shapes(state)` — `[(slot, Shape), ...]` for every visible slot whose shape can be built.
- `_visible_roi_keys(state, matched)` — `(union_keys, visible_pairs)` for the viz + status.
- `build_plotly_figure` gains a `roi_shapes: Optional[List[Shape]]` kwarg; the legacy `roi_shape` stays as a back-compat shim. List wins when both are passed.

## Save flow

The save handler still iterates `cluster_rois` in order, but skips slots with `visible=False` before building any per-ROI entries. The saved montage.json contains only the visible ROIs.

## Tests

- +9 state tests (`TestROISlotVisibility`, `TestROISlotIsPristineDefault`).
- +4 figure tests (`TestBuildPlotlyFigureRoiShapes`).
- +3 shape-collection tests (`TestVisibleShapes`).
- +2 union-keys tests (`TestVisibleRoiKeysUnion`).

Full suite: **909 passed** (+15 new), 0 failures.

## Independent of PR #58

The pywebview filter-syntax hotfix in PR #58 is independent — these two PRs touch overlapping files (`hrtree_panel.py`) but in different sections. Whichever merges first, the other rebases cleanly.

## Test plan

- [ ] Click Add Montage on a fresh project → confirm the orphan "ROI 1" at (0, 0, 0) is gone and the list shows only the per-channel spheres
- [ ] Edit the default ROI 1's centre, then click Add Montage → confirm the edited ROI 1 is preserved (the drop only kicks in when pristine)
- [ ] Tick a montage with 5+ ROIs, hide two via the eye icon → confirm viz overlays show only the 3 visible shapes + halos, save writes only those 3
- [ ] Toggle the master "ROI active" off → confirm the viz hides all overlays regardless of per-ROI visibility
- [ ] Click on a hidden ROI in the list to make it active → confirm the right panel shows its parameters editable, viz still hides it
- [ ] Save montage → confirm the hidden ROIs aren't in the JSON; the visible-only toast count matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)
