### PR TITLE
fix: three ROI / submission GUI correctness bugs

### DIFF
--- a/src/hrfunc/gui/components/hrtree_panel.py
+++ b/src/hrfunc/gui/components/hrtree_panel.py
@@ -1884,8 +1884,17 @@ def _render_viz_pane(state: AppState) -> None:
                 # PR #55: also stamp the anchor onto the *active* ROI
                 # slot so it travels with the slot (and into the saved
                 # montage). Pre-PR-#55 the anchor was a single global
-                # field; now each ROI keeps its own.
-                state.active_roi.anchor = anchor_dict
+                # field; now each ROI keeps its own. Since the 2026-05-16
+                # layout refactor cluster_rois defaults to EMPTY, so on a
+                # fresh library load active_roi is None -- guard the stamp
+                # rather than dereferencing None (which aborted the handler
+                # before the selection event published, so the very first
+                # HRF click did nothing visible). The centre-seed proxy
+                # writes and the painted-set clear below already no-op when
+                # there's no active slot.
+                active = state.active_roi
+                if active is not None:
+                    active.anchor = anchor_dict
                 # Seed the Cluster sub-tab's shape centre from the clicked
                 # HRF so sphere mode's behaviour matches the v1.2 "click
                 # an HRF, sphere centres on it" workflow even though the

--- a/src/hrfunc/gui/state.py
+++ b/src/hrfunc/gui/state.py
@@ -85,6 +85,7 @@ earlier sprints don't need updates as later panels land.
 from __future__ import annotations
 
 import logging
+import re
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Set, Tuple
@@ -95,6 +96,12 @@ from ..io.raw_cache import RawCache
 logger = logging.getLogger(__name__)
 
 EventCallback = Callable[..., None]
+
+# Matches the auto-generated ROI slot names ("ROI 1", "ROI 2", ...) that
+# ``add_roi`` / the default factory produce. Used by ``clear_active_roi`` to
+# renumber ONLY auto-named slots after a delete, leaving descriptive names
+# ("Montage: S1_D1" from Add Montage, or user renames) untouched.
+_AUTO_ROI_NAME_RE = re.compile(r"^ROI \d+$")
 
 
 @dataclass
@@ -639,10 +646,17 @@ class AppState:
             self.cluster_active_index = max(
                 0, self.cluster_active_index - 1
             )
-            # Renumber default names so the list stays
-            # "ROI 1 ... ROI N" in order.
-            for i, slot in enumerate(self.cluster_rois):
-                slot.name = f"ROI {i + 1}"
+            # Renumber ONLY auto-generated "ROI N" names so the auto-named
+            # slots stay "ROI 1 ... ROI N" in order. Descriptive names --
+            # "Montage: S1_D1" from Add Montage, or a user rename -- are left
+            # untouched. The pre-fix code overwrote EVERY name on any delete,
+            # which clobbered montage provenance and corrupted the saved
+            # montage.json (build_roi_entry reads slot.name verbatim).
+            auto_index = 0
+            for slot in self.cluster_rois:
+                if _AUTO_ROI_NAME_RE.match(slot.name):
+                    auto_index += 1
+                    slot.name = f"ROI {auto_index}"
         else:
             self.cluster_active_index = 0
 

--- a/src/hrfunc/gui/submission.py
+++ b/src/hrfunc/gui/submission.py
@@ -266,8 +266,15 @@ class SubmissionMetadata:
         # the dataset.
         if self.dataset_ownership == "no" and not self.dataset_permission.strip():
             missing.append("Dataset Permission")
-        # Conditional: owner + contact only required when permission == yes.
-        if self.dataset_permission == "yes":
+        # Conditional: owner + contact only required when the user does NOT
+        # own the dataset AND has permission. The ownership clause guards
+        # against a stale dataset_permission=="yes" left over from a prior
+        # answer (the form hides these inputs once ownership flips back to
+        # "yes"); without it, missing_required would demand owner/contact for
+        # fields that aren't rendered, stranding the Submit button. The panel
+        # also clears these children on the parent change, so this is
+        # defence in depth.
+        if self.dataset_ownership == "no" and self.dataset_permission == "yes":
             if not self.dataset_owner.strip():
                 missing.append("Dataset Owner Name")
             if not self.dataset_contact.strip():
@@ -536,17 +543,38 @@ def render_submission_panel(state, *, default_path: Optional[Path] = None) -> No
         _text_input(metadata, "doi", "DOI of the paper detailing data collection")
 
         # --- Dataset rights -------------------------------------------
+        # Conditional sub-fields are stamped onto the shared ``metadata`` by
+        # their inputs and are NOT auto-cleared when the parent select hides
+        # them. Without the resets below, flipping a parent back (e.g.
+        # ownership "no" -> "yes") would leave a stale dataset_permission /
+        # owner / contact on metadata: to_form_dict would then POST
+        # contradictory rights metadata, and a stale permission could even
+        # strand Submit on now-hidden required fields. Clear children on the
+        # parent change before refreshing.
+        def _on_ownership_change() -> None:
+            if metadata.dataset_ownership != "no":
+                metadata.dataset_permission = ""
+                metadata.dataset_owner = ""
+                metadata.dataset_contact = ""
+            _body.refresh()
+
+        def _on_permission_change() -> None:
+            if metadata.dataset_permission != "yes":
+                metadata.dataset_owner = ""
+                metadata.dataset_contact = ""
+            _body.refresh()
+
         _section_label("Dataset rights")
         _select_input(
             metadata, "dataset_ownership",
             "Do you own the dataset these HRFs were estimated from?",
-            on_change=_body.refresh,
+            on_change=_on_ownership_change,
         )
         if metadata.dataset_ownership == "no":
             _select_input(
                 metadata, "dataset_permission",
                 "Do you have the owner's permission to add these HRFs to the HRtree?",
-                on_change=_body.refresh,
+                on_change=_on_permission_change,
             )
             if metadata.dataset_permission == "no":
                 with ui.row().classes("items-start gap-2"):
@@ -561,11 +589,19 @@ def render_submission_panel(state, *, default_path: Optional[Path] = None) -> No
                 _text_input(metadata, "dataset_contact", "Dataset owner email")
 
         # --- HRfunc usage ---------------------------------------------
+        # Same stale-child concern as Dataset rights: clear hrfunc_extension
+        # when the user flips back to "yes" so a prior extension summary
+        # isn't silently POSTed for a now-standard submission.
+        def _on_hrfunc_standard_change() -> None:
+            if metadata.hrfunc_standard != "no":
+                metadata.hrfunc_extension = ""
+            _body.refresh()
+
         _section_label("HRfunc usage")
         _select_input(
             metadata, "hrfunc_standard",
             "Did you estimate these HRFs using the unaltered HRfunc library?",
-            on_change=_body.refresh,
+            on_change=_on_hrfunc_standard_change,
         )
         if metadata.hrfunc_standard == "no":
             ui.label(


### PR DESCRIPTION
Three GUI correctness bugs from the parallel review.

- **HRtree first-click crash (#1):** clicking an HRF on a fresh library load dereferenced `state.active_roi` (None, since `cluster_rois` defaults to empty), aborting the handler before the selection event published — so the first click did nothing visible. Guard the anchor stamp; selection + detail-pane refresh now run regardless.
- **clear_active_roi name clobber (#2):** deleting any ROI renumbered *every* surviving slot to `ROI N`, destroying `Montage: S1_D1` provenance labels (which also feed the saved `montage.json`). Now renumbers only auto-generated `^ROI \d+$` names, leaving descriptive/user names intact.
- **Submission form stale conditional fields (#3):** flipping a parent select back (dataset ownership `no`→`yes`, or hrfunc_standard `no`→`yes`) left hidden children on `metadata`, so `to_form_dict` POSTed contradictory rights metadata and a stale permission could strand Submit on now-invisible required fields. Clear children on the parent change and gate the owner/contact requirement on ownership.

**Testing:** verified by `py_compile`; full `pytest` not run in the authoring env (no mne/nicegui).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
