### PR TITLE
fix: scope per-scan result state to the owning scan/project

### DIFF
--- a/src/hrfunc/gui/components/activity_panel.py
+++ b/src/hrfunc/gui/components/activity_panel.py
@@ -167,8 +167,18 @@ def _render_body(state: AppState, opts: ActivityOptions) -> None:
         # ── Run row + progress + errors
         _render_run_row(state, scan, checked_scans, opts)
 
-        # ── Preview (single-scan only -- bulk overwrites activity_raw)
-        if state.activity_raw is not None and not bulk_mode:
+        # ── Preview (single-scan only -- bulk overwrites activity_raw).
+        # Gate on activity_source_scan: activity_raw is a single global slot
+        # that is NOT cleared when the selected scan changes, so without this
+        # check the preview overlays scan A's deconvolved Raw against scan B's
+        # preprocessed Raw (channel names overlap across a shared montage, so
+        # the mismatch renders silently rather than erroring).
+        activity_matches = (
+            scan is not None
+            and state.activity_source_scan is not None
+            and state.activity_source_scan.path == scan.path
+        )
+        if state.activity_raw is not None and activity_matches and not bulk_mode:
             ui.separator()
             ui.label("Deconvolved preview").classes(
                 "text-xs uppercase opacity-60 tracking-wide"
@@ -441,6 +451,7 @@ def _run_bulk(
         if result is None:
             return
         state.activity_raw = result
+        state.activity_source_scan = scan
         state.publish("activity_estimated", scan)
 
     async def _bulk() -> None:
@@ -523,6 +534,7 @@ def _run(
         if result is None:
             return
         state.activity_raw = result
+        state.activity_source_scan = scan
         state.publish("activity_estimated", scan)
 
     background_tasks.create(

--- a/src/hrfunc/gui/components/export_panel.py
+++ b/src/hrfunc/gui/components/export_panel.py
@@ -108,13 +108,29 @@ def _render_body(state: AppState) -> None:
             on_click=lambda: _save_processed(state, scan),
         )
 
-        # ── Activity Raw
+        # ── Activity Raw. Gate on the activity result belonging to the
+        # selected scan: activity_raw is a single global slot not cleared on
+        # scan change, so without this the row would offer to save scan A's
+        # deconvolved data under a "<scanB>_activity.snirf" name with a
+        # dropped-channel count computed against scan B's baseline. Gating on
+        # the match means `scan` here IS the source scan, so the filename and
+        # source-count in _save_activity are correct by construction.
+        activity_matches = (
+            state.activity_raw is not None
+            and state.activity_source_scan is not None
+            and state.activity_source_scan.path == scan.path
+        )
         _render_row(
             "Activity Raw",
             "Deconvolved neural-activity output of the Activity tab. Saves "
             "as SNIRF or FIF.",
-            available=(state.activity_raw is not None),
-            unavailable_hint="Run the Activity tab first.",
+            available=activity_matches,
+            unavailable_hint=(
+                "Run the Activity tab on this scan first."
+                if state.activity_raw is None
+                else "The in-memory activity result is from another scan — "
+                "re-run the Activity tab on this scan."
+            ),
             button_label="Save activity scan…",
             on_click=lambda: _save_activity(state, scan),
         )

--- a/src/hrfunc/gui/components/hrf_panel.py
+++ b/src/hrfunc/gui/components/hrf_panel.py
@@ -805,6 +805,23 @@ def _render_hrf_preview(
         ui.image(png).classes("max-w-3xl")
         return
 
+    # Toeplitz montages are scan-specific (the library matches by channel
+    # name, not scan identity), so a montage estimated from scan A must not
+    # be plotted under scan B's header. Selecting a new scan does NOT clear
+    # state.montage, so guard the gallery the same way the Activity panel
+    # guards its run — by comparing montage_source_scan to the selected scan.
+    source = state.montage_source_scan
+    if source is None or source.path != scan.path:
+        source_name = (
+            source.display_name or source.path.name
+            if source is not None else "another scan"
+        )
+        ui.label(
+            f"These HRFs were estimated from {source_name}. "
+            "Re-run estimation on this scan to preview them here."
+        ).classes("text-sm opacity-60")
+        return
+
     _render_toeplitz_gallery(state, result)
 
 

--- a/src/hrfunc/gui/state.py
+++ b/src/hrfunc/gui/state.py
@@ -278,6 +278,13 @@ class AppState:
     # Typed Any for the same import-graph reason. The Activity panel reads
     # the data + annotations for the lens-style preproc/deconv overlay plot.
     activity_raw: Optional[Any] = None
+    # Scan that produced the current ``activity_raw``. Like
+    # ``montage_source_scan`` for the montage, this exists so the Activity
+    # preview and the Export tab don't overlay/ship scan A's deconvolved Raw
+    # against scan B's data after the user switches the selected scan (the
+    # single ``activity_raw`` slot is not cleared on scan change). Consumers
+    # compare ``activity_source_scan.path`` to the selected scan's path.
+    activity_source_scan: Optional[ScanEntry] = None
     # Per-scan quality metrics (Sprint 4.1). Keyed by ``ScanEntry.path.resolve()``;
     # each value is a dict {"raw": metrics_dict, "preprocessed": metrics_dict,
     # "deconvolved": metrics_dict}. Each metrics_dict contains numeric summaries
@@ -714,9 +721,28 @@ class AppState:
         from inside their callback see the new value. Subscribers themselves
         are not cleared — panels stay subscribed across project switches in
         the single-shell GUI; their handlers re-read state and refresh.
+
+        Per-scan state that is meaningless against a different project is
+        cleared here, not just in ``reset()``: the picker drives every
+        project change (open / switch-to-recent / close) through this
+        method, never through ``reset()``. Without the clear, the previous
+        project's ``selected_scan`` and cached Raws leak into the Inspect
+        panel, and its ``checked_scan_paths`` can silently pre-check (and
+        bulk-include) a colliding path in the new project. A ``scan_selected``
+        None is published so panels keyed only on that event (Inspect) blank
+        themselves. Idempotent: setting the manifest already in place is a
+        no-op so a stray re-set can't wipe a live selection.
         """
+        if manifest is self.manifest:
+            return
         self.manifest = manifest
+        self.selected_scan = None
+        self.raw_cache.clear()
+        self.processed_cache.clear()
+        self.checked_scan_paths.clear()
+        self.bulk_progress = None
         self.publish("project_changed", manifest)
+        self.publish("scan_selected", None)
 
     def reset(self) -> None:
         """Return to the welcome-screen state.
@@ -745,6 +771,7 @@ class AppState:
         self.montage = None
         self.montage_source_scan = None
         self.activity_raw = None
+        self.activity_source_scan = None
         self.quality_metrics.clear()
         # Note: library_hbo / library_hbr are deliberately NOT cleared by
         # reset(). They hold immutable bundled data loaded once per process;


### PR DESCRIPTION
Five related bugs from a parallel functionality review, all rooted in single-valued global result state never being scoped to, or invalidated on, a scan/project change.

- **set_manifest** now clears `selected_scan`, `raw_cache`, `processed_cache`, `checked_scan_paths`, `bulk_progress` (and publishes `scan_selected` None) when the manifest identity changes. The picker drives every project switch through `set_manifest`, never `reset()`, so previously the prior project's scan + cached Raw leaked into the Inspect panel and its checked paths could pre-check/bulk-include a colliding path in the new project. Idempotency guard prevents a re-set wiping a live selection. *(review #10, #11)*
- **HRF toeplitz gallery** guards on `montage_source_scan == selected scan`, so scan A's per-channel HRFs are no longer plotted under scan B's header. Canonical previews stay scan-agnostic. *(#6)*
- New **`AppState.activity_source_scan`** tracks which scan produced `activity_raw`; the Activity preview only renders on a match, fixing the silent overlay of scan A's deconvolved Raw against scan B's preprocessed Raw. *(#7)*
- **Activity export** row gates on the same activity-source match, so the saved filename + dropped-channel count can't be derived from a different scan than the data written. *(#14)*

**Testing:** verified by `py_compile`; full `pytest` not run in the authoring env (no mne/nicegui). Please run the suite before merge — watch the `set_manifest` clear-on-change behavior against existing GUI tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
