### PR TITLE
fix: eight lower-severity correctness/robustness issues

### DIFF
--- a/src/hrfunc/gui/components/hrtree_panel.py
+++ b/src/hrfunc/gui/components/hrtree_panel.py
@@ -255,6 +255,27 @@ def _alignment_for_shape(state: AppState, shape: Optional[Shape]) -> "Optional[n
     return _build_atlas_alignment_affine(state)
 
 
+def _apply_alignment_to_point(
+    point_mm: Tuple[float, float, float],
+    alignment_affine: "Optional[np.ndarray]",
+) -> Tuple[float, float, float]:
+    """Map an MNE-head mm point to MNI mm through the alignment affine.
+
+    Mirrors the per-HRF transform in ``compute_roi_keys_by_shape`` so a
+    single-point lookup (the Cluster centre's "Region at centre" readout)
+    lands in the same frame as the membership check. Returns the point
+    unchanged when there's no affine (sphere/box mode, or atlas mode with
+    no alignment configured), matching the membership path's behaviour.
+    """
+    if alignment_affine is None:
+        return point_mm
+    homo = np.array(
+        [point_mm[0], point_mm[1], point_mm[2], 1.0], dtype=np.float64
+    )
+    aligned = alignment_affine @ homo
+    return (float(aligned[0]), float(aligned[1]), float(aligned[2]))
+
+
 def _build_shape_for_slot(state: AppState, slot) -> Optional[Shape]:
     """Build the spatial-layer Shape for a specific ROI slot.
 
@@ -824,10 +845,24 @@ def _render_cluster_subtab(state: AppState) -> None:
                 # Atlas readout is shown in BOTH modes so sphere users
                 # can see "my centre sits in: Frontal Pole" without
                 # switching modes -- useful navigation aid.
-                region_at_centre = atlas.region_at((
-                    state.cluster_center_x_mm,
-                    state.cluster_center_y_mm,
-                    state.cluster_center_z_mm,
+                #
+                # The centre is stored in MNE-head mm (it's seeded from
+                # clicked HRF locations, which are head-coord). atlas.region_at
+                # expects MNI mm, so apply the same alignment the membership
+                # check uses before the lookup -- otherwise this readout
+                # reports a different (wrong) region than the ROI it sits
+                # above whenever the user has set atlas offsets/affine.
+                # _alignment_for_shape returns None outside atlas mode, so
+                # sphere/box readouts are unchanged.
+                _centre_shape = _build_current_shape(state)
+                _centre_alignment = _alignment_for_shape(state, _centre_shape)
+                region_at_centre = atlas.region_at(_apply_alignment_to_point(
+                    (
+                        state.cluster_center_x_mm,
+                        state.cluster_center_y_mm,
+                        state.cluster_center_z_mm,
+                    ),
+                    _centre_alignment,
                 ))
                 centre_region_text = (
                     f"Region at centre: {region_at_centre}"
@@ -2736,8 +2771,12 @@ def compute_roi_average(
     # First pass: parse every subject-level estimate into a numpy array.
     # Track the source-channel count separately so the UI can show
     # "averaged N subjects across M channels".
-    candidates: List["np.ndarray"] = []
-    contributing_channels = 0
+    # Keep each parsed estimate paired with its source-channel key so the
+    # contributing-channel count can be taken AFTER the modal-length filter
+    # below -- a channel whose estimates are all an off-modal length
+    # contributes zero traces to the mean and must not inflate the reported
+    # "M channels" provenance figure.
+    candidates: List[Tuple[str, "np.ndarray"]] = []
     for key in roi_keys:
         hrf = hrfs.get(key)
         if hrf is None:
@@ -2749,7 +2788,6 @@ def compute_roi_average(
             # rather than fall back to hrf_mean (would mix two
             # averaging conventions in the same output).
             continue
-        added_from_this_channel = False
         for estimate in estimates:
             try:
                 arr = np.asarray(estimate, dtype=float)
@@ -2757,10 +2795,7 @@ def compute_roi_average(
                 continue
             if arr.ndim != 1 or arr.size == 0:
                 continue
-            candidates.append(arr)
-            added_from_this_channel = True
-        if added_from_this_channel:
-            contributing_channels += 1
+            candidates.append((key, arr))
 
     if len(candidates) < 2:
         return None
@@ -2771,13 +2806,15 @@ def compute_roi_average(
     # throw out the majority. Modal length is robust to iteration order
     # and matches what a researcher would expect: "average the traces
     # that share the typical duration; skip the oddball".
-    lengths = Counter(arr.shape[0] for arr in candidates)
+    lengths = Counter(arr.shape[0] for _, arr in candidates)
     canonical_len = lengths.most_common(1)[0][0]
-    traces = [arr for arr in candidates if arr.shape[0] == canonical_len]
+    kept = [(key, arr) for key, arr in candidates if arr.shape[0] == canonical_len]
 
-    if len(traces) < 2:
+    if len(kept) < 2:
         return None
 
+    traces = [arr for _, arr in kept]
+    contributing_channels = len({key for key, _ in kept})
     stacked = np.vstack(traces)
     return (
         stacked.mean(axis=0),

--- a/src/hrfunc/gui/components/preprocess_panel.py
+++ b/src/hrfunc/gui/components/preprocess_panel.py
@@ -298,8 +298,9 @@ def _run_pipeline(
         if result is None:
             return
         # run_pipeline_sync wraps the result so we can stash the processed
-        # Raw under the scan path in processed_cache.
-        state.processed_cache._cache[scan.path.resolve()] = result
+        # Raw under the scan path in processed_cache. put() enforces the LRU
+        # bound (a direct _cache write would not).
+        state.processed_cache.put(scan, result)
         state.publish("preprocess_done", scan)
 
     background_tasks.create(
@@ -342,7 +343,9 @@ def _run_pipeline_bulk(
     async def _on_each_done(scan: ScanEntry, result) -> None:
         if result is None:
             return
-        state.processed_cache._cache[scan.path.resolve()] = result
+        # put() enforces the LRU bound; the prior direct _cache write let a
+        # bulk preprocess retain every result and grow memory unbounded.
+        state.processed_cache.put(scan, result)
         state.publish("preprocess_done", scan)
 
     async def _bulk() -> None:

--- a/src/hrfunc/gui/components/quality_panel.py
+++ b/src/hrfunc/gui/components/quality_panel.py
@@ -155,6 +155,32 @@ def _render_per_scan(state: AppState, scan: ScanEntry) -> None:
                         ui.label("Working…").classes("text-sm opacity-70")
         else:
             _render_metrics_table(cached)
+            # A cached entry computed BEFORE Activity ran holds only the
+            # raw + preprocessed stages; nothing invalidates it when Activity
+            # later produces a deconvolved Raw for this scan. Offer an
+            # explicit recompute (the panel otherwise only shows the compute
+            # button on the empty branch) so the deconvolved row can be added
+            # without a full project reset.
+            deconv_available = (
+                STAGE_DECONVOLVED not in cached
+                and state.activity_raw is not None
+                and state.montage_source_scan is not None
+                and state.montage_source_scan.path == scan.path
+            )
+            with ui.row().classes("items-center gap-3 mt-2"):
+                recompute_disabled = (
+                    state.busy or scan not in state.processed_cache
+                )
+                ui.button(
+                    "Recompute metrics",
+                    icon="refresh",
+                    on_click=lambda: _run_per_scan(state, scan),
+                ).props(f"flat dense {'disable' if recompute_disabled else ''}")
+                if deconv_available:
+                    ui.label(
+                        "Activity result available — recompute to add the "
+                        "deconvolved row."
+                    ).classes("text-sm opacity-60")
 
 
 def _render_metrics_table(stages_metrics: Dict[str, QualityMetrics]) -> None:
@@ -405,10 +431,9 @@ def compute_dataset_sync(
                 processed_obj = None
             else:
                 if processed_obj is not None:
-                    processed_cache._cache[scan.path.resolve()] = processed_obj
-                    # Honor the LRU bound — _cache is an OrderedDict.
-                    while len(processed_cache._cache) > processed_cache.maxsize:
-                        processed_cache._cache.popitem(last=False)
+                    # put() enforces the LRU bound in one place (was an inline
+                    # direct write + manual popitem loop here).
+                    processed_cache.put(scan, processed_obj)
 
         stages: Dict[str, QualityMetrics] = {}
         stages[STAGE_RAW] = _compute_raw_metrics(raw_obj)

--- a/src/hrfunc/gui/pages/shell.py
+++ b/src/hrfunc/gui/pages/shell.py
@@ -380,6 +380,23 @@ def _render_empty_state(state: AppState, *, verb: str) -> None:
         ).classes("text-sm opacity-60")
 
         async def _on_click() -> None:
+            # Gate on busy BEFORE opening the OS dialog. During the very first
+            # project scan the empty-state is still showing (manifest is None)
+            # while busy is True; without this guard the click opens the
+            # folder dialog and then open_project_path -> run_in_background
+            # silently refuses (busy), so the click appears to do nothing.
+            # The picker dropdown disables Open while busy; this second entry
+            # point needs equivalent feedback. Checking here (rather than
+            # disabling the button) also avoids the button staying stuck if an
+            # initial scan fails — busy clears but no project_changed fires to
+            # re-render the empty state.
+            if state.busy:
+                ui.notify(
+                    "A task is still running — wait for it to finish before "
+                    "opening a project.",
+                    type="warning",
+                )
+                return
             path = await dataset_picker.pick_folder()
             if path is None:
                 return

--- a/src/hrfunc/gui/workers.py
+++ b/src/hrfunc/gui/workers.py
@@ -101,8 +101,12 @@ async def run_in_background(
         logger.exception("Background worker failed: %s", exc)
         return None
     finally:
-        state.set_busy(False)
+        # Clear progress BEFORE flipping busy: set_busy(False) synchronously
+        # publishes busy_changed, so a subscriber that re-renders would
+        # otherwise observe busy=False while estimation_progress still holds
+        # the last channel tuple. Matches the bulk worker's finally ordering.
         state.estimation_progress = None
+        state.set_busy(False)
 
     if on_done is not None:
         try:

--- a/src/hrfunc/hrfunc.py
+++ b/src/hrfunc/hrfunc.py
@@ -626,6 +626,16 @@ class montage(tree):
             # Grab channel optode attached to montage
             optode = self.channels[channel]
 
+            # Skip channels with no estimates: np.mean([], axis=0) is NaN
+            # (poisoning the trace and the global vstack pool) and
+            # update_centroid() indexes a 0-d mean of empty locations, raising
+            # IndexError. Per the subject-weighted averaging convention, HRFs
+            # without estimates are EXCLUDED, not folded in. 'global_*' entries
+            # carry no estimates either, so this also keeps a second
+            # generate_distribution call from re-pooling them.
+            if not optode.estimates:
+                continue
+
             # Calculate average HRF estimate and standard deviation
             optode.trace = np.mean(optode.estimates, axis = 0)
             optode.trace_std = np.std(optode.estimates, axis = 0)
@@ -652,6 +662,11 @@ class montage(tree):
 
         # Calculate global HRF mean and standard deviation
         for oxygenation, estimates in zip([True, False], [hbo_estimates, hbr_estimates]):
+            if not estimates:
+                # No channels of this oxygenation contributed a trace (all
+                # were skipped for lacking estimates). Nothing to pool, and
+                # np.vstack([]) would raise -- skip the global for this type.
+                continue
             type_estimates = np.vstack(estimates)
             global_mean = np.mean(type_estimates, axis = 0)
             global_std = np.std(type_estimates, axis = 0)

--- a/src/hrfunc/io/detect.py
+++ b/src/hrfunc/io/detect.py
@@ -65,8 +65,12 @@ def classify_path(path: Union[str, Path]) -> Optional[FormatHit]:
         not contain fNIRS channels.
 
     Notes:
-        - Symlinks are followed via ``Path.resolve`` so callers can pass
-          relative paths from any working directory.
+        - The returned ``FormatHit.path`` is the path AS PASSED (wrapped in a
+          ``Path``); it is not resolved or symlink-followed. Callers that need
+          an absolute/canonical path should resolve before calling (the folder
+          scanner does — it walks an already-resolved root). Resolving here
+          would change ``FormatHit.path``'s shape, which downstream BIDS
+          metadata parsing relies on being root-relative.
         - This function does not raise on bad input. A path that does not
           exist, a directory missing NIRx markers, a non-fNIRS FIF, etc., all
           return None. Errors during the FIF info read are logged and treated

--- a/src/hrfunc/io/raw_cache.py
+++ b/src/hrfunc/io/raw_cache.py
@@ -95,6 +95,25 @@ class RawCache:
             self._cache.popitem(last=False)
         return raw
 
+    def put(
+        self, scan_or_path: Union[ScanEntry, Path, str], raw: "mne.io.BaseRaw"
+    ) -> None:
+        """Insert (or replace) a Raw the caller already holds, honoring LRU.
+
+        Used by callers that produce a Raw themselves rather than loading it
+        through :meth:`get` — e.g. the Preprocess / Quality panels storing a
+        *preprocessed* Raw under its scan path. Writing straight into
+        ``_cache`` (as those sites previously did) bypasses the ``maxsize``
+        eviction that only :meth:`get` performed, so a bulk run could retain
+        every result and grow memory without bound. Routing the writes here
+        enforces the bound in one place. The entry is promoted to MRU.
+        """
+        path = self._extract_path(scan_or_path)
+        self._cache[path] = raw
+        self._cache.move_to_end(path)
+        if len(self._cache) > self.maxsize:
+            self._cache.popitem(last=False)
+
     def evict(self, scan_or_path: Union[ScanEntry, Path, str]) -> bool:
         """Remove a specific entry from the cache.
 


### PR DESCRIPTION
Eight lower-severity issues from the parallel review.

- **#5** Cluster "Region at centre" readout applies the same HRF-head→MNI alignment the membership check uses (shared point helper), so it agrees with the ROI it sits above when offsets/affine are set. Sphere/box readouts unchanged.
- **#8** `RawCache.put()` inserts *and* honors the LRU `maxsize`; the Preprocess (single + bulk) and Quality direct `_cache` writes route through it — the bulk preprocess previously retained every ~100 MB Raw (OOM risk).
- **#9** Quality panel renders a Recompute button on the cached branch, so a scan measured before Activity can pick up the deconvolved row without a project reset.
- **#13** `compute_roi_average` counts contributing channels *after* the modal-length filter, so an off-length-dropped channel no longer inflates the "M channels" figure.
- **#15** `run_in_background` clears `estimation_progress` before `set_busy(False)`, matching the bulk worker so a `busy_changed` subscriber can't observe stale progress.
- **#16** Empty-state "Open folder" button checks busy before opening the OS dialog and notifies instead of silently no-oping during the first scan.
- **#17** `generate_distribution` skips channels with no estimates (NaN trace + `update_centroid` IndexError) and an empty oxygenation pool, per the subject-weighted convention.
- **#18** `classify_path` docstring corrected to state `FormatHit.path` is not resolved (behavior unchanged — callers rely on the path shape for BIDS parsing).

**Testing:** verified by `py_compile`; full `pytest` not run in the authoring env (no mne/nicegui).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
