### PR TITLE
fix: two scientific-correctness bugs in core estimation

### DIFF
--- a/src/hrfunc/hrfunc.py
+++ b/src/hrfunc/hrfunc.py
@@ -577,14 +577,29 @@ class montage(tree):
                         False, self.sfreq, canonical_duration
                     )
 
-            # Figure out which channel to apply to
+            # Figure out which channel to apply to. Track the match explicitly:
+            # a bare for/break leaves nirx_channel bound to the LAST iterated
+            # channel when ch_name matches nothing, which would silently apply
+            # this HRF's deconvolution to an unrelated channel. self.channels
+            # can legitimately contain a channel absent from this scan — e.g. a
+            # montage loaded via load_montage (configured=True, so configure()
+            # is skipped), or estimate_activity reused across scans with
+            # differing layouts — so a no-match must skip, not act on a stale
+            # loop variable.
+            matched_channel = None
             for nirx_channel in nirx_obj.info['chs']:
-                standard_ch_name = standardize_name(nirx_channel['ch_name'])
-                if ch_name == standard_ch_name:
+                if ch_name == standardize_name(nirx_channel['ch_name']):
+                    matched_channel = nirx_channel
                     break
+            if matched_channel is None:
+                print(
+                    f"WARNING: channel {ch_name} not found in scan {nirx_obj}; "
+                    "skipping deconvolution for it"
+                )
+                continue
 
             print(f"Deconvolving channel {ch_name}...") # Apply deconvolution
-            nirx_obj.apply_function(deconvolution, picks = [nirx_channel['ch_name']]) # Apply deconvolution for channel
+            nirx_obj.apply_function(deconvolution, picks = [matched_channel['ch_name']]) # Apply deconvolution for channel
 
             # Remove channel if neural activity estimation failed to converge.
             # M4: also drop the orphaned entry from self.channels and the
@@ -596,7 +611,7 @@ class montage(tree):
             # this release iterates the full tree except montage.branch()
             # which rebuilds from self.channels.
             if success is False:
-                nirx_obj.drop_channels([nirx_channel['ch_name']])
+                nirx_obj.drop_channels([matched_channel['ch_name']])
                 dropped_channels.append(ch_name)
 
             # Replace the canonical HRF estimate temporarily used with the HRF estimate

--- a/src/hrfunc/observer.py
+++ b/src/hrfunc/observer.py
@@ -82,27 +82,31 @@ class lens:
             'Deconvolved': []
         }
 
-        count = 0
         _min = -0.02
         _max = 0.07
-        
+
         for state in ['Preprocessed', 'Deconvolved']:
-            count = 0
+            # Each channel's value is a sum over SUBJECTS, so the per-channel
+            # average divides by the subject count. The previous code divided
+            # by a running (subject x channel) pair count, shrinking every
+            # reported average by a factor of the channel count.
+            n_subjects = len(self.metrics[state]['kurtosis'])
+
             #Add all kurtosis across subjects per channel
             for subject_id, channels in self.metrics[state]['kurtosis'].items():
                 for channel in channels:
                     channel_kurtosis[state][channel] += self.metrics[state]['kurtosis'][subject_id][channel]
-                    count += 1
 
             # Add all skewness across subjects per channel
             for subject_id, channels in self.metrics[state]['skewness'].items():
                 for channel in channels:
                     channel_skewness[state][channel] += self.metrics[state]['skewness'][subject_id][channel]
-            
+
             # Average across subjects for each channel
+            divisor = n_subjects if n_subjects else 1
             for channel in channels:
-                skewness[state].append(channel_skewness[state][channel] / count)
-                kurtosis[state].append(channel_kurtosis[state][channel] / count) 
+                skewness[state].append(channel_skewness[state][channel] / divisor)
+                kurtosis[state].append(channel_kurtosis[state][channel] / divisor)
         
         print(f"Average {state} skew: {sum(skewness[state]) / len(skewness[state])} \nAverage {state} kurtosis: {sum(kurtosis[state]) / len(kurtosis[state])}")
         


### PR DESCRIPTION
Two confirmed scientific-correctness bugs from the parallel review.

- **estimate_activity wrong-channel deconvolution (#4):** the inner loop mapping a montage channel name to a scan channel used a bare `for/break` with no match flag. On a no-match (a montage loaded via `load_montage`, or `estimate_activity` reused across scans with differing layouts) `nirx_channel` stayed bound to the *last* iterated channel, so the HRF deconvolution — and any failure drop — was silently applied to an unrelated channel, corrupting the estimate. Now tracks the match explicitly and skips the channel when the scan doesn't contain it. The happy path (configured from the same scan) always matches, so output is unchanged there.
- **observer.compare_subjects averaging divisor (#12):** per-channel kurtosis/skewness were divided by a running `(subject × channel)` pair count instead of the subject count, shrinking every reported/plotted value by a factor of the channel count. Now divides by `len(subjects)`.

**Testing:** verified by `py_compile`; full `pytest` not run in the authoring env (no mne/nicegui).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
