### PR TITLE
feat: hint + link to Preprocess when estimating activity on an unprocessed scan

### DIFF
--- a/src/hrfunc/gui/components/activity_panel.py
+++ b/src/hrfunc/gui/components/activity_panel.py
@@ -323,9 +323,23 @@ def _render_run_row(
         if state.busy:
             _render_busy_progress(state)
         elif not bulk_mode and scan is not None and scan not in state.processed_cache:
-            ui.label("Waiting for preprocess output…").classes(
-                "text-sm opacity-60"
-            )
+            # Activity deconvolution runs on the *preprocessed* signal, so
+            # the Run button is disabled until the scan has been through the
+            # Preprocess tab. Spell that out and link straight there rather
+            # than leaving a disabled button with no explanation. The link
+            # goes through the event bus (navigate_preprocess) so this panel
+            # doesn't need a reference to the shell's tab control.
+            with ui.row().classes("items-center gap-2"):
+                ui.icon("info").classes("text-amber-500")
+                ui.label(
+                    "This scan hasn't been preprocessed yet — activity is "
+                    "estimated from the preprocessed signal."
+                ).classes("text-sm opacity-70")
+                ui.button(
+                    "Go to Preprocess",
+                    icon="arrow_forward",
+                    on_click=lambda: state.publish("navigate_preprocess"),
+                ).props("flat dense color=primary")
 
     if state.last_error and not state.busy:
         with ui.row().classes("items-center gap-2"):

--- a/src/hrfunc/gui/pages/shell.py
+++ b/src/hrfunc/gui/pages/shell.py
@@ -169,7 +169,17 @@ def _render(state: AppState) -> None:
 
     tabs_holder: dict = {}
     _render_toolbar(state, tabs_holder)
-    _render_tab_panels(state, tabs_holder["tabs"], initial_tab)
+    tabs = tabs_holder["tabs"]
+    _render_tab_panels(state, tabs, initial_tab)
+
+    # Let panels request a tab switch without holding a reference to the
+    # ``ui.tabs`` element (and without importing this module, which would be
+    # circular). The Activity tab publishes ``navigate_preprocess`` when the
+    # selected scan hasn't been preprocessed yet, linking the user straight
+    # to the Preprocess tab. Keep the tab-name string solely here.
+    state.subscribe(
+        "navigate_preprocess", lambda *_: tabs.set_value(TAB_PREPROCESS)
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Activity deconvolution runs on the preprocessed signal, so the Run button is disabled until the scan has been through the Preprocess tab. Previously that state showed only a vague "Waiting for preprocess output…" label with no path forward — to the user it looked like the button just did nothing.

Replaces it with an explicit hint ("This scan hasn't been preprocessed yet…") and a **Go to Preprocess** button that switches the user straight to the Preprocess tab (same scan still selected).

The jump goes through a new `navigate_preprocess` event so the Activity panel doesn't need a reference to the shell's `ui.tabs` (importing the shell would be circular); the shell subscribes and calls `tabs.set_value(TAB_PREPROCESS)`.

**Testing:** verified by `py_compile`; full `pytest` not run in the authoring env. Worth a quick click-test that `tabs.set_value(...)` switches tabs as expected on the installed NiceGUI version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
