### PR TITLE
feat: make the GUI stack a core dependency (was a [gui] extra)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,10 +25,13 @@ dependencies = [
     "nilearn",
     "matplotlib",
     "platformdirs>=3.0",
-    ]
-
-[project.optional-dependencies]
-gui = [
+    # GUI stack. The `hrfunc` command IS the desktop GUI, so these are
+    # core dependencies rather than an optional extra -- a plain
+    # `pip install hrfunc` must give a working app, since the target
+    # users are researchers who launch HRfunc as a desktop program and
+    # shouldn't have to know about pip extras. (Was a `[gui]` extra
+    # pre-1.3.x; promoted to core so `hrfunc` never fails with a bare
+    # ModuleNotFoundError on a default install.)
     "nicegui>=2.0",
     "plotly>=5.18",
     "pywebview>=5.0",
@@ -39,6 +42,14 @@ gui = [
     # shortcut install doesn't depend on transitive coincidence.
     "Pillow>=9.0",
     ]
+
+[project.optional-dependencies]
+# The GUI stack moved into core `dependencies` (above), so installing the
+# GUI no longer needs an extra. This empty `gui` extra is kept purely so
+# existing instructions / scripts that run `pip install hrfunc[gui]`
+# don't error on an unknown extra -- it resolves to the (already core)
+# GUI deps as a no-op.
+gui = []
 
 [project.scripts]
 hrfunc = "hrfunc.gui.app:main"

--- a/src/hrfunc/gui/app.py
+++ b/src/hrfunc/gui/app.py
@@ -1,6 +1,6 @@
 """HRfunc GUI entry point.
 
-``hrfunc`` (the CLI command installed by ``pip install hrfunc[gui]``)
+``hrfunc`` (the CLI command installed by ``pip install hrfunc``)
 calls ``main()``, which dispatches three classes of invocation:
 
 1. **Bare launch** (``hrfunc`` or ``hrfunc <path>``) — the dominant path.
@@ -93,9 +93,26 @@ def _launch_gui(argv: List[str]) -> int:
     args = parser.parse_args(argv)
 
     # Import NiceGUI lazily so `hrfunc --version` and `hrfunc --help` work
-    # even if the [gui] extras are not fully installed (e.g. user is checking
-    # what version they have before pip install hrfunc[gui]).
-    from nicegui import ui
+    # even before the heavier GUI imports resolve. The GUI stack is now a
+    # core dependency (see pyproject), so this should always succeed on a
+    # normal install -- but guard it anyway: if the env is broken/partial,
+    # a clear "reinstall" hint beats a raw ModuleNotFoundError traceback for
+    # the non-technical researchers who are the GUI's audience.
+    try:
+        from nicegui import ui
+    except ModuleNotFoundError as exc:
+        if exc.name not in ("nicegui", "plotly", "pywebview", "webview"):
+            raise
+        print(
+            "HRfunc's desktop GUI couldn't start because a required package "
+            f"is missing ({exc.name}). Your install looks incomplete.\n\n"
+            "Reinstall HRfunc to pull the GUI dependencies:\n"
+            "    pip install --force-reinstall hrfunc\n\n"
+            "From a source checkout:\n"
+            "    pip install -e .",
+            file=sys.stderr,
+        )
+        return 1
 
     from .state import state
 


### PR DESCRIPTION
The `hrfunc` command launches the desktop GUI, and its users are researchers who run HRfunc as an app — not developers who know to type `pip install hrfunc[gui]`. Shipping nicegui/plotly/pywebview/pyshortcuts/Pillow as an optional extra meant a plain `pip install hrfunc` produced an `hrfunc` command that crashed with a bare `ModuleNotFoundError`.

- **pyproject:** GUI deps moved into `[project].dependencies`; the `gui` extra is kept as an empty no-op so existing `pip install hrfunc[gui]` instructions don't error on an unknown extra.
- **app.py:** the lazy `nicegui` import now degrades to a clear "reinstall" hint instead of a raw traceback if the env is somehow partial (defense in depth — shouldn't trigger on a normal install now).

**Testing:** verified by `py_compile` + `tomllib` parse of pyproject.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
