### PR TITLE
GUI: Activity HRF sources, channel-wise QC, events upload, bulk robustness + core deconvolution speedup

### DIFF
--- a/src/hrfunc/gui/components/activity_panel.py
+++ b/src/hrfunc/gui/components/activity_panel.py
@@ -46,9 +46,13 @@ from nicegui import background_tasks, ui
 
 from ..state import AppState
 from ..workers import (
+    capture_client,
+    client_scope,
     make_progress_callback,
+    notify_if_alive,
     run_bulk_in_background,
     run_in_background,
+    summarize_failures,
 )
 from ...io.manifest import ScanEntry
 from .hrf_panel import _CanonicalResult
@@ -61,9 +65,54 @@ logger = logging.getLogger(__name__)
 
 MODEL_TOEPLITZ = "toeplitz"
 MODEL_CANONICAL = "canonical"
+MODEL_LIBRARY = "library"
 DEFAULT_LMBDA = 1e-4
 LOG_LMBDA_MIN = -6
 LOG_LMBDA_MAX = -1
+# Per-channel solve timeout (s); mirrors montage.estimate_activity's default.
+DEFAULT_TIMEOUT = 30.0
+
+# Human-readable names for the HRF sources estimate_activity supports.
+# Drives the right-column "HRF source" selector and the left-column readout.
+SOURCE_LABELS = {
+    MODEL_TOEPLITZ: "Estimated HRFs (from the HRFs tab)",
+    MODEL_CANONICAL: "Canonical reference HRF (library)",
+    MODEL_LIBRARY: "HRtree HRF (selected in the HRtree tab)",
+}
+
+
+def _library_kernel_from_state(state: AppState):
+    """The (trace, oxygenation) of the HRtree HRF selected for deconvolution.
+
+    Reads ``state.library_selected_hrf`` (the HRF the user clicked in the
+    HRtree tab). Returns ``(trace_list, oxygenation_bool)`` or ``None`` when no
+    HRF is selected / it has no usable mean trace.
+    """
+    hrf = getattr(state, "library_selected_hrf", None)
+    if not hrf:
+        return None
+    trace = hrf.get("hrf_mean") or []
+    if not len(trace):
+        return None
+    return list(trace), bool(hrf.get("oxygenation"))
+
+
+def _snapshot_options(state: AppState, opts: "ActivityOptions") -> "ActivityOptions":
+    """Snapshot ActivityOptions for a background run, capturing the HRtree
+    kernel when in library mode so the run sees a stable trace."""
+    kernel = (
+        _library_kernel_from_state(state)
+        if opts.hrf_model == MODEL_LIBRARY else None
+    )
+    return ActivityOptions(
+        hrf_model=opts.hrf_model,
+        lmbda=opts.lmbda,
+        preview_channel=opts.preview_channel,
+        timeout=opts.timeout,
+        drop_failed_channels=opts.drop_failed_channels,
+        library_trace=kernel[0] if kernel else None,
+        library_oxygenation=kernel[1] if kernel else True,
+    )
 
 
 @dataclass
@@ -77,6 +126,16 @@ class ActivityOptions:
     hrf_model: str = MODEL_TOEPLITZ
     lmbda: float = DEFAULT_LMBDA
     preview_channel: int = 0
+    # Per-channel lstsq solve timeout (seconds) and whether a failed channel
+    # is dropped (scan continues) vs aborting the whole scan. Forwarded to
+    # montage.estimate_activity.
+    timeout: float = DEFAULT_TIMEOUT
+    drop_failed_channels: bool = True
+    # Snapshot of the HRtree kernel for hrf_model == MODEL_LIBRARY, captured at
+    # Run-click so a background run sees a stable trace even if the HRtree
+    # selection changes mid-run. None in other modes.
+    library_trace: Optional[list] = None
+    library_oxygenation: bool = True
 
 
 def render(state: AppState) -> None:
@@ -102,6 +161,11 @@ def render(state: AppState) -> None:
     state.subscribe("preprocess_done", _refresh)
     state.subscribe("hrf_estimated", _refresh)
     state.subscribe("activity_estimated", _refresh)
+    # Recompute bulk mode when the dataset-tree checked set changes.
+    state.subscribe("checked_changed", _refresh)
+    # Update the "HRtree HRF" source status when the user picks an HRF in the
+    # HRtree tab (so the kernel readout / Run gating refresh live).
+    state.subscribe("hrtree_selection_changed", _refresh)
 
     def _poll_progress() -> None:
         if state.busy and state.estimation_progress is not None:
@@ -130,60 +194,175 @@ def _render_body(state: AppState, opts: ActivityOptions) -> None:
             ).classes("text-sm opacity-60")
             return
 
-        if bulk_mode:
-            ui.label(
-                f"Bulk run on {len(checked_scans)} checked scan"
-                f"{'s' if len(checked_scans) != 1 else ''}."
-            ).classes("text-sm font-mono opacity-70")
-            if opts.hrf_model == MODEL_TOEPLITZ:
-                # Toeplitz bulk needs per-scan estimated HRFs, but
-                # ``state.montage`` is single-valued. The bulk worker
-                # will skip scans whose montage_source_scan doesn't
-                # match -- in practice that's every scan except whichever
-                # one the user last ran HRFs on. Canonical bulk works
-                # universally.
-                ui.label(
-                    "Toeplitz mode in bulk only succeeds on the scan "
-                    "whose HRFs are currently in memory; other scans "
-                    "will be skipped. Switch to canonical for an "
-                    "every-scan deconvolution."
-                ).classes("text-xs opacity-60 italic")
-        elif scan is not None:
-            ui.label(scan.display_name or scan.path.name).classes(
-                "text-sm font-mono opacity-70"
+        # Two-column workspace: deconvolution controls on the left, the HRF
+        # source picker + preview in its own column on the right (mirrors the
+        # HRFs / HRtree tabs). The right column makes it explicit WHICH HRFs
+        # the deconvolution will use, and links to the HRFs tab when the
+        # chosen source isn't ready yet.
+        with ui.row().classes("w-full gap-6 items-start no-wrap"):
+            with ui.column().classes("flex-1 min-w-0 gap-4"):
+                if bulk_mode:
+                    ui.label(
+                        f"Bulk run on {len(checked_scans)} checked scan"
+                        f"{'s' if len(checked_scans) != 1 else ''}."
+                    ).classes("text-sm font-mono opacity-70")
+                elif scan is not None:
+                    ui.label(scan.display_name or scan.path.name).classes(
+                        "text-sm font-mono opacity-70"
+                    )
+
+                # Shared filename options for the Save action; created here so
+                # the inputs (inside the Deconvolution card) and the Save
+                # button (in the run row) read/write the same dict.
+                naming = {"postfix": "_deconvolved", "ext": ".snirf"}
+
+                # ── Parameter controls. HRF-source selection lives in the
+                # right column; here we show the current source as a readout
+                # plus the regularization control, then the save options as a
+                # subsection at the bottom.
+                with ui.card().classes("w-full"):
+                    ui.label("Deconvolution").classes(
+                        "text-xs uppercase opacity-60 tracking-wide"
+                    )
+                    ui.label(
+                        f"HRF source: {SOURCE_LABELS[opts.hrf_model]}"
+                    ).classes("text-sm opacity-70")
+                    ui.label("Choose the source in the panel on the right.").classes(
+                        "text-xs opacity-50"
+                    )
+                    _render_lmbda_slider(opts)
+                    _render_deconv_controls(opts)
+                    # Save-output subsection (filename postfix + format).
+                    _render_save_options(state, scan, checked_scans, naming)
+
+                # ── Run row: Estimate + Save on the same horizontal level,
+                # then progress / errors.
+                _render_run_row(state, scan, checked_scans, opts, naming)
+
+                # ── Deconvolved preview (single-scan only -- bulk overwrites
+                # activity_raw). Gate on activity_source_scan: activity_raw is
+                # a single global slot NOT cleared when the selected scan
+                # changes, so without this check the preview would overlay scan
+                # A's deconvolution against scan B's preprocessed Raw (channel
+                # names overlap across a shared montage, so it renders silently
+                # rather than erroring).
+                activity_matches = (
+                    scan is not None
+                    and state.activity_source_scan is not None
+                    and state.activity_source_scan.path == scan.path
+                )
+                if (
+                    state.activity_raw is not None
+                    and activity_matches
+                    and not bulk_mode
+                ):
+                    ui.separator()
+                    ui.label("Deconvolved preview").classes(
+                        "text-xs uppercase opacity-60 tracking-wide"
+                    )
+                    _render_preview(state, scan, opts)
+
+            # ── Right column: HRF source picker + status + visualization
+            with ui.column().classes("flex-1 min-w-0 gap-3"):
+                _render_hrf_source_column(state, scan, opts, bulk_mode)
+
+
+def _can_save(
+    state: AppState,
+    scan: Optional[ScanEntry],
+    checked_scans: List[ScanEntry],
+) -> bool:
+    """Whether a Save action is available: an in-memory result for the current
+    scan, or one or more checked scans to estimate-and-save in bulk."""
+    has_current = state.activity_raw is not None and scan is not None
+    can_mass = len(checked_scans) >= 1
+    return has_current or can_mass
+
+
+def _render_save_options(
+    state: AppState,
+    scan: Optional[ScanEntry],
+    checked_scans: List[ScanEntry],
+    naming: dict,
+) -> None:
+    """Filename postfix + format inputs for the Save action.
+
+    Rendered as a subsection at the bottom of the Deconvolution card; the
+    Save button itself lives in the run row beside Estimate. Shares ``naming``
+    with that button so the chosen postfix / format reach the save call.
+    """
+    if not _can_save(state, scan, checked_scans):
+        return
+    ui.separator()
+    ui.label("Save deconvolved output").classes(
+        "text-xs uppercase opacity-60 tracking-wide"
+    )
+    with ui.row().classes("items-center gap-3 flex-wrap"):
+        ui.input(
+            label="Filename postfix",
+            value=naming["postfix"],
+            on_change=lambda e: naming.__setitem__("postfix", e.value or ""),
+        ).props("dense outlined").classes("w-44")
+        ui.select(
+            {".snirf": "SNIRF (.snirf)", ".fif": "FIF (.fif)"},
+            value=naming["ext"],
+            label="Format",
+            on_change=lambda e: naming.__setitem__("ext", e.value or ".snirf"),
+        ).props("dense outlined").classes("w-40")
+
+
+def _render_save_button(
+    state: AppState,
+    scan: Optional[ScanEntry],
+    checked_scans: List[ScanEntry],
+    naming: dict,
+) -> None:
+    """The Save button (rendered beside Estimate in the run row).
+
+    Save is INDEPENDENT of Estimate — it writes results that already exist, it
+    never re-estimates. With scans checked it's a batch: save every checked
+    scan that has been estimated (``state.activity_cache``) to a folder;
+    otherwise it saves the single in-memory deconvolved result for the current
+    scan. When checked scans exist but none have been estimated yet, the button
+    is disabled with a hint. Filename postfix / format come from ``naming``.
+    """
+    has_current = state.activity_raw is not None and scan is not None
+    bulk_mode = len(checked_scans) >= 1
+
+    if bulk_mode:
+        cached = [s for s in checked_scans if s in state.activity_cache]
+        if not cached:
+            ui.button("Save", icon="save").props(
+                "outline color=primary disable"
+            ).tooltip(
+                "Estimate the checked scans first — Save does not re-estimate."
             )
+            return
 
-        # ── Mode + parameter controls
-        with ui.card().classes("w-full"):
-            ui.label("Estimation").classes(
-                "text-xs uppercase opacity-60 tracking-wide"
-            )
-            _render_model_radio(state, opts)
-            _render_lmbda_slider(opts)
+        async def _save() -> None:
+            await _mass_save_activity(state, cached, naming)
 
-            if opts.hrf_model == MODEL_TOEPLITZ and scan is not None:
-                _render_toeplitz_requirements(state, scan)
-
-        # ── Run row + progress + errors
-        _render_run_row(state, scan, checked_scans, opts)
-
-        # ── Preview (single-scan only -- bulk overwrites activity_raw).
-        # Gate on activity_source_scan: activity_raw is a single global slot
-        # that is NOT cleared when the selected scan changes, so without this
-        # check the preview overlays scan A's deconvolved Raw against scan B's
-        # preprocessed Raw (channel names overlap across a shared montage, so
-        # the mismatch renders silently rather than erroring).
-        activity_matches = (
-            scan is not None
-            and state.activity_source_scan is not None
-            and state.activity_source_scan.path == scan.path
+        n = len(cached)
+        ui.button(
+            "Save", icon="save", on_click=_save,
+        ).props(
+            f"outline color=primary {'disable' if state.busy else ''}"
+        ).tooltip(
+            f"Saves {n} already-estimated scan"
+            f"{'s' if n != 1 else ''} to a folder (no re-estimation)."
         )
-        if state.activity_raw is not None and activity_matches and not bulk_mode:
-            ui.separator()
-            ui.label("Deconvolved preview").classes(
-                "text-xs uppercase opacity-60 tracking-wide"
-            )
-            _render_preview(state, scan, opts)
+        return
+
+    if has_current:
+        async def _save() -> None:
+            from .export_panel import _save_activity
+            await _save_activity(state, scan, naming)
+
+        ui.button(
+            "Save", icon="save", on_click=_save,
+        ).props("outline color=primary").tooltip(
+            "Saves the deconvolved current scan."
+        )
 
 
 def _resolve_checked_scans(state: AppState) -> List[ScanEntry]:
@@ -200,18 +379,255 @@ def _resolve_checked_scans(state: AppState) -> List[ScanEntry]:
     ]
 
 
-def _render_model_radio(state: AppState, opts: ActivityOptions) -> None:
-    def _set(value: str) -> None:
+def _render_hrf_source_column(
+    state: AppState,
+    scan: Optional[ScanEntry],
+    opts: ActivityOptions,
+    bulk_mode: bool,
+) -> None:
+    """Right column: pick the HRF source, show its readiness, preview it.
+
+    ``estimate_activity`` supports three sources:
+
+    - **Estimated HRFs** (toeplitz): the per-channel HRFs from the HRFs tab
+      (``state.montage``). If none are in memory / they're for another scan,
+      the column says so and offers a "Go to HRFs tab" jump.
+    - **HRtree HRF** (library): a single HRF selected in the HRtree tab, used
+      as the kernel for every channel. Offers a "Go to HRtree tab" jump when
+      nothing is selected.
+    - **Canonical reference** (canonical): a fixed SPM double-gamma from the
+      bundled library — always available, no estimation required.
+
+    The selector sits at the top; the body below reflects the choice so the
+    user can always see which HRFs the deconvolution will actually use.
+    """
+    ui.label("HRF source").classes(
+        "text-xs uppercase opacity-60 tracking-wide"
+    )
+
+    def _set_source(value: str) -> None:
         opts.hrf_model = value
-        # Trigger a body re-render so toeplitz-requirements text appears/
-        # disappears with the selection.
+        # Re-render the body so the readout (left) and status (right) track
+        # the new source.
         state.publish("scan_selected", state.selected_scan)
 
     ui.radio(
-        [MODEL_TOEPLITZ, MODEL_CANONICAL],
+        SOURCE_LABELS,
         value=opts.hrf_model,
-        on_change=lambda e: _set(e.value),
-    ).props("inline")
+        on_change=lambda e: _set_source(e.value),
+    ).props("dense").classes("w-full")
+
+    ui.separator()
+
+    if opts.hrf_model == MODEL_TOEPLITZ:
+        _render_estimated_source_status(state, scan, bulk_mode)
+    elif opts.hrf_model == MODEL_LIBRARY:
+        _render_library_source_status(state)
+    else:
+        _render_canonical_source_status(state, scan)
+
+
+def _go_to_hrfs_button(state: AppState) -> None:
+    """A "Go to HRFs tab" jump button (publishes ``navigate_estimate``)."""
+    with ui.row().classes("items-center gap-2"):
+        ui.icon("arrow_forward").classes("text-primary")
+        ui.button(
+            "Go to HRFs tab to estimate",
+            icon="show_chart",
+            on_click=lambda: state.publish("navigate_estimate"),
+        ).props("flat dense color=primary")
+
+
+def _go_to_hrtree_button(state: AppState) -> None:
+    """A "Go to HRtree tab" jump button (publishes ``navigate_hrtree``)."""
+    with ui.row().classes("items-center gap-2"):
+        ui.icon("arrow_forward").classes("text-primary")
+        ui.button(
+            "Go to HRtree tab to select",
+            icon="account_tree",
+            on_click=lambda: state.publish("navigate_hrtree"),
+        ).props("flat dense color=primary")
+
+
+def _render_library_source_status(state: AppState) -> None:
+    """Status + preview for the "HRtree HRF" (library) source.
+
+    Uses the HRF currently selected in the HRtree tab
+    (``state.library_selected_hrf``) as the single deconvolution kernel for
+    every channel. Prompts the user to the HRtree tab when nothing is picked.
+    """
+    hrf = getattr(state, "library_selected_hrf", None)
+    kernel = _library_kernel_from_state(state)
+
+    if kernel is None:
+        ui.label(
+            "No HRtree HRF selected yet."
+        ).classes("text-sm opacity-70")
+        ui.label(
+            "Open the HRtree tab and click an HRF in the 3D view; it will be "
+            "used as the deconvolution kernel for every channel."
+        ).classes("text-xs opacity-60")
+        _go_to_hrtree_button(state)
+        return
+
+    trace, oxy = kernel
+    key = hrf.get("_key", "") if isinstance(hrf, dict) else ""
+    ui.label(
+        f"Using the HRtree HRF: {key or '(selected HRF)'}"
+    ).classes("text-sm opacity-70")
+    ui.label(
+        f"{'HbO' if oxy else 'HbR'} source · applied to every channel "
+        "(sign-flipped for the opposite oxygenation)."
+    ).classes("text-xs opacity-60")
+    _go_to_hrtree_button(state)
+
+    # Preview the selected kernel shape (reuse the canonical PNG renderer —
+    # it just plots a trace at a given sfreq/duration).
+    try:
+        from .hrf_panel import (
+            _CanonicalResult as _CR,
+            _render_canonical_preview_png,
+        )
+        sfreq = float(hrf.get("sfreq", 0)) if isinstance(hrf, dict) else 0.0
+        if sfreq <= 0:
+            sfreq = 7.81
+        arr = np.asarray(trace, dtype=float)
+        duration = len(arr) / sfreq if sfreq else 30.0
+        png = _render_canonical_preview_png(
+            _CR(canonical_trace=arr, duration=duration, sfreq=sfreq)
+        )
+        if png is not None:
+            ui.image(png).classes("max-w-md")
+            ui.label(
+                "Selected HRtree HRF (mean trace)."
+            ).classes("text-xs opacity-50")
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("HRtree kernel preview failed: %s", exc)
+
+
+def _safe_render_gallery(state: AppState, montage) -> None:
+    """Render the per-channel HRF accordion; never blank the panel on error."""
+    try:
+        from .hrf_panel import _render_toeplitz_gallery
+        _render_toeplitz_gallery(state, montage)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("activity HRF-source gallery render failed: %s", exc)
+        ui.label("HRF preview unavailable.").classes("text-sm opacity-60")
+
+
+def _render_estimated_source_status(
+    state: AppState, scan: Optional[ScanEntry], bulk_mode: bool
+) -> None:
+    """Status + preview for the "Estimated HRFs" (toeplitz) source.
+
+    HRFs are cached per scan (``state.montage_cache``), so each scan is
+    deconvolved with its OWN HRFs — single or bulk. Reports this scan's
+    readiness (single mode) or a batch summary (bulk mode).
+    """
+    if bulk_mode:
+        n_cached = len(state.montage_cache)
+        ui.label(
+            "Each checked scan is deconvolved with its own estimated HRFs. "
+            f"{n_cached} scan(s) currently have estimated HRFs; checked scans "
+            "without them are skipped — estimate HRFs for them first."
+        ).classes("text-xs opacity-70 italic")
+        if n_cached == 0:
+            _go_to_hrfs_button(state)
+        montage = _montage_for_scan(state, scan)
+        if montage is not None:
+            _safe_render_gallery(state, montage)
+        return
+
+    montage = _montage_for_scan(state, scan)
+    if montage is not None:
+        ui.label("Using HRFs estimated for this scan.").classes(
+            "text-sm opacity-70"
+        )
+        _safe_render_gallery(state, montage)
+        return
+
+    # Not ready for this scan — tailor the message.
+    if isinstance(state.montage, _CanonicalResult) and not state.montage_cache:
+        ui.label(
+            "Toeplitz mode requires real per-channel HRFs, but the HRFs tab "
+            "last produced a canonical reference shape."
+        ).classes("text-sm opacity-70")
+        ui.label(
+            "Re-run the HRFs tab in toeplitz mode, or switch the source above "
+            "to canonical."
+        ).classes("text-xs opacity-60")
+        _go_to_hrfs_button(state)
+        return
+
+    any_estimated = bool(state.montage_cache) or (
+        state.montage is not None
+        and not isinstance(state.montage, _CanonicalResult)
+    )
+    if not any_estimated:
+        ui.label(
+            "Toeplitz mode requires estimated HRFs — none have been estimated "
+            "yet."
+        ).classes("text-sm opacity-70")
+        ui.label(
+            "Estimate per-channel HRFs first, then return here to deconvolve "
+            "activity with them."
+        ).classes("text-xs opacity-60")
+    else:
+        ui.label(
+            "No estimated HRFs for this scan."
+        ).classes("text-sm opacity-70")
+        ui.label(
+            "Estimate HRFs for this scan (toeplitz), or switch the source "
+            "above to canonical."
+        ).classes("text-xs opacity-60")
+    _go_to_hrfs_button(state)
+
+
+def _render_canonical_source_status(
+    state: AppState, scan: Optional[ScanEntry]
+) -> None:
+    """Status + illustrative curve for the canonical-reference source."""
+    ui.label(
+        "Using the canonical reference HRF — an SPM-style double-gamma shape "
+        "from the bundled library. No estimation needed; works on every scan."
+    ).classes("text-sm opacity-70")
+
+    try:
+        from .hrf_panel import (
+            _CanonicalResult as _CR,
+            _render_canonical_preview_png,
+            canonical_double_gamma,
+        )
+        sfreq = _representative_sfreq(state, scan)
+        trace = canonical_double_gamma(30.0, sfreq)
+        png = _render_canonical_preview_png(
+            _CR(canonical_trace=trace, duration=30.0, sfreq=sfreq)
+        )
+        if png is not None:
+            ui.image(png).classes("max-w-md")
+            ui.label(
+                "Representative shape (30 s window)."
+            ).classes("text-xs opacity-50")
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("canonical source preview failed: %s", exc)
+
+
+def _representative_sfreq(
+    state: AppState, scan: Optional[ScanEntry]
+) -> float:
+    """Best-effort sampling rate for the illustrative canonical curve.
+
+    Prefer the scan's processed / raw sfreq when already cached (no load
+    forced); fall back to a sensible fNIRS default otherwise.
+    """
+    if scan is not None:
+        for cache in (state.processed_cache, state.raw_cache):
+            try:
+                if scan in cache:
+                    return float(cache.get(scan).info["sfreq"])
+            except Exception:  # noqa: BLE001
+                continue
+    return 7.81  # typical NIRx sampling rate; illustrative only
 
 
 def _render_lmbda_slider(opts: ActivityOptions) -> None:
@@ -239,50 +655,41 @@ def _render_lmbda_slider(opts: ActivityOptions) -> None:
     )
 
 
-def _render_toeplitz_requirements(state: AppState, scan: ScanEntry) -> None:
-    """Surface the toeplitz-mode dependency on a real estimated Montage.
+def _render_deconv_controls(opts: ActivityOptions) -> None:
+    """Per-channel timeout + drop-failed-channels controls.
 
-    Three blocking conditions:
-    - No Montage yet (HRFs tab not run).
-    - Montage is a _CanonicalResult (HRFs tab last ran in canonical mode,
-      which doesn't produce per-channel traces toeplitz needs).
-    - Montage was produced for a different scan than the one currently
-      selected (Sprint 3.4 review: applying scan A's HRFs to scan B's
-      Raw silently produces wrong results because the library matches
-      by channel name, not scan identity).
+    Both forward to montage.estimate_activity. The timeout bounds each
+    channel's lstsq solve; "Drop failed channels" keeps the scan with its
+    surviving channels when a channel errors (the default) rather than
+    failing the whole scan.
     """
-    montage = state.montage
-    if montage is None:
-        ui.label(
-            "Toeplitz mode requires estimated HRFs from this scan. Run the "
-            "HRFs tab in toeplitz mode first."
-        ).classes("text-sm opacity-70")
-    elif isinstance(montage, _CanonicalResult):
-        ui.label(
-            "Toeplitz mode requires real per-channel HRFs, but the HRFs tab "
-            "last produced a canonical reference shape. Re-run the HRFs tab "
-            "in toeplitz mode or switch the model selector below to "
-            "canonical."
-        ).classes("text-sm opacity-70")
-    elif (
-        state.montage_source_scan is None
-        or state.montage_source_scan.path != scan.path
-    ):
-        source_label = (
-            state.montage_source_scan.display_name
-            or state.montage_source_scan.path.name
-            if state.montage_source_scan is not None
-            else "another scan"
+    with ui.row().classes("items-center gap-3 flex-wrap"):
+        def _on_timeout(event) -> None:
+            try:
+                opts.timeout = max(1.0, float(event.value))
+            except (TypeError, ValueError):
+                opts.timeout = DEFAULT_TIMEOUT
+
+        ui.number(
+            label="Per-channel timeout (s)",
+            value=opts.timeout,
+            min=1.0,
+            step=5.0,
+            format="%.0f",
+            on_change=_on_timeout,
+        ).props("dense outlined").classes("w-48").tooltip(
+            "Seconds to wait for one channel's solve before dropping it."
         )
-        ui.label(
-            f"The current HRFs were estimated from {source_label}, not this "
-            f"scan. Re-run the HRFs tab on this scan in toeplitz mode, or "
-            f"switch the model selector below to canonical."
-        ).classes("text-sm opacity-70")
-    else:
-        ui.label(
-            "Using HRFs estimated in the HRFs tab."
-        ).classes("text-sm opacity-60")
+        ui.checkbox(
+            "Drop failed channels",
+            value=opts.drop_failed_channels,
+            on_change=lambda e: setattr(
+                opts, "drop_failed_channels", bool(e.value)
+            ),
+        ).props("dense").tooltip(
+            "On: a channel that fails is dropped and the scan keeps its good "
+            "channels. Off: any channel failure fails the whole scan."
+        )
 
 
 def _render_run_row(
@@ -290,13 +697,15 @@ def _render_run_row(
     scan: Optional[ScanEntry],
     checked: List[ScanEntry],
     opts: ActivityOptions,
+    naming: dict,
 ) -> None:
-    """Render the Run button row + progress / error display.
+    """Render the Estimate + Save buttons (same row) + progress / errors.
 
     PR #55a: dispatches single vs bulk based on the checked set. Bulk
     button is enabled whenever there's no in-flight task; per-scan gates
     (raw + montage match) are evaluated inside the worker and incompatible
-    scans are skipped.
+    scans are skipped. The Save button sits on the same horizontal level
+    (filename options come from the Deconvolution card via ``naming``).
     """
     bulk_mode = bool(checked)
     if bulk_mode:
@@ -306,18 +715,26 @@ def _render_run_row(
         )
         can_run = not state.busy
     else:
-        raw_ready = scan is not None and scan in state.processed_cache
+        # Activity deconvolution must run on deconvolution-preprocessed data
+        # (not the GLM/haemoglobin pipeline), so require the scan to be in
+        # processed_deconvolved as well as the cache.
+        raw_ready = (
+            scan is not None
+            and scan in state.processed_cache
+            and scan.path.resolve() in state.processed_deconvolved
+        )
         if opts.hrf_model == MODEL_TOEPLITZ:
-            montage_ready = state.montage is not None and not isinstance(
-                state.montage, _CanonicalResult
-            )
-            scan_matches = (
-                state.montage_source_scan is not None
-                and scan is not None
-                and state.montage_source_scan.path == scan.path
-            )
+            # This scan needs its own estimated HRFs (per-scan cache).
             can_run = (
-                raw_ready and montage_ready and scan_matches
+                raw_ready
+                and _montage_for_scan(state, scan) is not None
+                and not state.busy
+            )
+        elif opts.hrf_model == MODEL_LIBRARY:
+            # Library mode needs an HRtree HRF selected as the kernel.
+            can_run = (
+                raw_ready
+                and _library_kernel_from_state(state) is not None
                 and not state.busy
             )
         else:
@@ -330,15 +747,14 @@ def _render_run_row(
             on_click=lambda: _run_dispatch(state, scan, checked, opts),
         ).props(f"color=primary {'disable' if not can_run else ''}")
 
+        # Save sits on the same horizontal level as Estimate.
+        _render_save_button(state, scan, checked, naming)
+
         if state.busy:
             _render_busy_progress(state)
         elif not bulk_mode and scan is not None and scan not in state.processed_cache:
-            # Activity deconvolution runs on the *preprocessed* signal, so
-            # the Run button is disabled until the scan has been through the
-            # Preprocess tab. Spell that out and link straight there rather
-            # than leaving a disabled button with no explanation. The link
-            # goes through the event bus (navigate_preprocess) so this panel
-            # doesn't need a reference to the shell's tab control.
+            # Not preprocessed yet — link straight to the Preprocess tab via
+            # the event bus (no reference to the shell's tab control needed).
             with ui.row().classes("items-center gap-2"):
                 ui.icon("info").classes("text-amber-500")
                 ui.label(
@@ -350,6 +766,17 @@ def _render_run_row(
                     icon="arrow_forward",
                     on_click=lambda: state.publish("navigate_preprocess"),
                 ).props("flat dense color=primary")
+        elif (
+            not bulk_mode and scan is not None
+            and scan.path.resolve() not in state.processed_deconvolved
+        ):
+            # Preprocessed, but GLM/haemoglobin mode — activity needs the
+            # deconvolution pipeline.
+            ui.label(
+                "This scan was preprocessed for haemoglobin (GLM). Neural-"
+                "activity estimation needs the deconvolution pipeline — re-"
+                "preprocess it in deconvolution mode (Preprocess tab)."
+            ).classes("text-sm text-amber-400")
 
     if state.last_error and not state.busy:
         with ui.row().classes("items-center gap-2"):
@@ -410,6 +837,56 @@ def _run_dispatch(
         _run(state, selected, opts)
 
 
+def _montage_for_scan(state: AppState, scan: Optional[ScanEntry]):
+    """The per-channel Montage to use for toeplitz activity on ``scan``.
+
+    Prefers the scan's own cached montage (``state.montage_cache``, populated
+    by every HRF estimate), so toeplitz works per-scan across single and bulk
+    runs. Falls back to the single most-recent ``state.montage`` when it was
+    estimated for this exact scan. Returns None when neither applies.
+    """
+    if scan is None:
+        return None
+    cached = state.montage_cache.get(scan.path.resolve())
+    if cached is not None:
+        return cached
+    if (
+        state.montage is not None
+        and not isinstance(state.montage, _CanonicalResult)
+        and state.montage_source_scan is not None
+        and state.montage_source_scan.path == scan.path
+    ):
+        return state.montage
+    return None
+
+
+def _toeplitz_skip_reason(state: AppState, scan: ScanEntry) -> Optional[str]:
+    """Why this scan can't be deconvolved in toeplitz mode, or None if it can.
+
+    Toeplitz activity needs this scan's own estimated per-channel HRFs. Each
+    scan's montage is cached when HRFs are estimated (single or bulk), so a
+    scan qualifies once it's been estimated. Returns a user-facing reason for
+    the bulk worker to log when it hasn't.
+    """
+    if _montage_for_scan(state, scan) is not None:
+        return None
+    # Nothing estimated anywhere vs. estimated-but-not-this-scan: tailor the hint.
+    any_estimated = bool(state.montage_cache) or (
+        state.montage is not None
+        and not isinstance(state.montage, _CanonicalResult)
+    )
+    if not any_estimated:
+        return (
+            "toeplitz mode needs per-channel HRFs, but none have been "
+            "estimated — estimate HRFs on the HRFs tab first, or switch this "
+            "run to canonical mode (works on every scan)"
+        )
+    return (
+        "no estimated HRFs for this scan — estimate HRFs for it on the HRFs "
+        "tab, or use canonical mode"
+    )
+
+
 def _run_bulk(
     state: AppState,
     scans: List[ScanEntry],
@@ -430,50 +907,64 @@ def _run_bulk(
     if state.busy:
         return
 
-    snapshot = ActivityOptions(
-        hrf_model=opts.hrf_model,
-        lmbda=opts.lmbda,
-        preview_channel=opts.preview_channel,
-    )
+    snapshot = _snapshot_options(state, opts)
 
     def _build(scan: ScanEntry):
-        if scan not in state.processed_cache:
-            return None
         if snapshot.hrf_model == MODEL_TOEPLITZ:
-            if state.montage is None or isinstance(
-                state.montage, _CanonicalResult
-            ):
-                return None
-            if (
-                state.montage_source_scan is None
-                or state.montage_source_scan.path != scan.path
-            ):
-                return None
-            existing_montage = state.montage
+            reason = _toeplitz_skip_reason(state, scan)
+            if reason is not None:
+                return reason  # intentional skip carrying its reason
+            existing_montage = _montage_for_scan(state, scan)
+        elif snapshot.hrf_model == MODEL_LIBRARY:
+            if snapshot.library_trace is None:
+                return (
+                    "no HRtree HRF selected — pick one in the HRtree tab to "
+                    "use as the deconvolution kernel"
+                )
+            existing_montage = None
         else:
             existing_montage = None
 
-        raw = state.processed_cache.get(scan)
         progress_cb = make_progress_callback(state)
-        return (
-            run_activity_sync,
-            (raw, snapshot, existing_montage, progress_cb),
-            {},
-        )
+
+        def _pp_and_estimate(
+            scan=scan, existing_montage=existing_montage, progress_cb=progress_cb,
+        ):
+            # Preprocess on demand (deconvolution) if needed, so the bulk run
+            # triggers the preprocessing each scan needs instead of skipping.
+            # ensure_deconvolved_raw raises a specific reason on failure.
+            from .preprocess_panel import ensure_deconvolved_raw
+            raw = ensure_deconvolved_raw(state, scan)
+            return run_activity_sync(raw, snapshot, existing_montage, progress_cb)
+
+        return (_pp_and_estimate, (), {})
 
     async def _on_each_done(scan: ScanEntry, result) -> None:
         if result is None:
-            return
+            # Raise so an empty deconvolution is reported as a failure with a
+            # reason instead of being silently counted as a success.
+            raise RuntimeError(
+                "deconvolution produced no channels — every channel was "
+                "dropped (check the scan's HRFs and preprocessing)"
+            )
         state.activity_raw = result
+        # Cache per scan so channel-wise 3-stage QC can read each scan's
+        # deconvolution (activity_raw only holds the most-recent one).
+        state.activity_cache._cache[scan.path.resolve()] = result
+        # Track which scan produced activity_raw so the preview won't overlay
+        # one scan's deconvolution against another's preprocessed Raw.
         state.activity_source_scan = scan
         state.publish("activity_estimated", scan)
 
+    client = capture_client()
+
     async def _bulk() -> None:
-        bulk_result = await run_bulk_in_background(
-            state, scans, _build,
-            on_each_done=_on_each_done,
-            label="estimate_activity",
-        )
+        with client_scope(client):
+            bulk_result = await run_bulk_in_background(
+                state, scans, _build,
+                on_each_done=_on_each_done,
+                label="estimate_activity",
+            )
         if bulk_result is None:
             return
         successes, failures = bulk_result
@@ -482,14 +973,109 @@ def _run_bulk(
             f"Estimated activity for {n_ok}/{n_ok + n_fail} scan(s)."
         )
         if failures:
-            fail_names = ", ".join(
-                s.display_name or s.path.name for s, _ in failures[:3]
+            summary += f" Failed/skipped: {summarize_failures(failures)}"
+        # Guarded: the page client may have been deleted during a long run.
+        notify_if_alive(
+            client, summary,
+            type="positive" if n_fail == 0 else "warning",
+            multi_line=True,
+            close_button=True,
+        )
+
+    background_tasks.create(_bulk())
+
+
+async def _mass_save_activity(
+    state: AppState,
+    scans: List[ScanEntry],
+    naming: dict,
+) -> None:
+    """Save the ALREADY-estimated activity for each scan, colocated with its
+    source file.
+
+    For a batch there's no file dialog: each deconvolved scan is written into
+    the SAME folder as its source as ``<stem><postfix><ext>``, after a single
+    confirmation showing the filename format and how many scans will be saved.
+    Save is independent of Estimate — it writes each scan's cached
+    deconvolution (``state.activity_cache``) and never re-estimates; scans
+    with no cached result are skipped with a clear "not estimated yet" reason.
+    Continue-on-error with a final summary toast.
+    """
+    if state.busy:
+        return
+    from .export_panel import _save_raw
+
+    postfix = naming.get("postfix", "_deconvolved")
+    ext = naming.get("ext", ".snirf")
+    n = len(scans)
+    example = f"{scans[0].path.stem}{postfix}{ext}" if scans else f"<scan>{postfix}{ext}"
+
+    # Confirm rather than open a file dialog: each scan saves next to its
+    # source (colocated), so there's no destination to pick.
+    with ui.dialog() as dialog, ui.card().classes("gap-2"):
+        ui.label("Save deconvolved scans").classes("text-base font-semibold")
+        ui.label(
+            f"{n} deconvolved scan{'s' if n != 1 else ''} will be saved next "
+            "to each source file (same folder)."
+        ).classes("text-sm")
+        ui.label(f"Filename format:  <scan>{postfix}{ext}").classes(
+            "text-xs font-mono opacity-70"
+        )
+        ui.label(f"e.g.  {example}").classes("text-xs font-mono opacity-50")
+        with ui.row().classes("justify-end gap-2 w-full"):
+            ui.button("Cancel", on_click=lambda: dialog.submit(False)).props("flat")
+            ui.button("Save", icon="save", on_click=lambda: dialog.submit(True)).props(
+                "color=primary"
             )
-            if len(failures) > 3:
-                fail_names += f" (+{len(failures) - 3} more)"
-            summary += f" Failed/skipped: {fail_names}."
-        ui.notify(
-            summary, type="positive" if n_fail == 0 else "warning"
+    confirmed = await dialog
+    if not confirmed:
+        return
+
+    def _build(scan: ScanEntry):
+        # Save only — never estimate. Skip scans that haven't been run yet.
+        if scan not in state.activity_cache:
+            return (
+                "not estimated yet — run Estimate first (Save does not "
+                "re-estimate)"
+            )
+        result = state.activity_cache.get(scan)
+        # Colocated: write next to the source scan.
+        out_path = scan.path.parent / f"{scan.path.stem}{postfix}{ext}"
+
+        def _save_only(result=result, out_path=out_path):
+            try:
+                _save_raw(result, out_path)
+            except Exception as exc:  # noqa: BLE001 — disk/format failure
+                raise RuntimeError(
+                    f"could not write {out_path.name} "
+                    f"({type(exc).__name__}: {exc})"
+                ) from exc
+            return out_path
+
+        return (_save_only, (), {})
+
+    client = capture_client()
+
+    async def _bulk() -> None:
+        with client_scope(client):
+            bulk_result = await run_bulk_in_background(
+                state, scans, _build, label="save_activity",
+            )
+        if bulk_result is None:
+            return
+        successes, failures = bulk_result
+        n_ok, n_fail = len(successes), len(failures)
+        summary = (
+            f"Saved {n_ok}/{n_ok + n_fail} deconvolved scan(s) next to their "
+            "source files."
+        )
+        if failures:
+            summary += f" Failed/skipped: {summarize_failures(failures)}"
+        notify_if_alive(
+            client, summary,
+            type="positive" if n_fail == 0 else "warning",
+            multi_line=True,
+            close_button=True,
         )
 
     background_tasks.create(_bulk())
@@ -510,44 +1096,47 @@ def _run(
     if scan not in state.processed_cache:
         state.last_error = "Preprocess the scan first."
         return
+    if scan.path.resolve() not in state.processed_deconvolved:
+        state.last_error = (
+            "Neural-activity estimation requires deconvolution-mode "
+            "preprocessing — re-preprocess this scan with deconvolution."
+        )
+        return
 
     if opts.hrf_model == MODEL_TOEPLITZ:
-        if state.montage is None:
-            state.last_error = "Estimate HRFs (toeplitz mode) first."
-            return
-        if isinstance(state.montage, _CanonicalResult):
+        # Use this scan's own estimated HRFs (per-scan cache), so it works
+        # whether the scan was estimated singly or as part of a bulk run.
+        if _montage_for_scan(state, scan) is None:
             state.last_error = (
-                "Toeplitz activity needs real estimated HRFs; the HRFs tab "
-                "last produced a canonical reference. Re-run HRFs in "
-                "toeplitz mode."
+                "No estimated HRFs for this scan. Estimate HRFs for it on the "
+                "HRFs tab (toeplitz mode), or switch the source to canonical."
             )
             return
-        if (
-            state.montage_source_scan is None
-            or state.montage_source_scan.path != scan.path
-        ):
+    elif opts.hrf_model == MODEL_LIBRARY:
+        if _library_kernel_from_state(state) is None:
             state.last_error = (
-                "The HRFs in memory were estimated for a different scan. "
-                "Re-run the HRFs tab on this scan in toeplitz mode first."
+                "Select an HRF in the HRtree tab to use as the deconvolution "
+                "kernel first."
             )
             return
 
-    snapshot = ActivityOptions(
-        hrf_model=opts.hrf_model,
-        lmbda=opts.lmbda,
-        preview_channel=opts.preview_channel,
-    )
+    snapshot = _snapshot_options(state, opts)
 
     raw = state.processed_cache.get(scan)
     progress_cb = make_progress_callback(state)
     existing_montage = (
-        state.montage if snapshot.hrf_model == MODEL_TOEPLITZ else None
+        _montage_for_scan(state, scan)
+        if snapshot.hrf_model == MODEL_TOEPLITZ else None
     )
 
     async def _on_done(result) -> None:
         if result is None:
             return
         state.activity_raw = result
+        # Cache per scan so channel-wise 3-stage QC can read this scan's
+        # deconvolution later (activity_raw only holds the most-recent one).
+        state.activity_cache._cache[scan.path.resolve()] = result
+        # Track which scan produced activity_raw (preview gate uses it).
         state.activity_source_scan = scan
         state.publish("activity_estimated", scan)
 
@@ -586,8 +1175,10 @@ def run_activity_sync(
     611) does not corrupt ``state.montage`` for the HRFs tab. The
     returned Raw still reflects whichever channels survived deconvolution.
 
-    For canonical mode, ``existing_montage`` is ignored and a fresh Montage
-    is configured to the scan.
+    For canonical and library modes, ``existing_montage`` is ignored and a
+    fresh Montage is configured to the scan. Library mode deconvolves every
+    channel with ``opts.library_trace`` (an HRtree selection), oriented by
+    ``opts.library_oxygenation``.
 
     Module-level so tests can call it without dispatching through workers.
     """
@@ -596,7 +1187,8 @@ def run_activity_sync(
     work_raw = raw.copy()
 
     snapshot = None
-    if opts.hrf_model == MODEL_CANONICAL or existing_montage is None:
+    fresh_montage_models = (MODEL_CANONICAL, MODEL_LIBRARY)
+    if opts.hrf_model in fresh_montage_models or existing_montage is None:
         m = Montage(nirx_obj=work_raw)
     else:
         m = existing_montage
@@ -610,6 +1202,14 @@ def run_activity_sync(
             "hbr_channels": list(getattr(m, "hbr_channels", [])),
         }
 
+    estimate_kwargs = {
+        "timeout": opts.timeout,
+        "drop_failed_channels": opts.drop_failed_channels,
+    }
+    if opts.hrf_model == MODEL_LIBRARY:
+        estimate_kwargs["library_trace"] = opts.library_trace
+        estimate_kwargs["library_oxygenation"] = opts.library_oxygenation
+
     try:
         result = m.estimate_activity(
             work_raw,
@@ -617,6 +1217,7 @@ def run_activity_sync(
             hrf_model=opts.hrf_model,
             preprocess=False,
             progress_callback=progress_callback,
+            **estimate_kwargs,
         )
     finally:
         if snapshot is not None:

--- a/src/hrfunc/gui/components/dataset_tree.py
+++ b/src/hrfunc/gui/components/dataset_tree.py
@@ -235,6 +235,11 @@ def render(
         # Re-render so the Select-all checkbox indeterminate / checked
         # display tracks the new set without waiting on another event.
         _tree_body.refresh()
+        # Notify the action panels so they recompute bulk mode — without
+        # this, ticking scans never makes them eligible for a bulk
+        # Preprocess / HRF / Activity run (the panels only re-render on
+        # their subscribed events, none of which fired on a tick).
+        state.publish("checked_changed", state.checked_scan_paths)
 
     @ui.refreshable
     def _tree_body() -> None:
@@ -271,6 +276,7 @@ def render(
                     state.checked_scan_paths - visible_paths
                 )
             _tree_body.refresh()
+            state.publish("checked_changed", state.checked_scan_paths)
 
         n_checked = sum(
             1 for p in visible_paths if p in state.checked_scan_paths
@@ -322,6 +328,17 @@ def render(
         on_change=_on_filter_change,
     ).props("dense clearable").classes("w-full")
     _tree_body()
+
+    # Cross-tab sync: each data tab (Preprocess / HRFs / Activity) mounts its
+    # OWN dataset tree, but they all share ``state.checked_scan_paths``. When
+    # one tab changes the checked set (tick / select-all here, or a panel that
+    # clears it), the other tabs' trees must re-render their visual ticks or
+    # they drift — e.g. the Activity bulk label reads "2 selected" while this
+    # tab's checkboxes show none. Refresh on ``checked_changed`` so every tree
+    # reflects the shared set. ``_tree_body.refresh()`` rebuilds the tree and
+    # re-applies ticks from state; programmatic ``tree.tick()`` does not emit
+    # ``on_tick``, so this can't loop with the tree that published the event.
+    state.subscribe("checked_changed", lambda _p=None: _tree_body.refresh())
 
 
 def find_scan(manifest: Optional[Manifest], path_id: str) -> Optional[ScanEntry]:

--- a/src/hrfunc/gui/components/export_panel.py
+++ b/src/hrfunc/gui/components/export_panel.py
@@ -250,12 +250,14 @@ async def _save_processed(state: AppState, scan) -> None:
         ui.notify(state.last_error, type="negative")
 
 
-async def _save_activity(state: AppState, scan) -> None:
+async def _save_activity(state: AppState, scan, naming=None) -> None:
     if state.activity_raw is None:
         state.last_error = "No activity scan available."
         return
+    postfix = (naming or {}).get("postfix", "_deconvolved")
+    ext = (naming or {}).get("ext", ".snirf")
     path = await _pick_save_path(
-        suggested=f"{scan.path.stem}_activity.snirf",
+        suggested=f"{scan.path.stem}{postfix}{ext}",
         title="Save activity scan",
     )
     if path is None:
@@ -358,15 +360,24 @@ async def _save_quality_csv(state: AppState) -> None:
 def _save_raw(raw: "mne.io.BaseRaw", path: Path) -> None:
     """Save an MNE Raw to SNIRF or FIF based on file extension.
 
-    MNE doesn't expose a single ``raw.save()`` that handles both formats;
-    ``mne.export.export_raw`` does SNIRF and the Raw's own ``.save()`` does
-    FIF. Dispatch on extension.
+    Core MNE has no SNIRF writer (``mne.export.export_raw`` only supports
+    bdf / brainvision / edf / eeglab, and ``read_raw_snirf`` is read-only),
+    so SNIRF is written via ``mne_nirs.io.write_raw_snirf`` (h5py opens the
+    file in "w" mode, so it overwrites). FIF uses the Raw's own ``.save()``.
+    Dispatch on extension.
     """
     raw.load_data()
     suffix = path.suffix.lower()
     if suffix == ".snirf":
-        import mne
-        mne.export.export_raw(str(path), raw, fmt="snirf", overwrite=True)
+        try:
+            from mne_nirs.io import write_raw_snirf
+        except Exception as exc:  # noqa: BLE001 — mne-nirs not installed
+            raise RuntimeError(
+                "SNIRF export needs the 'mne-nirs' package "
+                f"({type(exc).__name__}: {exc}). Install mne-nirs or save as "
+                ".fif instead."
+            ) from exc
+        write_raw_snirf(raw, str(path))
     elif suffix == ".fif":
         raw.save(str(path), overwrite=True, verbose="ERROR")
     else:

--- a/src/hrfunc/gui/components/hrf_panel.py
+++ b/src/hrfunc/gui/components/hrf_panel.py
@@ -12,6 +12,15 @@ Sprint 3.3 ships:
 - Controls: model radio (toeplitz/canonical), event picker (multi-select
   toggles), lambda slider on log scale (1e-5..1e-1, default 1e-3),
   duration field (default 30.0 s).
+
+Events can come from the scan's own MNE annotations OR an uploaded file
+(``events_io``: BIDS ``events.tsv`` or a simple ``onset,label`` CSV). An
+uploaded file overrides annotations for the scan it was loaded against, and
+for every scan when "apply to all checked scans" is set (shared paradigms).
+Onsets are converted to a per-scan impulse series, so one table fits scans
+of differing length. A wildcard box mass-selects labels by glob, and the
+Estimate button runs a coverage pre-flight that warns when a scan is too
+short to contain the events.
 - Result preview: matplotlib base64 PNG showing all estimated HRF traces
   overlaid by channel (toeplitz mode) or the canonical HRF (canonical mode).
 
@@ -51,12 +60,196 @@ import numpy as np
 from nicegui import background_tasks, ui
 
 from ..state import AppState
+from ..events_io import (
+    EventsParseError,
+    build_impulse_from_rows,
+    build_impulse_from_vector,
+    coverage_report,
+    coverage_report_vector,
+    discover_collocated_events,
+    find_event_files,
+    parse_events_file,
+)
 from ..workers import (
+    capture_client,
+    client_scope,
     make_progress_callback,
+    notify_if_alive,
     run_bulk_in_background,
     run_in_background,
+    summarize_failures,
 )
 from ...io.manifest import ScanEntry
+
+# Library default edge-expansion fraction in montage.estimate_hrf. Used to
+# estimate the dropped start-of-scan window for the coverage warning so it
+# matches what the core actually discards.
+_EDGE_EXPANSION = 0.15
+
+
+def _file_applies_to_scan(state: AppState, scan: Optional[ScanEntry]) -> bool:
+    """True when an uploaded events file should drive ``scan``'s estimation.
+
+    The file overrides embedded annotations for the scan it was uploaded
+    against (``events_source_scan``) always, and for every scan when
+    ``events_apply_all`` is set (shared paradigm across the batch).
+    """
+    if (state.events_rows is None and state.events_impulse is None) or scan is None:
+        return False
+    if state.events_apply_all:
+        return True
+    src = state.events_source_scan
+    return src is not None and src.path == scan.path
+
+
+def _event_labels_for_scan(
+    state: AppState, scan: Optional[ScanEntry], raw
+) -> List[str]:
+    """Available event labels for a scan — file labels when the file applies,
+    else the scan's own annotation descriptions. An impulse vector has the
+    single synthetic label "events"."""
+    if _file_applies_to_scan(state, scan):
+        if state.events_impulse is not None:
+            return ["events"]
+        return sorted({row.label for row in state.events_rows})
+    return sorted_unique_annotation_descriptions(raw)
+
+
+def _resolve_bulk_events(state: AppState, scan: ScanEntry, raw, snapshot):
+    """Resolve the events a *bulk* HRF run should use for one scan.
+
+    A bulk run can't lean on the single global events slot (it only holds one
+    scan's worth) or on the UI's single label selection — the single-scan path
+    fills those by auto-matching on selection, but checking a batch never
+    triggers that. So resolve each scan independently, mirroring the
+    single-scan precedence:
+
+      1. the manually-loaded file when it applies (apply-to-all paradigm, or
+         this is the upload's source scan) — keep the user's label selection;
+      2. else a collocated sidecar discovered for THIS scan (BIDS-strict then
+         lone-file) — use all of its conditions;
+      3. else the scan's own embedded annotations — use every description.
+
+    Returns ``(event_rows, event_impulse, selected_events)``. When all three
+    sources are empty the tuple is ``(None, None, ())`` so the caller can fail
+    the scan with a clear "no events found" reason instead of silently
+    estimating on an all-zero impulse.
+    """
+    if _file_applies_to_scan(state, scan):
+        return state.events_rows, state.events_impulse, snapshot.selected_events
+
+    all_paths = [s.path for s in state.manifest.scans] if state.manifest else []
+    found = discover_collocated_events(scan.path, all_paths)
+    if found is not None:
+        try:
+            parsed = parse_events_file(found)
+        except EventsParseError:
+            parsed = None
+        if parsed is not None:
+            if parsed.impulse is not None:
+                return None, list(parsed.impulse), ("events",)
+            return parsed.rows, None, tuple(parsed.labels())
+
+    # Fall back to this scan's own annotations (all descriptions).
+    return None, None, tuple(sorted_unique_annotation_descriptions(raw))
+
+
+def _maybe_automatch_events(
+    state: AppState, scan: Optional[ScanEntry], opts: EstimationOptions
+) -> None:
+    """Auto-match a collocated events file to ``scan`` on selection.
+
+    Fires when no loaded events cover this scan and the user hasn't opted it
+    out (manual upload / clear, or a prior empty discovery). BIDS-strict then
+    lone-file (see ``discover_collocated_events``). Loads silently with an
+    "auto-matched" badge the user can clear or override. A successful match is
+    NOT added to ``events_no_automatch`` so returning to the scan re-matches
+    it even after the single global slot was replaced by another scan.
+    """
+    if scan is None or _file_applies_to_scan(state, scan):
+        return
+    key = scan.path.resolve()
+    if key in state.events_no_automatch:
+        return
+    all_paths = [s.path for s in state.manifest.scans] if state.manifest else []
+    found = discover_collocated_events(scan.path, all_paths)
+    if found is None:
+        state.events_no_automatch.add(key)  # nothing here; don't re-scan
+        return
+    try:
+        parsed = parse_events_file(found)
+    except EventsParseError:
+        state.events_no_automatch.add(key)  # broken file; don't retry
+        return
+    _apply_parsed_events(state, opts, scan, parsed, is_auto=True)
+    state.events_apply_all = False
+    # Verbose: announce the auto-match (this fires once per scan — the match
+    # is memoized — so it isn't spammy). The not-found case is conveyed by
+    # the status banner ("scan annotations · none loaded from file").
+    ui.notify(
+        f"Auto-matched events: {found.name} ({_events_summary(parsed)}).",
+        type="positive",
+    )
+
+
+def _events_summary(parsed) -> str:
+    """One-line description of a parsed events file (format + counts)."""
+    if parsed.impulse is not None:
+        return f"impulse vector, {int(sum(parsed.impulse))} events"
+    return (
+        f"{parsed.fmt}, {len(parsed.rows)} onsets, "
+        f"{len(parsed.labels())} condition(s)"
+    )
+
+
+def _apply_parsed_events(
+    state: AppState,
+    opts: EstimationOptions,
+    scan: Optional[ScanEntry],
+    parsed,
+    *,
+    is_auto: bool,
+) -> None:
+    """Load an ``EventsParse`` into state (handles onset rows vs impulse vector).
+
+    Sets the source fields and seeds the selection. Caller owns
+    ``events_apply_all`` and ``events_no_automatch`` policy.
+    """
+    if parsed.impulse is not None:
+        state.events_impulse = list(parsed.impulse)
+        state.events_rows = None
+    else:
+        state.events_rows = parsed.rows
+        state.events_impulse = None
+    state.events_format = parsed.fmt
+    state.events_source_label = parsed.source_name
+    state.events_source_scan = scan
+    state.events_is_automatched = is_auto
+    opts.selected_events = tuple(parsed.labels())
+
+
+def _event_counts_for_scan(state: AppState, scan, raw) -> dict:
+    """Map each event label to its occurrence count, for the picker display.
+
+    Counts come from the uploaded file when it applies to ``scan``, else
+    from the scan's annotations. Surfacing counts makes a non-descriptive
+    marker (e.g. a numeric SNIRF trigger labelled "1.0") read as an event
+    with N occurrences rather than a mystery checkbox.
+    """
+    from collections import Counter
+
+    if _file_applies_to_scan(state, scan):
+        if state.events_impulse is not None:
+            return {"events": int(sum(state.events_impulse))}
+        return dict(Counter(row.label for row in state.events_rows))
+    counts: dict = {}
+    annotations = getattr(raw, "annotations", None)
+    if annotations is not None:
+        for ann in annotations:
+            description = str(ann["description"])
+            if description:
+                counts[description] = counts.get(description, 0) + 1
+    return counts
 
 if TYPE_CHECKING:
     import mne
@@ -70,6 +263,8 @@ DEFAULT_DURATION = 30.0
 DEFAULT_LMBDA = 1e-3
 LOG_LMBDA_MIN = -5
 LOG_LMBDA_MAX = -1
+# Per-channel solve timeout (s); mirrors montage.estimate_hrf's default.
+DEFAULT_TIMEOUT = 30.0
 
 
 @dataclass
@@ -84,6 +279,9 @@ class EstimationOptions:
     lmbda: float = DEFAULT_LMBDA
     duration: float = DEFAULT_DURATION
     selected_events: Tuple[str, ...] = field(default_factory=tuple)
+    # Per-channel lstsq solve timeout (seconds), forwarded to
+    # montage.estimate_hrf. A channel that exceeds it is skipped.
+    timeout: float = DEFAULT_TIMEOUT
 
 
 def render(state: AppState) -> None:
@@ -112,6 +310,13 @@ def render(state: AppState) -> None:
     # HRFs-tab body re-render, avoiding the 6-subscriber re-render
     # cascade that republishing hrf_estimated would cause.
     state.subscribe("hrf_selection_changed", _refresh)
+    # React to busy transitions so the inline "Preprocess now" / estimate
+    # spinner appears immediately on start and clears on finish (the poll
+    # timer below only fires while estimation_progress is set).
+    state.subscribe("busy_changed", _refresh)
+    # Recompute bulk mode when the dataset-tree checked set changes, so
+    # ticking scans immediately makes them eligible to estimate.
+    state.subscribe("checked_changed", _refresh)
 
     # Progress polling timer — refreshes the body every 0.5 s WHILE an
     # estimation is in flight, so the progress bar advances. The
@@ -160,64 +365,137 @@ def _render_body(state: AppState, opts: EstimationOptions) -> None:
             ).classes("text-sm opacity-60")
             return
 
-        if bulk_mode:
-            ui.label(
-                f"Bulk run on {len(checked_scans)} checked scan"
-                f"{'s' if len(checked_scans) != 1 else ''}."
-            ).classes("text-sm font-mono opacity-70")
-        elif scan is not None:
-            ui.label(scan.display_name or scan.path.name).classes(
-                "text-sm font-mono opacity-70"
-            )
-
-        # ── Model selector + controls. The controls remain anchored on
-        # ``selected_scan`` so the user still picks events / lambda /
-        # duration from a concrete scan's metadata -- the bulk run uses
-        # those same options across every checked scan (events that
-        # don't exist in a particular scan are silently dropped by the
-        # per-scan toeplitz call, counting as a "no events" skip).
-        with ui.card().classes("w-full"):
-            ui.label("Estimation").classes(
-                "text-xs uppercase opacity-60 tracking-wide"
-            )
-            _render_model_radio(opts, _refresh_body_for(state))
-            if opts.model == MODEL_TOEPLITZ:
-                if scan is not None:
-                    _render_toeplitz_controls(state, opts, scan)
-                else:
+        # Two-column workspace: estimation controls on the left, the
+        # per-channel HRF visualization in its own column on the right
+        # (mirrors the HRtree tab's viz | detail split so the channel
+        # accordion gets horizontal room instead of stacking under the
+        # controls).
+        with ui.row().classes("w-full gap-6 items-start no-wrap"):
+            with ui.column().classes("flex-1 min-w-0 gap-4"):
+                if bulk_mode:
                     ui.label(
-                        "Pick one of the checked scans to populate the "
-                        "event picker / lambda / duration controls."
-                    ).classes("text-sm opacity-60")
-            else:
-                _render_canonical_note()
+                        f"Bulk run on {len(checked_scans)} checked scan"
+                        f"{'s' if len(checked_scans) != 1 else ''}."
+                    ).classes("text-sm font-mono opacity-70")
+                    if opts.model == MODEL_TOEPLITZ:
+                        ui.label(
+                            "Each scan auto-discovers its own events at run "
+                            "time: an applied uploaded file → a collocated "
+                            "sidecar (BIDS or lone file) → the scan's embedded "
+                            "annotations. Scans with no events of any kind are "
+                            "reported as failures with the reason."
+                        ).classes("text-xs opacity-60 italic")
+                elif scan is not None:
+                    ui.label(scan.display_name or scan.path.name).classes(
+                        "text-sm font-mono opacity-70"
+                    )
 
-        # ── Run button + progress / error display
-        _render_run_row(state, scan, checked_scans, opts)
+                # ── Model selector + controls. The controls remain anchored
+                # on ``selected_scan`` for lambda / duration / (single-scan)
+                # event picking. In bulk the events are NOT taken from the UI
+                # scan's selection -- each checked scan resolves its own
+                # events via ``_resolve_bulk_events`` (uploaded-file →
+                # collocated sidecar → annotations), so a batch of scans with
+                # per-scan sidecars all estimate correctly instead of
+                # inheriting one scan's labels.
+                with ui.card().classes("w-full"):
+                    ui.label("Estimation").classes(
+                        "text-xs uppercase opacity-60 tracking-wide"
+                    )
+                    _render_model_radio(opts, _refresh_body_for(state))
+                    if opts.model == MODEL_TOEPLITZ:
+                        if scan is not None:
+                            _render_toeplitz_controls(state, opts, scan)
+                        else:
+                            ui.label(
+                                "Pick one of the checked scans to populate the "
+                                "event picker / lambda / duration controls."
+                            ).classes("text-sm opacity-60")
+                    else:
+                        _render_canonical_note()
 
-        # ── Result preview (single-scan only; bulk mode overwrites
-        # state.montage scan-by-scan and the preview would just flash
-        # whichever scan landed last)
-        if state.montage is not None and not bulk_mode:
-            ui.separator()
-            ui.label("HRF preview").classes(
-                "text-xs uppercase opacity-60 tracking-wide"
-            )
-            _render_hrf_preview(state, scan, opts)
+                # ── Run button + progress / error display
+                _render_run_row(state, scan, checked_scans, opts)
 
-            # Submission card -- same form the Export tab renders.
-            # Surfaced here so users who finish an estimation can go
-            # straight to sharing without hopping to Export. The
-            # file picker defaults to state.last_saved_roi_path (set
-            # by the Cluster sub-tab's Save montage flow); if the
-            # user hasn't saved yet, they pick the JSON manually.
-            ui.separator()
-            with ui.card().classes("w-full"):
-                from ..submission import render_submission_panel
-                render_submission_panel(
-                    state,
-                    default_path=state.last_saved_roi_path,
-                )
+            # ── Right column: per-channel HRF visualization + save / submit
+            with ui.column().classes("flex-1 min-w-0 gap-3"):
+                _render_preview_column(state, scan, opts, bulk_mode)
+
+
+def _render_preview_column(
+    state: AppState,
+    scan: Optional[ScanEntry],
+    opts: EstimationOptions,
+    bulk_mode: bool,
+) -> None:
+    """Right-hand column: the per-channel HRF visualization + save/submit.
+
+    Kept in its own column (mirroring the HRtree detail pane) so the channel
+    accordion has horizontal room and the estimation controls on the left stay
+    compact. Shows a placeholder until a montage exists.
+
+    Bulk mode overwrites ``state.montage`` scan-by-scan, so during a run the
+    preview would just flash whichever scan landed last -- we gate on
+    ``not state.busy`` so it only appears once the batch FINISHES, and point
+    the preview/save at the scan that actually produced the montage
+    (``montage_source_scan``) rather than the UI selection.
+    """
+    ui.label("HRF preview").classes(
+        "text-xs uppercase opacity-60 tracking-wide"
+    )
+
+    if state.busy:
+        ui.label("Estimating…").classes("text-sm opacity-60")
+        return
+
+    preview_scan = scan if not bulk_mode else state.montage_source_scan
+    if state.montage is None or preview_scan is None:
+        ui.label(
+            "Estimate HRFs to see the per-channel results here."
+        ).classes("text-sm opacity-60")
+        return
+
+    if bulk_mode:
+        shown = preview_scan.display_name or preview_scan.path.name
+        ui.label(
+            f"Showing HRFs for the last-estimated scan: {shown}. "
+            "A bulk run keeps only the most recent scan's HRFs in memory — "
+            "save each scan's HRFs (below or via mass-save), or select a "
+            "single scan to view or re-estimate it."
+        ).classes("text-xs opacity-70 italic")
+
+    _render_hrf_preview(state, preview_scan, opts)
+
+    # Save the estimated HRFs to JSON right here (same action as the Export
+    # tab's "Save montage HRFs"). Only meaningful for a real toeplitz montage.
+    if not isinstance(state.montage, _CanonicalResult):
+        async def _on_save_hrfs(_scan=preview_scan) -> None:
+            from .export_panel import _save_montage
+            await _save_montage(state, _scan)
+
+        with ui.row().classes("items-center gap-2"):
+            ui.button(
+                "Save",
+                icon="save",
+                on_click=_on_save_hrfs,
+            ).props("color=primary")
+            ui.label(
+                "Saves the per-channel estimated HRFs as a tree.load_hrfs "
+                "JSON file."
+            ).classes("text-xs opacity-60")
+
+    # Submission card -- same form the Export tab renders. Surfaced here so
+    # users who finish an estimation can go straight to sharing without
+    # hopping to Export. The file picker defaults to state.last_saved_roi_path
+    # (set by the Cluster sub-tab's Save montage flow); if the user hasn't
+    # saved yet, they pick the JSON manually.
+    ui.separator()
+    with ui.card().classes("w-full"):
+        from ..submission import render_submission_panel
+        render_submission_panel(
+            state,
+            default_path=state.last_saved_roi_path,
+        )
 
 
 def _refresh_body_for(state: AppState):
@@ -246,32 +524,551 @@ def _render_model_radio(
     ).props("inline")
 
 
+def _preprocess_now(state: AppState, scan: ScanEntry) -> None:
+    """Run the DECONVOLUTION preprocessing pipeline on ``scan`` from the HRFs
+    tab.
+
+    Reuses the Preprocess tab's ``run_pipeline_sync`` so the output is
+    byte-identical to running it there (one source of truth for the
+    pipeline). HRF estimation requires deconvolution-mode preprocessing, so
+    this forces ``deconvolution=True`` and records it in
+    ``processed_deconvolved``. On completion the result lands in
+    ``processed_cache`` and ``preprocess_done`` fires, refreshing the panel.
+    """
+    if state.busy:
+        return
+    if scan not in state.raw_cache:
+        state.last_error = "Raw not loaded yet; wait for the scan to load."
+        return
+    # Lazy import: keep the module-load import graph free of a cross-panel
+    # dependency, and guarantee the same pipeline as the Preprocess tab.
+    from .preprocess_panel import PreprocessOptions, run_pipeline_sync
+
+    snapshot = PreprocessOptions(deconvolution=True)  # required for HRF est.
+    raw = state.raw_cache.get(scan)
+
+    async def _on_done(result) -> None:
+        if result is None:
+            return
+        state.processed_cache._cache[scan.path.resolve()] = result
+        # Honor the LRU bound (RawCache.put() centralizes this once PR #68
+        # lands; evict inline here as the other cache writers do today).
+        while len(state.processed_cache._cache) > state.processed_cache.maxsize:
+            state.processed_cache._cache.popitem(last=False)
+        state.processed_deconvolved.add(scan.path.resolve())
+        state.publish("preprocess_done", scan)
+
+    ui.notify("Preprocessing…", type="info")
+    background_tasks.create(
+        run_in_background(
+            state, run_pipeline_sync, raw, snapshot, on_done=_on_done
+        )
+    )
+
+
+def _render_preprocess_now(state: AppState, scan: ScanEntry) -> None:
+    """Render the 'not preprocessed yet -> Preprocess now' affordance."""
+    if state.busy:
+        with ui.row().classes("items-center gap-2"):
+            ui.spinner(size="sm")
+            ui.label("Preprocessing…").classes("text-sm opacity-70")
+        return
+    ui.label(
+        "This scan isn't preprocessed yet — HRF estimation runs on the "
+        "preprocessed signal."
+    ).classes("text-sm opacity-70")
+    loaded = scan in state.raw_cache
+    with ui.row().classes("items-center gap-2"):
+        ui.button(
+            "Preprocess now",
+            icon="play_arrow",
+            on_click=lambda: _preprocess_now(state, scan),
+        ).props(f"color=primary {'disable' if not loaded else ''}")
+        ui.label(
+            "Uses default settings — for custom options use the Preprocess tab."
+        ).classes("text-xs opacity-60")
+    if not loaded:
+        ui.label(
+            "Waiting for the scan to finish loading…"
+        ).classes("text-xs opacity-60")
+
+
+def _render_needs_deconvolution(state: AppState, scan: ScanEntry) -> None:
+    """Shown when a scan is preprocessed in GLM/haemoglobin mode: HRF
+    estimation requires the deconvolution pipeline, so block + offer a
+    one-click re-preprocess in deconvolution mode."""
+    if state.busy:
+        with ui.row().classes("items-center gap-2"):
+            ui.spinner(size="sm")
+            ui.label("Preprocessing…").classes("text-sm opacity-70")
+        return
+    ui.label(
+        "This scan was preprocessed for haemoglobin (GLM mode), but HRF "
+        "estimation requires the deconvolution pipeline."
+    ).classes("text-sm text-amber-400")
+    ui.button(
+        "Re-preprocess with deconvolution",
+        icon="play_arrow",
+        on_click=lambda: _preprocess_now(state, scan),
+    ).props("color=primary")
+
+
+def _set_events_selection(
+    state: AppState, opts: EstimationOptions, selection: Tuple[str, ...]
+) -> None:
+    """Set the selected-events tuple and refresh the picker."""
+    opts.selected_events = selection
+    state.publish("hrf_selection_changed")
+
+
+def _set_apply_all(state: AppState, value: bool) -> None:
+    state.events_apply_all = value
+    state.publish("hrf_selection_changed")
+
+
+def _clear_events_file(state: AppState, opts: EstimationOptions) -> None:
+    """Drop the loaded events file and revert to scan annotations.
+
+    The scan the file belonged to is added to ``events_no_automatch`` so the
+    auto-matcher doesn't immediately re-load it on the next render — clearing
+    is an explicit "use annotations for this scan" choice.
+    """
+    if state.events_source_scan is not None:
+        state.events_no_automatch.add(state.events_source_scan.path.resolve())
+    state.events_rows = None
+    state.events_impulse = None
+    state.events_format = None
+    state.events_source_label = None
+    state.events_apply_all = False
+    state.events_source_scan = None
+    state.events_is_automatched = False
+    opts.selected_events = ()  # re-seeds from annotations on next render
+    state.publish("hrf_selection_changed")
+
+
+def _render_events_source(
+    state: AppState, opts: EstimationOptions, scan: ScanEntry
+) -> None:
+    """Compact events-source row: a loud status of what's loaded + a single
+    "Upload / find events…" button that opens the find-window dialog where
+    all the loading options live."""
+    loaded = state.events_rows is not None or state.events_impulse is not None
+
+    if loaded:
+        _render_events_status(state, scan)
+    else:
+        ui.label(
+            "Events source: this scan's own annotations (none loaded from "
+            "file)."
+        ).classes("text-xs opacity-60")
+
+    async def _open() -> None:
+        # Surface any failure as a toast — a silent exception here is exactly
+        # the "button does nothing" symptom.
+        try:
+            await _open_events_dialog(state, opts, scan)
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("events dialog failed to open: %s", exc)
+            ui.notify(
+                f"Couldn't open events dialog: {type(exc).__name__}: {exc}",
+                type="negative",
+            )
+
+    with ui.row().classes("items-center gap-2"):
+        ui.button(
+            "Upload / find events…", icon="upload_file", on_click=_open
+        ).props("flat dense")
+        if loaded:
+            ui.checkbox(
+                "Apply to all checked scans",
+                value=state.events_apply_all,
+                on_change=lambda e: _set_apply_all(state, bool(e.value)),
+            ).props("dense").classes("text-xs")
+            ui.button(
+                "Use annotations instead",
+                on_click=lambda: _clear_events_file(state, opts),
+            ).props("flat dense")
+
+
+async def _open_events_dialog(
+    state: AppState, opts: EstimationOptions, scan: Optional[ScanEntry]
+) -> None:
+    """Find-window dialog for loading events.
+
+    A glob box searches the loaded project folder for event files and
+    highlights matches; selecting one shows a format/count preview so a
+    wrong file is obvious before loading. "Browse…" falls back to the OS
+    picker. On Load the file is parsed and applied (with the apply-to-all
+    choice). All file-loading options live here so the HRFs page stays tidy.
+    """
+    root = state.manifest.root if state.manifest is not None else None
+    sel = {
+        "pattern": "",
+        "results": find_event_files(root, "") if root else [],
+        "chosen": None,
+        "parsed": None,
+        "error": None,
+        "apply_all": state.events_apply_all,
+    }
+
+    def _choose(path: Path) -> None:
+        sel["chosen"] = path
+        try:
+            sel["parsed"] = parse_events_file(path)
+            sel["error"] = None
+        except EventsParseError as exc:
+            sel["parsed"] = None
+            sel["error"] = str(exc)
+        _results.refresh()
+        _preview.refresh()
+
+    def _search() -> None:
+        sel["results"] = find_event_files(root, sel["pattern"]) if root else []
+        _results.refresh()
+
+    with ui.dialog() as dialog, ui.card().classes("w-[640px] max-w-full gap-2"):
+        ui.label("Load events").classes("text-lg font-semibold")
+        ui.label(
+            f"Searching project: {root}" if root else
+            "No project loaded — use Browse to pick a file."
+        ).classes("text-xs opacity-60 break-all")
+
+        with ui.row().classes("w-full items-center gap-2"):
+            ui.input(
+                placeholder="filter, e.g. events*  or  *.tsv  (blank = all)",
+                on_change=lambda e: sel.__setitem__("pattern", e.value or ""),
+            ).props("dense outlined").classes("flex-1").on(
+                "keydown.enter", lambda e: _search()
+            )
+            ui.button("Search", icon="search", on_click=_search).props("flat dense")
+
+            async def _browse() -> None:
+                from .dataset_picker import pick_file
+                path = await pick_file(
+                    file_types=["Events (*.tsv;*.csv;*.txt)", "All files (*.*)"],
+                )
+                if path is not None:
+                    _choose(path)
+
+            ui.button("Browse…", icon="folder_open", on_click=_browse).props(
+                "flat dense"
+            )
+
+        @ui.refreshable
+        def _results() -> None:
+            if not sel["results"]:
+                ui.label(
+                    "No matching files. Adjust the filter and Search, or Browse."
+                ).classes("text-sm opacity-60")
+                return
+            with ui.column().classes("w-full max-h-60 overflow-auto gap-0"):
+                for path in sel["results"]:
+                    rel = (
+                        str(path.relative_to(root)) if root
+                        and root in path.parents else path.name
+                    )
+                    is_chosen = sel["chosen"] == path
+                    row = ui.row().classes(
+                        "w-full items-center gap-2 px-2 py-1 rounded cursor-pointer "
+                        + ("bg-indigo-700/40" if is_chosen else "hover:bg-slate-700/40")
+                    )
+                    with row:
+                        ui.icon("description").classes("text-indigo-300 text-sm")
+                        ui.label(rel).classes("text-xs font-mono")
+                    row.on("click", lambda _e=None, p=path: _choose(p))
+
+        _results()
+
+        @ui.refreshable
+        def _preview() -> None:
+            if sel["error"]:
+                ui.label(f"⚠ Can't read: {sel['error']}").classes(
+                    "text-xs text-red-400"
+                )
+                return
+            parsed = sel["parsed"]
+            if parsed is None:
+                return
+            if parsed.impulse is not None:
+                ui.label(
+                    f"✓ {sel['chosen'].name}: IMPULSE vector · "
+                    f"{len(parsed.impulse)} samples · "
+                    f"{int(sum(parsed.impulse))} events."
+                ).classes("text-xs text-green-400")
+            else:
+                ui.label(
+                    f"✓ {sel['chosen'].name}: {parsed.fmt.upper()} · "
+                    f"{len(parsed.rows)} onsets · "
+                    f"{len(parsed.labels())} condition(s)."
+                ).classes("text-xs text-green-400")
+                if parsed.needs_simple_confirm:
+                    ui.label(
+                        "Note: simple onset,label shape (not BIDS events.tsv)."
+                    ).classes("text-xs opacity-60")
+
+        _preview()
+
+        ui.checkbox(
+            "Apply to all checked scans",
+            value=sel["apply_all"],
+            on_change=lambda e: sel.__setitem__("apply_all", bool(e.value)),
+        ).props("dense").classes("text-xs")
+
+        with ui.row().classes("justify-end gap-2 w-full"):
+            ui.button("Cancel", on_click=lambda: dialog.submit(None)).props("flat")
+            ui.button(
+                "Load",
+                on_click=lambda: dialog.submit(
+                    sel["chosen"] if sel["parsed"] is not None else None
+                ),
+            ).props("color=primary")
+
+    dialog.open()
+    chosen = await dialog
+    if chosen is None:
+        return
+    try:
+        parsed = parse_events_file(chosen)
+    except EventsParseError as exc:
+        ui.notify(f"Couldn't read events: {exc}", type="negative")
+        return
+    _apply_parsed_events(state, opts, scan, parsed, is_auto=False)
+    state.events_apply_all = bool(sel["apply_all"])
+    if scan is not None:
+        state.events_no_automatch.add(scan.path.resolve())
+    for warning in parsed.warnings:
+        ui.notify(warning, type="warning")
+    ui.notify(
+        f"Loaded events from {chosen.name} ({_events_summary(parsed)}).",
+        type="positive",
+    )
+    state.publish("hrf_selection_changed")
+
+
+def _render_events_status(state: AppState, scan: Optional[ScanEntry]) -> None:
+    """LOUD banner describing the loaded events: file, format, how it loaded,
+    counts, and (for impulse vectors) whether the length matches this scan."""
+    fmt = (state.events_format or "").upper()
+    how = "auto-matched" if state.events_is_automatched else "uploaded"
+    with ui.column().classes(
+        "w-full gap-0.5 px-3 py-2 rounded-md "
+        "bg-indigo-950/40 border border-indigo-700/60"
+    ):
+        with ui.row().classes("items-center gap-2"):
+            ui.icon(
+                "auto_awesome" if state.events_is_automatched else "description"
+            ).classes("text-indigo-300")
+            ui.label(
+                f"Events {how}: {state.events_source_label or '(file)'}"
+            ).classes("text-sm font-medium")
+            ui.badge(fmt or "?").props("color=indigo")
+
+        # Format-specific provenance line.
+        if state.events_impulse is not None:
+            n_samp = len(state.events_impulse)
+            n_ev = int(sum(state.events_impulse))
+            ui.label(
+                f"Per-sample impulse vector · {n_samp} samples · {n_ev} event "
+                "onset(s) · applied by sample index."
+            ).classes("text-xs opacity-80")
+            # Length-match check against the current scan — the key "is this
+            # the right vector for this scan?" signal.
+            raw = (
+                state.processed_cache.get(scan)
+                if scan is not None and scan in state.processed_cache
+                else (
+                    state.raw_cache.get(scan)
+                    if scan is not None and scan in state.raw_cache
+                    else None
+                )
+            )
+            if raw is not None:
+                scan_n = int(raw.n_times)
+                if scan_n == n_samp:
+                    ui.label(
+                        f"✓ Length matches this scan ({scan_n} samples)."
+                    ).classes("text-xs text-green-400")
+                elif n_samp > scan_n:
+                    ui.label(
+                        f"⚠ Vector ({n_samp}) is LONGER than this scan "
+                        f"({scan_n}) — trailing {n_samp - scan_n} samples will "
+                        "be dropped."
+                    ).classes("text-xs text-amber-400")
+                else:
+                    ui.label(
+                        f"⚠ Vector ({n_samp}) is SHORTER than this scan "
+                        f"({scan_n}) — the tail has no events."
+                    ).classes("text-xs text-amber-400")
+        else:
+            rows = state.events_rows or []
+            labels = sorted({r.label for r in rows})
+            shown = ", ".join(labels[:6]) + ("…" if len(labels) > 6 else "")
+            ui.label(
+                f"Onset events · {len(rows)} onset(s) · {len(labels)} "
+                f"condition(s): {shown}"
+            ).classes("text-xs opacity-80")
+
+        scope = (
+            "ALL checked scans" if state.events_apply_all else "this scan only"
+        )
+        ui.label(f"Applies to: {scope}").classes("text-xs opacity-60")
+
+
+async def _confirm_simple_events(parsed) -> bool:
+    """Warn that a file matched only the simple onset,label shape; confirm use."""
+    with ui.dialog() as dialog, ui.card():
+        ui.label("Simple events file").classes("text-base font-semibold")
+        ui.label(
+            f"'{parsed.source_name}' looks like a simple onset,label file, "
+            "not a BIDS events.tsv (no trial_type / duration columns). "
+            f"Continue using it? Detected {len(parsed.rows)} events across "
+            f"{len(parsed.labels())} label(s)."
+        ).classes("text-sm opacity-80")
+        with ui.row().classes("justify-end gap-2 w-full"):
+            ui.button("Cancel", on_click=lambda: dialog.submit(False)).props("flat")
+            ui.button(
+                "Use it", on_click=lambda: dialog.submit(True)
+            ).props("color=primary")
+    dialog.open()
+    return bool(await dialog)
+
+
+async def _confirm_coverage(issues) -> bool:
+    """Confirm dialog listing scans whose events fall outside the usable window."""
+    with ui.dialog() as dialog, ui.card().classes("max-w-xl"):
+        ui.label("Some events fall outside the scan").classes(
+            "text-base font-semibold"
+        )
+        ui.label(
+            "These scans are shorter than the events extend, or have events "
+            "inside the dropped edge-expansion window. Out-of-range events "
+            "won't contribute to the estimate. Proceed anyway?"
+        ).classes("text-sm opacity-80")
+        for scan, cov in issues:
+            name = scan.display_name or scan.path.name
+            parts = []
+            if cov.past_end:
+                parts.append(f"{cov.past_end} past end")
+            if cov.in_edge:
+                parts.append(f"{cov.in_edge} in edge window")
+            ui.label(
+                f"• {name}: {cov.scan_seconds:.0f}s scan, events to "
+                f"{cov.max_onset_s:.0f}s — {', '.join(parts)}; "
+                f"{cov.placed} usable."
+            ).classes("text-xs font-mono opacity-80")
+        with ui.row().classes("justify-end gap-2 w-full"):
+            ui.button("Cancel", on_click=lambda: dialog.submit(False)).props("flat")
+            ui.button(
+                "Estimate anyway", on_click=lambda: dialog.submit(True)
+            ).props("color=primary")
+    dialog.open()
+    return bool(await dialog)
+
+
+async def _estimate_clicked(
+    state: AppState,
+    selected: Optional[ScanEntry],
+    checked: List[ScanEntry],
+    opts: EstimationOptions,
+) -> None:
+    """Estimate-button handler: coverage pre-flight, then dispatch.
+
+    For toeplitz scans driven by an uploaded events file, check that the
+    scan is long enough to contain the events (and flag the dropped edge
+    window). If any scan drops events, confirm before running. Annotation-
+    sourced scans keep the library's lenient drop behavior.
+    """
+    issues = []
+    if opts.model == MODEL_TOEPLITZ:
+        scans = list(checked) if checked else (
+            [selected] if selected is not None else []
+        )
+        for scan in scans:
+            if not _file_applies_to_scan(state, scan):
+                continue
+            if scan not in state.processed_cache:
+                continue
+            raw = state.processed_cache.get(scan)
+            sfreq = float(raw.info["sfreq"])
+            n_samples = int(raw.n_times)
+            edge_samples = int(round(_EDGE_EXPANSION * opts.duration * sfreq))
+            if state.events_impulse is not None:
+                cov = coverage_report_vector(
+                    state.events_impulse, sfreq, n_samples, edge_samples,
+                )
+            else:
+                cov = coverage_report(
+                    state.events_rows, opts.selected_events,
+                    sfreq, n_samples, edge_samples,
+                )
+            if cov.past_end or cov.in_edge:
+                issues.append((scan, cov))
+    if issues and not await _confirm_coverage(issues):
+        return
+    _run_dispatch(state, selected, checked, opts)
+
+
 def _render_toeplitz_controls(
     state: AppState, opts: EstimationOptions, scan: ScanEntry
 ) -> None:
     """Event picker + lmbda slider + duration field for toeplitz mode."""
+    # Try to auto-match a collocated events file for this scan before we read
+    # the event source (no-op if one already applies or the user opted out).
+    _maybe_automatch_events(state, scan, opts)
     raw = state.processed_cache.get(scan) if scan in state.processed_cache else None
 
     # ── Event picker
     ui.label("Events").classes("text-xs uppercase opacity-60 tracking-wide")
     if raw is None:
-        ui.label(
-            "Preprocess the scan first (Preprocess tab) before estimating."
-        ).classes("text-sm opacity-60")
+        # Not preprocessed yet -- offer a one-click "Preprocess now" right
+        # here instead of sending the user to the Preprocess tab.
+        _render_preprocess_now(state, scan)
         return
 
-    event_names = sorted_unique_annotation_descriptions(raw)
+    if scan.path.resolve() not in state.processed_deconvolved:
+        # Preprocessed, but with the GLM/haemoglobin pipeline — HRF
+        # estimation requires deconvolution-mode preprocessing. Hard-block
+        # and offer a one-click re-preprocess.
+        _render_needs_deconvolution(state, scan)
+        return
+
+    # Source row: upload an events file (overrides annotations) or use the
+    # scan's own annotations.
+    _render_events_source(state, opts, scan)
+
+    event_names = _event_labels_for_scan(state, scan, raw)
     if not event_names:
         ui.label(
-            "No events found in the preprocessed scan."
+            "No events in this scan. Upload an events file above to supply "
+            "trial onsets, then pick which to estimate."
         ).classes("text-sm opacity-60")
     else:
-        # Seed selection on first render — default to all events so users
-        # don't need to tick anything in the common case.
-        if not opts.selected_events:
+        # Seed (or re-seed) the selection to all labels when it's empty or
+        # entirely stale (e.g. after switching scans or swapping the event
+        # source). A deliberate subset that still overlaps is left alone.
+        if not (set(opts.selected_events) & set(event_names)):
             opts.selected_events = tuple(event_names)
 
+        # Condition selection: which event labels to estimate. (File finding
+        # / globbing lives in the Upload dialog now — this is just picking
+        # conditions among the loaded events.)
+        ui.label("Conditions to estimate").classes(
+            "text-xs uppercase opacity-50 tracking-wide"
+        )
+        with ui.row().classes("items-center gap-2"):
+            ui.button(
+                "All",
+                on_click=lambda: _set_events_selection(
+                    state, opts, tuple(sorted(event_names))
+                ),
+            ).props("flat dense")
+            ui.button(
+                "None",
+                on_click=lambda: _set_events_selection(state, opts, ()),
+            ).props("flat dense")
+
         selected_set = set(opts.selected_events)
+        counts = _event_counts_for_scan(state, scan, raw)
 
         def _toggle(name: str, checked: bool) -> None:
             new_selection = set(opts.selected_events)
@@ -283,8 +1080,12 @@ def _render_toeplitz_controls(
 
         with ui.row().classes("gap-2 flex-wrap"):
             for name in event_names:
+                count = counts.get(name, 0)
+                # Show the occurrence count so a bare numeric marker reads as
+                # an event ("1.0 (42)"), not a mystery checkbox. Selection
+                # still keys off the raw label, not the displayed text.
                 ui.checkbox(
-                    name,
+                    f"{name}  ({count})" if count else name,
                     value=name in selected_set,
                     on_change=(lambda e, n=name: _toggle(n, bool(e.value))),
                 )
@@ -324,6 +1125,28 @@ def _render_toeplitz_controls(
         step=1.0,
         format="%.1f",
         on_change=lambda e: setattr(opts, "duration", float(e.value or DEFAULT_DURATION)),
+    )
+
+    # ── Per-channel solve timeout (forwarded to estimate_hrf). A channel
+    # whose solve exceeds this is skipped, not the whole scan.
+    ui.label("Per-channel timeout (seconds)").classes(
+        "text-xs uppercase opacity-60 tracking-wide"
+    )
+
+    def _on_timeout(event) -> None:
+        try:
+            opts.timeout = max(1.0, float(event.value))
+        except (TypeError, ValueError):
+            opts.timeout = DEFAULT_TIMEOUT
+
+    ui.number(
+        value=opts.timeout,
+        min=1.0,
+        step=5.0,
+        format="%.0f",
+        on_change=_on_timeout,
+    ).tooltip(
+        "Seconds to wait for one channel's solve before skipping it."
     )
 
     # ── Edge-expansion advisory (library default 0.15 of duration)
@@ -377,6 +1200,7 @@ def _render_run_row(
         can_run = (
             scan is not None
             and scan in state.processed_cache
+            and scan.path.resolve() in state.processed_deconvolved
             and bool(opts.selected_events)
             and not state.busy
         )
@@ -386,9 +1210,14 @@ def _render_run_row(
         run_label = "Generate canonical HRF"
 
     with ui.row().classes("items-center gap-3"):
+        # Async handler (passed directly, NOT wrapped in a sync lambda, which
+        # would silently no-op) so the coverage pre-flight dialog can await.
+        async def _on_estimate() -> None:
+            await _estimate_clicked(state, scan, checked, opts)
+
         ui.button(
             run_label,
-            on_click=lambda: _run_dispatch(state, scan, checked, opts),
+            on_click=_on_estimate,
         ).props(f"color=primary {'disable' if not can_run else ''}")
         if state.busy:
             _render_busy_progress(state)
@@ -509,16 +1338,49 @@ def _run_bulk(
         lmbda=opts.lmbda,
         duration=opts.duration,
         selected_events=opts.selected_events,
+        timeout=opts.timeout,
     )
 
     def _build(scan: ScanEntry):
         if snapshot.model == MODEL_TOEPLITZ:
-            if scan not in state.processed_cache:
-                # Preflight skip -- record as failure via the worker.
-                return None
-            raw = state.processed_cache.get(scan)
             progress_cb = make_progress_callback(state)
-            return (run_toeplitz_sync, (raw, snapshot, progress_cb), {})
+
+            def _pp_and_estimate(scan=scan, progress_cb=progress_cb):
+                # Preprocess on demand (deconvolution) if this scan isn't
+                # already cached+deconvolved, so the bulk run triggers the
+                # preprocessing each scan needs instead of skipping it.
+                # ensure_deconvolved_raw raises with a specific reason on
+                # failure; let it propagate so the worker records why.
+                from .preprocess_panel import ensure_deconvolved_raw
+                raw = ensure_deconvolved_raw(state, scan)
+                # Discover this scan's own events (manual file → collocated
+                # sidecar → embedded annotations). The single global events
+                # slot only covers one scan, so a batch must resolve each
+                # scan independently or every other scan estimates on empty
+                # events ("no usable event-locked responses").
+                event_rows, event_impulse, selected = _resolve_bulk_events(
+                    state, scan, raw, snapshot
+                )
+                if event_rows is None and event_impulse is None and not selected:
+                    raise RuntimeError(
+                        "no events found for this scan — no events file "
+                        "collocated with it (BIDS sidecar or lone file) and "
+                        "the scan has no embedded annotations; load/glob an "
+                        "events file, or check that sidecars sit beside the "
+                        "scan"
+                    )
+                scan_opts = EstimationOptions(
+                    model=snapshot.model,
+                    lmbda=snapshot.lmbda,
+                    duration=snapshot.duration,
+                    selected_events=selected,
+                    timeout=snapshot.timeout,
+                )
+                return run_toeplitz_sync(
+                    raw, scan_opts, progress_cb, event_rows, event_impulse
+                )
+
+            return (_pp_and_estimate, (), {})
         # Canonical: prefer processed_cache, fall back to raw_cache,
         # otherwise load on demand inside the worker thread.
         def _run_canonical():
@@ -533,17 +1395,30 @@ def _run_bulk(
 
     async def _on_each_done(scan: ScanEntry, result) -> None:
         if result is None:
-            return
+            # Raise so an empty estimate is reported as a failure (with a
+            # reason) instead of silently counting as a success.
+            raise RuntimeError(
+                "HRF estimation produced no result — no channels had usable "
+                "event-locked responses (check events coverage and channels)"
+            )
         state.montage = result
         state.montage_source_scan = scan
+        # Cache per scan so toeplitz activity can use each scan's own HRFs
+        # (montage only holds the most-recent estimate). Canonical results
+        # aren't real per-channel montages, so they're never cached.
+        if not isinstance(result, _CanonicalResult):
+            state.montage_cache[scan.path.resolve()] = result
         state.publish("hrf_estimated", scan)
 
     async def _bulk() -> None:
-        bulk_result = await run_bulk_in_background(
-            state, scans, _build,
-            on_each_done=_on_each_done,
-            label="estimate_hrf",
-        )
+        # Re-enter the captured client so refreshes work from this detached
+        # task (no slot context otherwise).
+        with client_scope(client):
+            bulk_result = await run_bulk_in_background(
+                state, scans, _build,
+                on_each_done=_on_each_done,
+                label="estimate_hrf",
+            )
         if bulk_result is None:
             return
         successes, failures = bulk_result
@@ -555,16 +1430,16 @@ def _run_bulk(
         )
         summary = f"{verb} {n_ok}/{n_ok + n_fail} scan(s)."
         if failures:
-            fail_names = ", ".join(
-                s.display_name or s.path.name for s, _ in failures[:3]
-            )
-            if len(failures) > 3:
-                fail_names += f" (+{len(failures) - 3} more)"
-            summary += f" Failed/skipped: {fail_names}."
-        ui.notify(
-            summary, type="positive" if n_fail == 0 else "warning"
+            summary += f" Failed/skipped: {summarize_failures(failures)}"
+        # Guarded: the page client may have been deleted during a long run.
+        notify_if_alive(
+            client, summary,
+            type="positive" if n_fail == 0 else "warning",
+            multi_line=True,
+            close_button=True,
         )
 
+    client = capture_client()
     background_tasks.create(_bulk())
 
 
@@ -585,19 +1460,30 @@ def _run(
         lmbda=opts.lmbda,
         duration=opts.duration,
         selected_events=opts.selected_events,
+        timeout=opts.timeout,
     )
 
     if snapshot.model == MODEL_TOEPLITZ:
         if scan not in state.processed_cache:
             state.last_error = "Preprocess the scan first."
             return
+        if scan.path.resolve() not in state.processed_deconvolved:
+            state.last_error = (
+                "HRF estimation requires deconvolution-mode preprocessing — "
+                "re-preprocess this scan with deconvolution."
+            )
+            return
         if not snapshot.selected_events:
             state.last_error = "Pick at least one event."
             return
         raw = state.processed_cache.get(scan)
         progress_cb = make_progress_callback(state)
+        applies = _file_applies_to_scan(state, scan)
+        event_rows = state.events_rows if applies else None
+        event_impulse = state.events_impulse if applies else None
         sync_call = (
-            run_toeplitz_sync, raw, snapshot, progress_cb
+            run_toeplitz_sync, raw, snapshot, progress_cb, event_rows,
+            event_impulse,
         )
     else:
         # Canonical mode doesn't need a processed Raw — only the raw_cache
@@ -621,6 +1507,9 @@ def _run(
         # Track which scan produced this montage so the Activity tab can
         # refuse a toeplitz run when the user switches scans mid-flow.
         state.montage_source_scan = scan
+        # Cache per scan so toeplitz activity can use each scan's own HRFs.
+        if not isinstance(result, _CanonicalResult):
+            state.montage_cache[scan.path.resolve()] = result
         state.publish("hrf_estimated", scan)
 
     background_tasks.create(
@@ -632,18 +1521,31 @@ def run_toeplitz_sync(
     raw: "mne.io.BaseRaw",
     opts: EstimationOptions,
     progress_callback=None,
+    event_rows=None,
+    event_impulse=None,
 ):
     """Run montage.estimate_hrf against a preprocessed Raw and return Montage.
 
-    Returns None if the events array can't be built (no annotation samples
-    match the selection). The library's ``estimate_hrf`` is called with
-    ``preprocess=False`` because the input is already preprocessed.
-
-    Module-level so tests can call without dispatching through workers.
+    Events come from, in priority order: an uploaded per-sample impulse
+    vector (``event_impulse``, applied by sample index), an uploaded onset
+    table (``event_rows`` — ``events_io.EventRow`` list, converted to a 0/1
+    impulse at this scan's sfreq), else the Raw's MNE annotations. Returns
+    None if no event samples land inside the scan (nothing to estimate).
+    ``estimate_hrf`` runs with ``preprocess=False`` (input already
+    preprocessed). Module-level so tests can call it directly.
     """
     from ...hrfunc import montage as Montage
 
-    events = build_events_array(raw, opts.selected_events)
+    n_samples = int(raw.n_times)
+    if event_impulse is not None:
+        events = build_impulse_from_vector(event_impulse, n_samples)
+    elif event_rows is not None:
+        sfreq = float(raw.info["sfreq"])
+        events = build_impulse_from_rows(
+            event_rows, opts.selected_events, sfreq, n_samples
+        )
+    else:
+        events = build_events_array(raw, opts.selected_events)
     if events is None or not events.any():
         logger.warning(
             "run_toeplitz_sync: no event samples matched the selected "
@@ -659,6 +1561,7 @@ def run_toeplitz_sync(
         lmbda=opts.lmbda,
         preprocess=False,
         progress_callback=progress_callback,
+        timeout=opts.timeout,
     )
     # estimate_hrf only appends to optode.estimates; it does NOT populate
     # optode.trace (which is what the preview reads). generate_distribution
@@ -826,54 +1729,56 @@ def _render_hrf_preview(
 
 
 def _render_toeplitz_gallery(state: AppState, montage) -> None:
-    """Per-channel HRF gallery: clickable mini-plots + detail panel.
+    """Per-channel HRF results as an accordion of dropdowns.
 
-    The mini-plots are rendered as base64 PNGs so they're inert (no plotly
-    state); clicks are wired through a ``ui.element`` wrapper around each
-    image that calls a closure setting ``state.hrf_selected_channel``. A
-    second ``@ui.refreshable`` block below the grid renders the full-size
-    plot for the currently-selected channel (with ±1 std shading).
+    One expandable row per channel (the channel name as the header); the
+    FIRST channel is open by default so the user immediately sees an
+    estimated HRF. Each channel's plot (trace + ±1 std shading) renders
+    lazily the first time its dropdown is opened, so a large montage doesn't
+    pay for every plot up front.
     """
     channels = _gather_channel_traces(montage)
     if not channels:
         ui.label("No channel HRFs available.").classes("text-sm opacity-60")
         return
 
-    if (
-        state.hrf_selected_channel is None
-        or state.hrf_selected_channel not in channels
-    ):
-        # Default-focus on the first channel so users see a detail view
-        # immediately rather than a blank "click one" prompt.
-        state.hrf_selected_channel = next(iter(channels))
+    ui.label(
+        f"{len(channels)} channel HRF{'s' if len(channels) != 1 else ''} — "
+        "open a channel to view its estimated response."
+    ).classes("text-xs opacity-60")
 
-    # ── Grid of mini-plots
-    with ui.row().classes("flex-wrap gap-2 max-w-4xl"):
-        for ch_name in channels.keys():
-            png = _render_mini_hrf_png(channels[ch_name])
-            selected = ch_name == state.hrf_selected_channel
-            border = "border-primary border-2" if selected else "border border-slate-700"
-            with ui.element("div").classes(
-                f"cursor-pointer rounded p-1 {border}"
-            ).on(
-                "click", lambda c=ch_name: _on_channel_click(state, c)
-            ):
-                if png is not None:
-                    ui.image(png).classes("w-32 h-20")
-                ui.label(ch_name).classes(
-                    "text-xs font-mono opacity-80 text-center w-32"
-                )
+    with ui.column().classes("w-full gap-1 max-w-2xl"):
+        for index, (ch_name, node) in enumerate(channels.items()):
+            _render_channel_dropdown(node, ch_name, open_default=(index == 0))
 
-    # ── Detail panel for the selected channel
-    selected = state.hrf_selected_channel
-    if selected and selected in channels:
-        ui.separator()
-        ui.label(f"Channel detail — {selected}").classes(
-            "text-xs uppercase opacity-60 tracking-wide"
-        )
-        png = _render_detail_hrf_png(channels[selected], selected)
-        if png is not None:
-            ui.image(png).classes("max-w-2xl")
+
+def _render_channel_dropdown(node, ch_name: str, open_default: bool) -> None:
+    """One channel's collapsible HRF panel; plot rendered lazily on open."""
+    expansion = ui.expansion(ch_name, value=open_default).classes(
+        "w-full border border-slate-700 rounded"
+    ).props("dense")
+    with expansion:
+        container = ui.column().classes("w-full p-2")
+
+    done = {"rendered": False}
+
+    def _fill() -> None:
+        if done["rendered"]:
+            return
+        done["rendered"] = True
+        with container:
+            png = _render_detail_hrf_png(node, ch_name)
+            if png is not None:
+                ui.image(png).classes("w-full max-w-2xl")
+            else:
+                ui.label(
+                    "Plot unavailable for this channel."
+                ).classes("text-xs opacity-60")
+
+    if open_default:
+        _fill()
+    # Render on first expand; collapsing doesn't tear it down (cheap to keep).
+    expansion.on_value_change(lambda e: _fill() if e.value else None)
 
 
 def _on_channel_click(state: AppState, ch_name: str) -> None:

--- a/src/hrfunc/gui/components/hrtree_panel.py
+++ b/src/hrfunc/gui/components/hrtree_panel.py
@@ -1895,6 +1895,7 @@ def _render_viz_pane(state: AppState) -> None:
                 matched,
                 show_brain=state.library_show_brain,
                 show_scalp=state.library_show_scalp,
+                show_info=state.library_show_info,
                 roi_keys=union_roi_keys,
                 roi_shapes=visible_shapes,
             )
@@ -1987,6 +1988,10 @@ def _render_viz_pane(state: AppState) -> None:
                 state.library_show_scalp = bool(event.value)
                 _publish_filter_change()
 
+            def _on_info_toggle(event) -> None:
+                state.library_show_info = bool(event.value)
+                _publish_filter_change()
+
             with ui.row().classes(
                 "w-full items-center justify-center gap-6 shrink-0 pt-1"
             ):
@@ -2005,6 +2010,16 @@ def _render_viz_pane(state: AppState) -> None:
                 ).props("dense").tooltip(
                     "Translucent fsaverage scalp (outer-skin) surface — "
                     "where forehead/head-mounted fNIRS optodes physically sit."
+                )
+                ui.switch(
+                    "Show info",
+                    value=state.library_show_info,
+                    on_change=_on_info_toggle,
+                ).props("dense").tooltip(
+                    "Show the per-HRF metadata popup on hover in the 3D view. "
+                    "Turn off to declutter dense clouds — the detail column on "
+                    "the right stays, and clicks / shift-hover ROI painting "
+                    "still work."
                 )
 
     _viz_body()
@@ -2030,8 +2045,22 @@ def _render_viz_pane(state: AppState) -> None:
     # sees the readout update while the 3D shape stays put.
     def _refresh_viz(_payload=None) -> None:
         _viz_body.refresh()
+
+    def _refresh_viz_after_event(_payload=None) -> None:
+        # Defer the rebuild to the next tick. The HRF click handler
+        # (``_on_click``) lives INSIDE ``_viz_body``; refreshing the body
+        # synchronously from there tears down the very plotly element that's
+        # mid-click, which drops that event's UI update batch — the detail
+        # pane (which refreshes later in the same ``publish``) then wouldn't
+        # repaint until the user's NEXT interaction (e.g. toggling a switch).
+        # Deferring lets the click event finish and flush first, then we
+        # rebuild the viz to re-centre the ROI shape overlay on the new
+        # anchor. once=True so the timer cleans itself up after firing.
+        ui.timer(0.05, _refresh_viz, once=True)
+
     state.subscribe("hrtree_filter_changed", _refresh_viz)
-    state.subscribe("hrtree_selection_changed", _refresh_viz)
+    # Selection comes from a plotly click inside this body, so defer (above).
+    state.subscribe("hrtree_selection_changed", _refresh_viz_after_event)
 
 
 def _extract_clicked_hrf_key(event) -> Optional[str]:
@@ -2095,10 +2124,17 @@ def _render_detail_pane(state: AppState) -> None:
                 ui.label("Context").classes(
                     "text-xs uppercase opacity-60 tracking-wide"
                 )
-                for ctx_key, value in context.items():
-                    if value is None:
-                        continue
-                    _kv(ctx_key, str(value))
+                # Cap the context block to its own scroll area so a long
+                # context (many populated fields) can't push the trace plot
+                # down / squish it — it scrolls within this box instead while
+                # the Trace section below keeps its space.
+                with ui.column().classes(
+                    "w-full max-h-40 overflow-auto gap-1 pr-1 shrink-0"
+                ):
+                    for ctx_key, value in context.items():
+                        if value is None:
+                            continue
+                        _kv(ctx_key, str(value))
 
             if trace:
                 ui.separator()
@@ -2107,7 +2143,9 @@ def _render_detail_pane(state: AppState) -> None:
                 )
                 png = _render_trace_png(hrf)
                 if png is not None:
-                    ui.image(png).classes("max-w-md")
+                    # shrink-0 so the plot keeps its natural size regardless
+                    # of how much context sits above it.
+                    ui.image(png).classes("max-w-md shrink-0")
 
             # ROI average plot (only renders when the ROI has at least
             # 2 averageable same-oxygenation HRFs — fewer than that
@@ -2372,6 +2410,7 @@ def build_plotly_figure(
     *,
     show_brain: bool = False,
     show_scalp: bool = False,
+    show_info: bool = True,
     roi_keys: Optional[Any] = None,
     roi_shape: Optional[Shape] = None,
     roi_shapes: Optional[List[Shape]] = None,
@@ -2492,6 +2531,10 @@ def build_plotly_figure(
             )
             traces.append(make_sphere_overlay_trace(sphere_m))
 
+    # "text" shows the per-HRF metadata popup on hover; "none" hides it but
+    # still fires hover/click events, so ROI clicks + shift-hover paint keep
+    # working with the popups off (the "Show info" toggle).
+    hover_mode = "text" if show_info else "none"
     if hbo_x:
         traces.append(
             go.Scatter3d(
@@ -2512,7 +2555,7 @@ def build_plotly_figure(
                 name="HbO",
                 customdata=hbo_keys,
                 hovertext=hbo_hover,
-                hoverinfo="text",
+                hoverinfo=hover_mode,
             )
         )
     if hbr_x:
@@ -2530,7 +2573,7 @@ def build_plotly_figure(
                 name="HbR",
                 customdata=hbr_keys,
                 hovertext=hbr_hover,
-                hoverinfo="text",
+                hoverinfo=hover_mode,
             )
         )
 
@@ -2565,7 +2608,7 @@ def build_plotly_figure(
                     name=f"ROI ({len(roi_x)})",
                     customdata=roi_keys_list,
                     hovertext=roi_hover,
-                    hoverinfo="text",
+                    hoverinfo=hover_mode,
                 )
             )
 

--- a/src/hrfunc/gui/components/preprocess_panel.py
+++ b/src/hrfunc/gui/components/preprocess_panel.py
@@ -40,7 +40,14 @@ from typing import TYPE_CHECKING, Dict, Optional
 from nicegui import background_tasks, ui
 
 from ..state import AppState
-from ..workers import run_bulk_in_background, run_in_background
+from ..workers import (
+    capture_client,
+    client_scope,
+    notify_if_alive,
+    run_bulk_in_background,
+    run_in_background,
+    summarize_failures,
+)
 from ...io.manifest import ScanEntry
 
 if TYPE_CHECKING:
@@ -82,8 +89,13 @@ def render(state: AppState) -> None:
     """
 
     # Holder for the toggles — updated by ui.switch on_change handlers and
-    # consumed by the click handler when Run is pressed.
-    opts = PreprocessOptions()
+    # consumed by the click handler when Run is pressed. The GUI defaults to
+    # DECONVOLUTION mode: it's the pipeline HRF / activity estimation
+    # requires, and the dominant use of this app. Users can toggle it off
+    # for plain haemoglobin (GLM) preprocessing, but then the HRFs / Activity
+    # tabs will ask them to re-preprocess in deconvolution mode. (The library
+    # PreprocessOptions default stays GLM; this is a GUI-workflow default.)
+    opts = PreprocessOptions(deconvolution=True)
 
     @ui.refreshable
     def _body() -> None:
@@ -97,6 +109,62 @@ def render(state: AppState) -> None:
     state.subscribe("scan_selected", _refresh)
     state.subscribe("scan_loaded", _refresh)
     state.subscribe("preprocess_done", _refresh)
+    # Recompute bulk mode when the dataset-tree checked set changes.
+    state.subscribe("checked_changed", _refresh)
+
+
+def _record_deconvolved(state: AppState, scan, deconvolution: bool) -> None:
+    """Track whether a scan's cached processed Raw came from the
+    deconvolution pipeline. HRF / activity estimation gate on this — a
+    GLM/hemoglobin preprocess (deconvolution=False) is removed from the set
+    so estimation refuses it until re-preprocessed in deconvolution mode."""
+    key = scan.path.resolve()
+    if deconvolution:
+        state.processed_deconvolved.add(key)
+    else:
+        state.processed_deconvolved.discard(key)
+
+
+def ensure_deconvolved_raw(state: AppState, scan):
+    """Return a deconvolution-preprocessed Raw for ``scan``, preprocessing on
+    demand if one isn't already cached.
+
+    Lets a bulk HRF / Activity run TRIGGER the preprocessing each scan needs
+    instead of skipping un-preprocessed scans. Runs synchronously (call from
+    a worker thread). Returns the processed Raw.
+
+    Raises ``RuntimeError`` (never returns None) with a specific reason when
+    the scan can't be made ready — the source file won't load, or the
+    deconvolution pipeline yields nothing. Raising rather than returning None
+    is deliberate: the bulk worker turns the exception into a per-scan failure
+    with this message, so the user sees *why* a scan dropped out instead of a
+    silent skip counted as success.
+
+    Reuse rule: a scan already preprocessed in deconvolution mode is returned
+    from cache as-is; a scan that's missing OR was GLM-preprocessed is
+    (re)run through the deconvolution pipeline so estimation gets valid input.
+    """
+    key = scan.path.resolve()
+    if scan in state.processed_cache and key in state.processed_deconvolved:
+        return state.processed_cache.get(scan)
+    try:
+        raw = state.raw_cache.get(scan)
+    except Exception as exc:  # noqa: BLE001 — bad/missing source file
+        logger.warning("ensure_deconvolved_raw: load failed for %s: %s",
+                       getattr(scan, "path", scan), exc)
+        raise RuntimeError(
+            f"could not load source file ({type(exc).__name__}: {exc})"
+        ) from exc
+    result = run_pipeline_sync(raw, PreprocessOptions(deconvolution=True))
+    if result is None:
+        raise RuntimeError(
+            "deconvolution preprocessing produced no output — the scan may "
+            "have no fNIRS channels, or every channel was dropped by the "
+            "pipeline (check the source file and montage)"
+        )
+    state.processed_cache._cache[key] = result
+    _record_deconvolved(state, scan, True)
+    return result
 
 
 def _resolve_checked_scans(state: AppState) -> list:
@@ -299,8 +367,11 @@ def _run_pipeline(
             return
         # run_pipeline_sync wraps the result so we can stash the processed
         # Raw under the scan path in processed_cache. put() enforces the LRU
-        # bound (a direct _cache write would not).
+        # bound (a direct _cache write would not). _record_deconvolved tracks
+        # whether this was a deconvolution-mode preprocess (the activity gate
+        # reads it).
         state.processed_cache.put(scan, result)
+        _record_deconvolved(state, scan, snapshot.deconvolution)
         state.publish("preprocess_done", scan)
 
     background_tasks.create(
@@ -342,34 +413,42 @@ def _run_pipeline_bulk(
 
     async def _on_each_done(scan: ScanEntry, result) -> None:
         if result is None:
-            return
-        # put() enforces the LRU bound; the prior direct _cache write let a
-        # bulk preprocess retain every result and grow memory unbounded.
+            # Counted as a failure (raising moves it to the failures bucket)
+            # so an empty pipeline result isn't silently scored as success.
+            raise RuntimeError(
+                "preprocessing produced no output — no fNIRS channels "
+                "survived the pipeline"
+            )
+        # put() enforces the LRU bound (the prior direct _cache write let a
+        # bulk preprocess retain every result and grow memory unbounded).
         state.processed_cache.put(scan, result)
+        _record_deconvolved(state, scan, snapshot.deconvolution)
         state.publish("preprocess_done", scan)
 
+    client = capture_client()
+
     async def _bulk() -> None:
-        bulk_result = await run_bulk_in_background(
-            state,
-            scans,
-            _build,
-            on_each_done=_on_each_done,
-            label="preprocess",
-        )
+        with client_scope(client):
+            bulk_result = await run_bulk_in_background(
+                state,
+                scans,
+                _build,
+                on_each_done=_on_each_done,
+                label="preprocess",
+            )
         if bulk_result is None:
             return
         successes, failures = bulk_result
         n_ok, n_fail = len(successes), len(failures)
         summary = f"Preprocessed {n_ok}/{n_ok + n_fail} scan(s)."
         if failures:
-            fail_names = ", ".join(
-                s.display_name or s.path.name for s, _ in failures[:3]
-            )
-            if len(failures) > 3:
-                fail_names += f" (+{len(failures) - 3} more)"
-            summary += f" Failed: {fail_names}."
-        ui.notify(
-            summary, type="positive" if n_fail == 0 else "warning"
+            summary += f" Failed: {summarize_failures(failures)}"
+        # Guarded: the page client may have been deleted during a long run.
+        notify_if_alive(
+            client, summary,
+            type="positive" if n_fail == 0 else "warning",
+            multi_line=True,
+            close_button=True,
         )
 
     background_tasks.create(_bulk())

--- a/src/hrfunc/gui/components/quality_panel.py
+++ b/src/hrfunc/gui/components/quality_panel.py
@@ -6,8 +6,14 @@ that researchers can use to QC scans before publication. Two views:
 - **Per-scan** (default): metrics for the currently-selected scan in
   whichever stages are cached. ``raw_cache`` provides the source signal
   for SCI; ``processed_cache`` provides preprocessed signal for
-  skewness/kurtosis/SNR; ``activity_raw`` (when the source scan matches
-  the selected scan) provides deconvolved signal for the same triplet.
+  skewness/kurtosis/SNR/variance; ``activity_cache`` (per scan) provides
+  the deconvolved signal for the same set. Beyond the stage-summary table,
+  a **channel-wise** table compares each channel across the three stages
+  (raw → hemoglobin → activity) with Δ (activity − hemoglobin) and ratio
+  (activity / hemoglobin) columns — the QC outcome for how much
+  deconvolution changed each channel. The raw column is mapped to a
+  haemoglobin channel by its source-detector prefix (raw wavelength
+  channels share the S-D pair).
 - **Dataset-wide aggregate**: a "Run on all scans" button kicks off a
   background task that walks every scan in the manifest, loading +
   preprocessing each (using library defaults) and computing the same
@@ -56,17 +62,28 @@ STAGE_DECONVOLVED = "deconvolved"
 class QualityMetrics:
     """Per-stage signal-quality summary.
 
-    Each field is a scalar averaged across channels. None for metrics that
-    weren't computable on the given stage (e.g. SCI is only meaningful on
-    raw fNIRS data in optical-amplitude units; it returns None for the
-    preprocessed/deconvolved stages).
+    The ``*_mean`` fields are scalars averaged across channels (used by the
+    dataset-wide aggregate plot and the stage-summary table). The
+    ``*_by_channel`` dicts map channel name -> value and drive the
+    channel-wise 3-stage table. None for metrics that weren't computable on
+    the given stage (e.g. SCI is only meaningful on raw fNIRS data in
+    optical-amplitude units; it is None for the preprocessed/deconvolved
+    stages).
     """
 
     snr_mean: Optional[float] = None
     skew_mean: Optional[float] = None
     kurtosis_mean: Optional[float] = None
+    variance_mean: Optional[float] = None
     sci_mean: Optional[float] = None
     n_channels: int = 0
+
+    # Per-channel breakdowns (channel name -> value). None when not computed.
+    snr_by_channel: Optional[Dict[str, float]] = None
+    skew_by_channel: Optional[Dict[str, float]] = None
+    kurtosis_by_channel: Optional[Dict[str, float]] = None
+    variance_by_channel: Optional[Dict[str, float]] = None
+    sci_by_channel: Optional[Dict[str, float]] = None
 
 
 def render(state: AppState) -> None:
@@ -154,33 +171,271 @@ def _render_per_scan(state: AppState, scan: ScanEntry) -> None:
                         ui.spinner(size="sm")
                         ui.label("Working…").classes("text-sm opacity-70")
         else:
-            _render_metrics_table(cached)
-            # A cached entry computed BEFORE Activity ran holds only the
-            # raw + preprocessed stages; nothing invalidates it when Activity
-            # later produces a deconvolved Raw for this scan. Offer an
-            # explicit recompute (the panel otherwise only shows the compute
-            # button on the empty branch) so the deconvolved row can be added
-            # without a full project reset.
-            deconv_available = (
-                STAGE_DECONVOLVED not in cached
-                and state.activity_raw is not None
-                and state.montage_source_scan is not None
-                and state.montage_source_scan.path == scan.path
-            )
-            with ui.row().classes("items-center gap-3 mt-2"):
-                recompute_disabled = (
-                    state.busy or scan not in state.processed_cache
-                )
+            # Offer a recompute so users can refresh after deconvolving (the
+            # cached metrics may predate the activity stage).
+            with ui.row().classes("items-center gap-2"):
                 ui.button(
-                    "Recompute metrics",
+                    "Recompute",
                     icon="refresh",
                     on_click=lambda: _run_per_scan(state, scan),
-                ).props(f"flat dense {'disable' if recompute_disabled else ''}")
-                if deconv_available:
+                ).props(f"flat dense {'disable' if state.busy else ''}")
+                if (
+                    STAGE_DECONVOLVED not in cached
+                    and scan in state.activity_cache
+                ):
                     ui.label(
-                        "Activity result available — recompute to add the "
-                        "deconvolved row."
-                    ).classes("text-sm opacity-60")
+                        "Activity available — recompute to include it."
+                    ).classes("text-xs opacity-60")
+            _render_metrics_table(cached)
+            ui.separator()
+            _render_channel_wise(state, scan, cached)
+
+
+# Metrics exposed in the channel-wise table, in display order.
+# (key on QualityMetrics, label). SCI is raw-only and handled separately.
+_CHANNEL_METRICS = (
+    ("snr_by_channel", "SNR"),
+    ("variance_by_channel", "Variance"),
+    ("skew_by_channel", "Skewness"),
+    ("kurtosis_by_channel", "Kurtosis"),
+)
+
+
+def _sd_prefix(ch_name: str) -> str:
+    """Source-detector prefix of a channel name ("S1_D1 hbo" -> "S1_D1").
+
+    Used to map a haemoglobin channel back to its raw wavelength channels,
+    which share the S-D pair but differ by the trailing chromophore /
+    wavelength token.
+    """
+    return ch_name.rsplit(" ", 1)[0] if " " in ch_name else ch_name
+
+
+def _raw_value_for(
+    raw_by_channel: Optional[Dict[str, float]], hemo_ch: str
+) -> Optional[float]:
+    """Raw-stage value for a haemoglobin channel, averaged over the raw
+    wavelength channels that share its source-detector pair."""
+    if not raw_by_channel:
+        return None
+    prefix = _sd_prefix(hemo_ch)
+    vals = [
+        v for ch, v in raw_by_channel.items()
+        if _sd_prefix(ch) == prefix and v is not None
+    ]
+    if not vals:
+        return None
+    return float(np.nanmean(vals))
+
+
+def _render_channel_wise(
+    state: AppState, scan: ScanEntry, stages_metrics: Dict[str, QualityMetrics]
+) -> None:
+    """Channel-wise QC across raw / hemoglobin / activity stages.
+
+    Rows are keyed by the haemoglobin (preprocessed) channel names — the
+    hemoglobin and activity stages align 1:1 there, so the Δ (activity −
+    hemoglobin) and ratio (activity / hemoglobin) columns are exact. The raw
+    column is mapped by source-detector prefix (raw wavelength channels share
+    the S-D pair), shown as a reference. One tab per metric.
+    """
+    hemo = stages_metrics.get(STAGE_PREPROCESSED)
+    raw_m = stages_metrics.get(STAGE_RAW)
+    act = stages_metrics.get(STAGE_DECONVOLVED)
+
+    ui.label("Channel-wise QC (raw → hemoglobin → activity)").classes(
+        "text-xs uppercase opacity-60 tracking-wide"
+    )
+
+    if hemo is None or not hemo.snr_by_channel and not hemo.variance_by_channel:
+        ui.label(
+            "Preprocess this scan to populate the channel-wise table."
+        ).classes("text-sm opacity-60")
+        return
+
+    if act is None:
+        with ui.row().classes("items-center gap-2"):
+            ui.icon("info").classes("text-amber-500")
+            ui.label(
+                "Deconvolve this scan on the Activity tab to fill the "
+                "activity / Δ / ratio columns."
+            ).classes("text-sm opacity-70")
+
+    # Channel order from the hemoglobin stage (the alignment key).
+    channels = sorted(
+        (hemo.variance_by_channel or hemo.snr_by_channel or {}).keys()
+    )
+    if not channels:
+        ui.label("No channels to display.").classes("text-sm opacity-60")
+        return
+
+    with ui.tabs().props("dense").classes("w-full") as metric_tabs:
+        for _key, label in _CHANNEL_METRICS:
+            ui.tab(label)
+    first_label = _CHANNEL_METRICS[0][1]
+    with ui.tab_panels(metric_tabs, value=first_label).classes("w-full"):
+        for key, label in _CHANNEL_METRICS:
+            with ui.tab_panel(label).classes("p-0"):
+                png = _render_channel_bar_png(
+                    key, label, channels, raw_m, hemo, act
+                )
+                if png is not None:
+                    ui.image(png).classes("w-full max-w-4xl")
+                _render_channel_metric_table(key, channels, raw_m, hemo, act)
+
+    # SCI is raw-only; surface it as a compact reference table when present.
+    if raw_m is not None and raw_m.sci_by_channel:
+        ui.label("Scalp coupling index (raw only)").classes(
+            "text-xs uppercase opacity-50 tracking-wide pt-2"
+        )
+        sci_rows = [
+            {"channel": ch, "sci": _format_metric(v)}
+            for ch, v in sorted(raw_m.sci_by_channel.items())
+        ]
+        ui.table(
+            columns=[
+                {"name": "channel", "label": "Channel", "field": "channel", "align": "left"},
+                {"name": "sci", "label": "SCI", "field": "sci", "align": "right"},
+            ],
+            rows=sci_rows,
+            row_key="channel",
+        ).classes("w-full").props("dense flat")
+
+
+def _render_channel_metric_table(
+    metric_key: str,
+    channels: List[str],
+    raw_m: Optional[QualityMetrics],
+    hemo: QualityMetrics,
+    act: Optional[QualityMetrics],
+) -> None:
+    """One metric's channel table: raw | hemoglobin | activity | Δ | ratio."""
+    raw_by = getattr(raw_m, metric_key) if raw_m is not None else None
+    hemo_by = getattr(hemo, metric_key) or {}
+    act_by = getattr(act, metric_key) if act is not None else None
+
+    rows = []
+    for ch in channels:
+        hemo_v = hemo_by.get(ch)
+        act_v = act_by.get(ch) if act_by else None
+        raw_v = _raw_value_for(raw_by, ch)
+
+        delta = (
+            act_v - hemo_v
+            if (act_v is not None and hemo_v is not None) else None
+        )
+        ratio = (
+            act_v / hemo_v
+            if (act_v is not None and hemo_v not in (None, 0)) else None
+        )
+        rows.append(
+            {
+                "channel": ch,
+                "raw": _format_metric(raw_v),
+                "hemo": _format_metric(hemo_v),
+                "activity": _format_metric(act_v),
+                "delta": _format_metric(delta),
+                "ratio": _format_metric(ratio),
+            }
+        )
+
+    ui.table(
+        columns=[
+            {"name": "channel", "label": "Channel", "field": "channel", "align": "left", "sortable": True},
+            {"name": "raw", "label": "Raw", "field": "raw", "align": "right", "sortable": True},
+            {"name": "hemo", "label": "Hemoglobin", "field": "hemo", "align": "right", "sortable": True},
+            {"name": "activity", "label": "Activity", "field": "activity", "align": "right", "sortable": True},
+            {"name": "delta", "label": "Δ (act−hemo)", "field": "delta", "align": "right", "sortable": True},
+            {"name": "ratio", "label": "Ratio (act/hemo)", "field": "ratio", "align": "right", "sortable": True},
+        ],
+        rows=rows,
+        row_key="channel",
+        pagination=0,
+    ).classes("w-full").props("dense flat")
+
+
+def _render_channel_bar_png(
+    metric_key: str,
+    label: str,
+    channels: List[str],
+    raw_m: Optional[QualityMetrics],
+    hemo: QualityMetrics,
+    act: Optional[QualityMetrics],
+) -> Optional[str]:
+    """Grouped bar chart of one metric per channel across the stages.
+
+    One cluster of bars per channel — raw / hemoglobin / activity — so the
+    per-channel quality and the hemoglobin → activity change are visible at a
+    glance. Stages with no data (e.g. activity before deconvolution) are
+    omitted. Returns a base64 PNG data URI, or None if nothing to plot.
+    """
+    try:
+        import matplotlib
+        matplotlib.use("Agg", force=False)
+        import matplotlib.pyplot as plt
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("matplotlib unavailable for channel bars: %s", exc)
+        return None
+
+    raw_by = getattr(raw_m, metric_key) if raw_m is not None else None
+    hemo_by = getattr(hemo, metric_key) or {}
+    act_by = getattr(act, metric_key) if act is not None else None
+
+    # One series per available stage (skip a stage with no usable values).
+    # Fixed colors: raw=orange, hemoglobin=red, neural activity=blue.
+    stage_colors = {
+        "Raw": "#ff7f0e",          # orange
+        "Hemoglobin": "#d62728",   # red
+        "Activity": "#1f77b4",     # blue
+    }
+    series: List[Tuple[str, List[float]]] = []
+    raw_vals = [_raw_value_for(raw_by, ch) for ch in channels]
+    hemo_vals = [hemo_by.get(ch) for ch in channels]
+    act_vals = [act_by.get(ch) if act_by else None for ch in channels]
+    for name, vals in (
+        ("Raw", raw_vals),
+        ("Hemoglobin", hemo_vals),
+        ("Activity", act_vals),
+    ):
+        if any(v is not None for v in vals):
+            series.append(
+                (name, [v if v is not None else np.nan for v in vals])
+            )
+    if not series:
+        return None
+
+    fig = None
+    try:
+        n = len(channels)
+        n_series = len(series)
+        x = np.arange(n)
+        # Bars share each channel's slot; width scales with series count.
+        width = 0.8 / n_series
+        fig, ax = plt.subplots(1, 1, figsize=(max(8, n * 0.5), 4))
+        for i, (name, vals) in enumerate(series):
+            offset = (i - (n_series - 1) / 2.0) * width
+            ax.bar(
+                x + offset, vals, width, label=name,
+                color=stage_colors.get(name),
+            )
+        ax.set_xticks(x)
+        ax.set_xticklabels(channels, rotation=60, ha="right", fontsize=8)
+        ax.set_ylabel(label)
+        ax.set_title(f"Per-channel {label} by stage")
+        ax.axhline(0, color="black", linewidth=0.6)
+        ax.legend(loc="upper right", fontsize=8)
+        fig.tight_layout()
+
+        buf = io.BytesIO()
+        fig.savefig(buf, format="png", dpi=100, bbox_inches="tight")
+        encoded = base64.b64encode(buf.getvalue()).decode("ascii")
+        return f"data:image/png;base64,{encoded}"
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("channel bar render failed: %s", exc)
+        return None
+    finally:
+        if fig is not None:
+            plt.close(fig)
 
 
 def _render_metrics_table(stages_metrics: Dict[str, QualityMetrics]) -> None:
@@ -194,6 +449,7 @@ def _render_metrics_table(stages_metrics: Dict[str, QualityMetrics]) -> None:
             {
                 "stage": stage_name,
                 "snr": _format_metric(m.snr_mean),
+                "variance": _format_metric(m.variance_mean),
                 "skew": _format_metric(m.skew_mean),
                 "kurtosis": _format_metric(m.kurtosis_mean),
                 "sci": _format_metric(m.sci_mean),
@@ -205,6 +461,7 @@ def _render_metrics_table(stages_metrics: Dict[str, QualityMetrics]) -> None:
         columns=[
             {"name": "stage", "label": "Stage", "field": "stage", "align": "left"},
             {"name": "snr", "label": "SNR", "field": "snr", "align": "right"},
+            {"name": "variance", "label": "Variance", "field": "variance", "align": "right"},
             {"name": "skew", "label": "Skewness", "field": "skew", "align": "right"},
             {"name": "kurtosis", "label": "Kurtosis", "field": "kurtosis", "align": "right"},
             {"name": "sci", "label": "SCI", "field": "sci", "align": "right"},
@@ -288,11 +545,15 @@ def _run_per_scan(state: AppState, scan: ScanEntry) -> None:
     raw_obj = state.raw_cache.get(scan) if scan in state.raw_cache else None
     processed_obj = state.processed_cache.get(scan)
     deconvolved_obj = None
-    if (
+    if scan in state.activity_cache:
+        # Per-scan deconvolution cache (any scan the user has run).
+        deconvolved_obj = state.activity_cache.get(scan)
+    elif (
         state.activity_raw is not None
         and state.montage_source_scan is not None
         and state.montage_source_scan.path == scan.path
     ):
+        # Fallback to the single most-recent result for the matching scan.
         deconvolved_obj = state.activity_raw
 
     async def _on_done(result) -> None:
@@ -474,6 +735,7 @@ def _compute_signal_metrics(raw: "mne.io.BaseRaw") -> QualityMetrics:
 
     raw.load_data()
     data = raw.get_data()
+    ch_names = list(raw.ch_names)
     n_ch = data.shape[0]
 
     # axis=1 → per-channel summaries. lens.calc_skewness_and_kurtosis
@@ -482,16 +744,35 @@ def _compute_signal_metrics(raw: "mne.io.BaseRaw") -> QualityMetrics:
     # the per-channel comparison plots downstream actually need.
     skew_vals = skew(data, axis=1)
     kurt_vals = kurtosis(data, axis=1)
+    var_vals = np.var(data, axis=1)
 
-    snr_mean = _compute_snr_safe(raw)
+    skew_by = {ch: float(v) for ch, v in zip(ch_names, skew_vals)}
+    kurt_by = {ch: float(v) for ch, v in zip(ch_names, kurt_vals)}
+    var_by = {ch: float(v) for ch, v in zip(ch_names, var_vals)}
+    snr_by = _compute_snr_by_channel(raw)
 
     return QualityMetrics(
-        snr_mean=snr_mean,
+        snr_mean=_nanmean_or_none(snr_by),
         skew_mean=float(np.nanmean(skew_vals)),
         kurtosis_mean=float(np.nanmean(kurt_vals)),
+        variance_mean=float(np.nanmean(var_vals)),
         sci_mean=None,
         n_channels=n_ch,
+        snr_by_channel=snr_by,
+        skew_by_channel=skew_by,
+        kurtosis_by_channel=kurt_by,
+        variance_by_channel=var_by,
     )
+
+
+def _nanmean_or_none(by_channel: Optional[Dict[str, float]]) -> Optional[float]:
+    """Mean of a by-channel dict's values, or None when absent/empty."""
+    if not by_channel:
+        return None
+    vals = [v for v in by_channel.values() if v is not None]
+    if not vals:
+        return None
+    return float(np.nanmean(vals))
 
 
 def _compute_raw_metrics(raw: "mne.io.BaseRaw") -> QualityMetrics:
@@ -501,23 +782,32 @@ def _compute_raw_metrics(raw: "mne.io.BaseRaw") -> QualityMetrics:
     MNE). If the data isn't suitable, SCI returns None and the rest of
     the metrics still populate.
     """
-    sci_mean = _compute_sci_safe(raw)
+    sci_by = _compute_sci_by_channel(raw)
     base = _compute_signal_metrics(raw)
     return QualityMetrics(
         snr_mean=base.snr_mean,
         skew_mean=base.skew_mean,
         kurtosis_mean=base.kurtosis_mean,
-        sci_mean=sci_mean,
+        variance_mean=base.variance_mean,
+        sci_mean=_nanmean_or_none(sci_by),
         n_channels=base.n_channels,
+        snr_by_channel=base.snr_by_channel,
+        skew_by_channel=base.skew_by_channel,
+        kurtosis_by_channel=base.kurtosis_by_channel,
+        variance_by_channel=base.variance_by_channel,
+        sci_by_channel=sci_by,
     )
 
 
-def _compute_sci_safe(raw: "mne.io.BaseRaw") -> Optional[float]:
-    """SCI mean across channels, None on failure.
+def _compute_sci_by_channel(
+    raw: "mne.io.BaseRaw",
+) -> Optional[Dict[str, float]]:
+    """Per-channel SCI (channel name -> value), None on failure.
 
     SCI is only defined on raw fNIRS cw_amplitude data. Wrapped in
     try/except because passing the wrong channel type raises ValueError
-    in MNE and we want the rest of the metrics to render anyway.
+    in MNE and we want the rest of the metrics to render anyway. Keyed by the
+    optical-density channel names (the raw wavelength channels).
     """
     try:
         import mne
@@ -525,14 +815,16 @@ def _compute_sci_safe(raw: "mne.io.BaseRaw") -> Optional[float]:
         raw_copy = raw.copy().load_data()
         od = mne.preprocessing.nirs.optical_density(raw_copy, verbose="ERROR")
         sci = mne.preprocessing.nirs.scalp_coupling_index(od, verbose="ERROR")
-        return float(np.nanmean(sci))
+        return {ch: float(v) for ch, v in zip(od.ch_names, sci)}
     except Exception as exc:  # noqa: BLE001
         logger.debug("SCI computation skipped: %s", exc)
         return None
 
 
-def _compute_snr_safe(raw: "mne.io.BaseRaw") -> Optional[float]:
-    """PSD-based SNR per lens.calc_snr, averaged across channels.
+def _compute_snr_by_channel(
+    raw: "mne.io.BaseRaw",
+) -> Optional[Dict[str, float]]:
+    """PSD-based per-channel SNR per lens.calc_snr (channel name -> value).
 
     Returns None on any MNE / scipy failure so the calling table still
     renders the skew/kurtosis numbers.
@@ -572,7 +864,9 @@ def _compute_snr_safe(raw: "mne.io.BaseRaw") -> Optional[float]:
         snr_per_channel = signal_power / np.where(
             noise_power > 0, noise_power, np.nan
         )
-        return float(np.nanmean(snr_per_channel))
+        return {
+            ch: float(v) for ch, v in zip(raw.ch_names, snr_per_channel)
+        }
     except Exception as exc:  # noqa: BLE001
         logger.debug("SNR computation skipped: %s", exc)
         return None

--- a/src/hrfunc/gui/events_io.py
+++ b/src/hrfunc/gui/events_io.py
@@ -1,0 +1,490 @@
+"""Parsing + impulse construction for user-supplied event files (HRFs tab).
+
+Many SNIRF / NIRx recordings reach the GUI with no usable MNE annotations,
+so the HRFs tab's event picker is empty and toeplitz estimation can't run.
+This module lets the user supply events from a file instead. Two shapes are
+accepted and auto-detected:
+
+- **BIDS ``events.tsv``** — a header row containing ``onset`` plus a label
+  column (``trial_type`` / ``value`` / ``condition``) and usually
+  ``duration``. Tab- or comma-separated; onset / duration in seconds. This
+  is the fNIRS/BIDS standard and carries explicit condition labels.
+- **Simple ``onset,label``** — two columns (onset seconds, label string),
+  header optional. Detected as a fallback. Because it has no BIDS
+  provenance, :func:`parse_events_file` flags it with
+  ``needs_simple_confirm`` so the UI can warn before using it.
+
+Everything here is ONSET-based: an event at time ``t`` becomes a ``1`` at
+sample ``round(t * sfreq)``. That's what lets one events table be applied
+across scans of differing length / sample rate -- the impulse series is
+rebuilt per scan from that scan's own ``sfreq`` and sample count
+(:func:`build_impulse_from_rows`), exactly mirroring the annotation path's
+``build_events_array``.
+
+Pure / UI-free so it's unit-testable without NiceGUI (same split as
+``submission.py``).
+"""
+
+from __future__ import annotations
+
+import csv
+import fnmatch
+import io
+import logging
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable, List, Optional, Sequence, Set
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+# Directories the events file-finder never descends into.
+_SKIP_DIRS = {".venv", "venv", "__pycache__", ".git", "node_modules", ".ipynb_checkpoints"}
+
+
+# Columns whose presence marks a file as a proper BIDS events table (so it's
+# used without the simple-format confirmation). ``label`` is deliberately NOT
+# here -- a bare ``onset,label`` file is the *simple* shape.
+_BIDS_LABEL_COLUMNS = ("trial_type", "value", "condition", "stim_type")
+# Where to read each event's label, in order of preference. Includes the
+# simple ``label`` column as a last resort.
+_LABEL_COLUMNS = _BIDS_LABEL_COLUMNS + ("label",)
+# Label used when a structured file has onsets but no recognizable label
+# column (every event then shares this single condition).
+_DEFAULT_LABEL = "event"
+# BIDS encodes "no value" as the literal string "n/a"; normalize it so it
+# doesn't masquerade as a real condition name.
+_NA_TOKENS = {"n/a", "na", "nan", ""}
+
+
+class EventsParseError(ValueError):
+    """Raised when a file can't be read as either supported events shape."""
+
+
+@dataclass
+class EventRow:
+    """One parsed event: an onset (seconds), a condition label, duration."""
+
+    onset: float
+    label: str
+    duration: float = 0.0
+
+
+@dataclass
+class EventsParse:
+    """Result of :func:`parse_events_file`.
+
+    - ``rows``: parsed events (already onset-sorted, bad rows dropped).
+    - ``fmt``: ``"bids"`` or ``"simple"``.
+    - ``needs_simple_confirm``: True when the file only matched the simple
+      ``onset,label`` shape -- the UI should warn + confirm before use.
+    - ``warnings``: non-fatal parse notes (skipped rows, missing label
+      column, etc.) to surface to the user.
+    - ``source_name``: the file's display name.
+    """
+
+    rows: List[EventRow]
+    fmt: str
+    needs_simple_confirm: bool
+    warnings: List[str] = field(default_factory=list)
+    source_name: str = ""
+    # Set for the "impulse" format: a per-sample 0/1 design vector (one value
+    # per timepoint), the shape estimate_hrf consumes directly. Indexed by
+    # SAMPLE, not time, so it's applied per scan by sample index (and the
+    # coverage check flags a scan shorter than the vector). ``rows`` is empty
+    # in this case; the single synthetic condition is labelled "events".
+    impulse: Optional[List[int]] = None
+
+    def labels(self) -> List[str]:
+        """Sorted unique condition labels (or ["events"] for an impulse vector)."""
+        if self.impulse is not None:
+            return ["events"]
+        return sorted({r.label for r in self.rows})
+
+
+def _detect_delimiter(sample: str) -> str:
+    """Tab if the first non-empty line has one, else comma.
+
+    BIDS ``events.tsv`` is tab-separated; the simple fallback is usually a
+    CSV. Sniffing the first populated line is enough -- we don't need
+    csv.Sniffer's heuristics (which misfire on 2-column files).
+    """
+    for line in sample.splitlines():
+        if line.strip():
+            return "\t" if "\t" in line else ","
+    return ","
+
+
+def _is_float(token: str) -> bool:
+    try:
+        float(token)
+        return True
+    except (TypeError, ValueError):
+        return False
+
+
+def _clean_label(raw: str) -> str:
+    token = (raw or "").strip()
+    if token.lower() in _NA_TOKENS:
+        return _DEFAULT_LABEL
+    return token
+
+
+def parse_events_file(path: Path) -> EventsParse:
+    """Parse an events file as BIDS ``events.tsv`` or simple ``onset,label``.
+
+    Detection:
+      1. Header present (a cell equals ``onset``, case-insensitive) AND a
+         recognized label column or a ``duration`` column -> ``bids``.
+      2. Header present with ``onset`` but no label/duration column, OR no
+         header but the first column parses as a float -> ``simple``
+         (``needs_simple_confirm=True``).
+      3. Otherwise -> :class:`EventsParseError`.
+
+    Rows whose onset isn't numeric are skipped (recorded in ``warnings``).
+    Raises :class:`EventsParseError` on an empty / unreadable file or when
+    no rows survive parsing.
+    """
+    try:
+        text = path.read_text(encoding="utf-8-sig")  # tolerate a BOM
+    except Exception as exc:  # noqa: BLE001
+        raise EventsParseError(f"Could not read {path.name}: {exc}") from exc
+
+    delimiter = _detect_delimiter(text)
+    table = [
+        row for row in csv.reader(io.StringIO(text), delimiter=delimiter)
+        if any(cell.strip() for cell in row)  # drop blank lines
+    ]
+    if not table:
+        raise EventsParseError(f"{path.name} is empty.")
+
+    header = [cell.strip().lower() for cell in table[0]]
+    has_header = "onset" in header
+
+    warnings: List[str] = []
+
+    if has_header:
+        onset_idx = header.index("onset")
+        label_idx: Optional[int] = next(
+            (header.index(c) for c in _LABEL_COLUMNS if c in header), None
+        )
+        duration_idx = header.index("duration") if "duration" in header else None
+        # BIDS proper is marked by a trial_type/value/condition column or a
+        # duration column. A header of just onset(+label) is the simple shape
+        # and should trigger the confirm.
+        is_bids = (
+            any(c in header for c in _BIDS_LABEL_COLUMNS)
+            or duration_idx is not None
+        )
+        if label_idx is None:
+            # Structured but unlabeled: maybe a 2nd column is an implicit
+            # label (simple), else everything shares the default label.
+            if len(header) >= 2 and not is_bids:
+                label_idx = 1 if onset_idx != 1 else 0
+            else:
+                warnings.append(
+                    "No trial_type/value/condition column found; all events "
+                    f"labeled '{_DEFAULT_LABEL}'."
+                )
+        fmt = "bids" if is_bids else "simple"
+        data_rows = table[1:]
+    else:
+        # No header. Accept only if the first column is numeric.
+        if not table[0] or not _is_float(table[0][0]):
+            raise EventsParseError(
+                f"{path.name} has no 'onset' header and its first column "
+                "isn't numeric -- can't read it as onset,label events."
+            )
+        # Per-sample impulse vector: a single column whose values are all 0/1
+        # (one value per timepoint), not onset times. Detect and return it as
+        # the "impulse" format so it's applied by sample index rather than
+        # misread as onsets-at-t=0/1.
+        single_col_vals = [
+            r[0].strip() for r in table if r and r[0].strip()
+        ]
+        is_single_col = all(len(r) == 1 for r in table) and single_col_vals
+        if is_single_col and all(
+            _is_float(v) and float(v) in (0.0, 1.0) for v in single_col_vals
+        ):
+            impulse = [int(float(v)) for v in single_col_vals]
+            impulse_warnings = []
+            if sum(impulse) == 0:
+                impulse_warnings.append(
+                    "Impulse vector contains no events (all zeros)."
+                )
+            return EventsParse(
+                rows=[],
+                fmt="impulse",
+                needs_simple_confirm=False,
+                warnings=impulse_warnings,
+                source_name=path.name,
+                impulse=impulse,
+            )
+        onset_idx = 0
+        label_idx = 1 if len(table[0]) >= 2 else None
+        duration_idx = None
+        fmt = "simple"
+        data_rows = table
+
+    rows: List[EventRow] = []
+    for i, raw_row in enumerate(data_rows):
+        if onset_idx >= len(raw_row) or not _is_float(raw_row[onset_idx]):
+            warnings.append(f"Skipped row {i + 1}: onset not numeric.")
+            continue
+        onset = float(raw_row[onset_idx])
+        label = (
+            _clean_label(raw_row[label_idx])
+            if label_idx is not None and label_idx < len(raw_row)
+            else _DEFAULT_LABEL
+        )
+        duration = 0.0
+        if duration_idx is not None and duration_idx < len(raw_row):
+            if _is_float(raw_row[duration_idx]):
+                duration = float(raw_row[duration_idx])
+        rows.append(EventRow(onset=onset, label=label, duration=duration))
+
+    if not rows:
+        raise EventsParseError(
+            f"{path.name} parsed to zero usable events."
+        )
+
+    rows.sort(key=lambda r: r.onset)
+    return EventsParse(
+        rows=rows,
+        fmt=fmt,
+        needs_simple_confirm=(fmt == "simple"),
+        warnings=warnings,
+        source_name=path.name,
+    )
+
+
+def build_impulse_from_rows(
+    rows: Sequence[EventRow],
+    labels: Iterable[str],
+    sfreq: float,
+    n_samples: int,
+) -> "np.ndarray":
+    """Build a 0/1 impulse series of length ``n_samples`` from event rows.
+
+    Mirrors ``hrf_panel.build_events_array`` but sources onsets from a parsed
+    file rather than MNE annotations. An event whose label is in ``labels``
+    becomes a ``1`` at ``round(onset * sfreq)``; onsets outside
+    ``[0, n_samples)`` are dropped (surfaced separately via
+    :func:`coverage_report`). Built per scan, so one table fits any length.
+    """
+    label_set = set(labels)
+    out = np.zeros(int(n_samples), dtype=np.int64)
+    for row in rows:
+        if row.label not in label_set:
+            continue
+        sample = int(round(row.onset * sfreq))
+        if 0 <= sample < n_samples:
+            out[sample] = 1
+    return out
+
+
+def build_impulse_from_vector(
+    impulse: Sequence[int], n_samples: int
+) -> "np.ndarray":
+    """Fit a per-sample impulse vector to a scan's length.
+
+    The vector is sample-indexed, so it's applied position-for-position:
+    truncated if longer than the scan, zero-padded if shorter. (A length
+    mismatch means the vector was made for a different-length recording —
+    :func:`coverage_report_vector` surfaces that for the Estimate warning.)
+    """
+    out = np.zeros(int(n_samples), dtype=np.int64)
+    m = min(len(impulse), int(n_samples))
+    for i in range(m):
+        if impulse[i]:
+            out[i] = 1
+    return out
+
+
+_EVENT_DISCOVERY_EXTS = (".tsv", ".csv", ".txt")
+
+
+def find_event_files(
+    root, pattern: str = "", limit: int = 300
+) -> List[Path]:
+    """Recursively find candidate event files under ``root`` (the find window).
+
+    The glob ``pattern`` is matched case-insensitively against each file NAME
+    (``fnmatch``). A bare term with no wildcard is treated as a substring
+    (wrapped to ``*term*``). An empty pattern lists all event-extension files
+    (.tsv/.csv/.txt). Noise dirs (.venv, __pycache__, .git, …) and hidden
+    dirs are skipped. Returns sorted paths capped at ``limit``; never raises.
+    """
+    pat = (pattern or "").strip().lower()
+    if pat and not any(ch in pat for ch in "*?["):
+        pat = f"*{pat}*"  # bare term -> substring match
+    results: List[Path] = []
+    try:
+        for dirpath, dirnames, filenames in os.walk(root):
+            dirnames[:] = [
+                d for d in dirnames
+                if d not in _SKIP_DIRS and not d.startswith(".")
+            ]
+            for name in filenames:
+                low = name.lower()
+                if pat:
+                    if not fnmatch.fnmatch(low, pat):
+                        continue
+                elif Path(low).suffix not in _EVENT_DISCOVERY_EXTS:
+                    continue
+                results.append(Path(dirpath) / name)
+                if len(results) >= limit:
+                    return sorted(results)
+    except OSError:
+        pass
+    return sorted(results)
+
+
+def _bids_events_prefix(scan_path: Path) -> Optional[str]:
+    """BIDS entity prefix for a scan, e.g. ``sub-01_task-x_nirs`` -> ``sub-01_task-x``.
+
+    Returns None when the name isn't BIDS-like (must start with ``sub-`` and
+    contain a ``_``). Used to look for a sibling ``<prefix>_events.tsv``.
+    """
+    stem = scan_path.stem if scan_path.suffix else scan_path.name
+    if not stem.startswith("sub-") or "_" not in stem:
+        return None
+    head, _, _last = stem.rpartition("_")
+    return head or None
+
+
+def discover_collocated_events(
+    scan_path: Path, all_scan_paths: Sequence[Path] = ()
+) -> Optional[Path]:
+    """Find an events file collocated with ``scan_path``.
+
+    Strategy (matches the locked UX decision):
+      1. **BIDS-strict** — a ``<entities>_events.tsv`` in the scan's folder
+         sharing the scan's BIDS entity prefix.
+      2. **Lone-file fallback** — if the scan's folder holds exactly one event
+         file (``.tsv`` / ``.csv``, or a ``.txt`` named like events/onsets) and
+         at most this one scan, use it.
+
+    Returns the matched Path, or None. Never raises (filesystem errors -> None)
+    so it's safe to call from a render path. Pure aside from the directory
+    read, so it's unit-testable with real temp files.
+    """
+    try:
+        folder = scan_path.parent
+        if not folder.is_dir():
+            return None
+
+        prefix = _bids_events_prefix(scan_path)
+        if prefix:
+            bids_candidate = folder / f"{prefix}_events.tsv"
+            if bids_candidate.is_file():
+                return bids_candidate
+
+        def _is_event_file(p: Path) -> bool:
+            suffix = p.suffix.lower()
+            if suffix in (".tsv", ".csv"):
+                return True
+            if suffix == ".txt":
+                low = p.name.lower()
+                return "event" in low or "onset" in low
+            return False
+
+        event_files = [
+            p for p in folder.iterdir() if p.is_file() and _is_event_file(p)
+        ]
+        folder_resolved = folder.resolve()
+        scans_here = [
+            p for p in all_scan_paths
+            if Path(p).resolve().parent == folder_resolved
+        ]
+        if len(event_files) == 1 and len(scans_here) <= 1:
+            return event_files[0]
+        return None
+    except OSError:
+        return None
+
+
+@dataclass
+class Coverage:
+    """How a selected event set lands against one scan's time axis."""
+
+    placed: int          # events that land inside the usable window
+    past_end: int        # onsets at/after the scan end (dropped)
+    in_edge: int         # onsets inside the dropped edge-expansion window
+    max_onset_s: float   # latest selected onset, seconds
+    scan_seconds: float  # scan duration, seconds
+
+
+def coverage_report(
+    rows: Sequence[EventRow],
+    labels: Iterable[str],
+    sfreq: float,
+    n_samples: int,
+    edge_samples: int = 0,
+) -> Coverage:
+    """Count how selected events land against a scan (for the Estimate check).
+
+    ``edge_samples`` is the toeplitz edge-expansion window at the start of
+    the scan (``round(edge_expansion * duration * sfreq)`` in the core); the
+    library shifts onsets back into it and drops anything that would precede
+    t=0, so events there don't contribute and are worth flagging.
+    """
+    label_set = set(labels)
+    placed = past_end = in_edge = 0
+    max_onset_s = 0.0
+    for row in rows:
+        if row.label not in label_set:
+            continue
+        max_onset_s = max(max_onset_s, row.onset)
+        sample = int(round(row.onset * sfreq))
+        if sample < 0 or sample >= n_samples:
+            past_end += 1
+        elif sample < edge_samples:
+            in_edge += 1
+        else:
+            placed += 1
+    scan_seconds = (n_samples / sfreq) if sfreq > 0 else 0.0
+    return Coverage(
+        placed=placed,
+        past_end=past_end,
+        in_edge=in_edge,
+        max_onset_s=max_onset_s,
+        scan_seconds=scan_seconds,
+    )
+
+
+def coverage_report_vector(
+    impulse: Sequence[int],
+    sfreq: float,
+    n_samples: int,
+    edge_samples: int = 0,
+) -> Coverage:
+    """Coverage for a per-sample impulse vector against a scan.
+
+    The vector is sample-indexed: events at index >= n_samples fall past the
+    scan end (the vector is longer than this recording), and events at index
+    < edge_samples sit in the dropped edge window.
+    """
+    placed = past_end = in_edge = 0
+    last_event_idx = 0
+    for i, value in enumerate(impulse):
+        if not value:
+            continue
+        last_event_idx = i
+        if i >= n_samples:
+            past_end += 1
+        elif i < edge_samples:
+            in_edge += 1
+        else:
+            placed += 1
+    scan_seconds = (n_samples / sfreq) if sfreq > 0 else 0.0
+    max_onset_s = (last_event_idx / sfreq) if sfreq > 0 else 0.0
+    return Coverage(
+        placed=placed,
+        past_end=past_end,
+        in_edge=in_edge,
+        max_onset_s=max_onset_s,
+        scan_seconds=scan_seconds,
+    )

--- a/src/hrfunc/gui/pages/shell.py
+++ b/src/hrfunc/gui/pages/shell.py
@@ -180,6 +180,18 @@ def _render(state: AppState) -> None:
     state.subscribe(
         "navigate_preprocess", lambda *_: tabs.set_value(TAB_PREPROCESS)
     )
+    # The Activity tab publishes ``navigate_estimate`` when the chosen HRF
+    # source is "estimated HRFs" but none are in memory yet — linking the
+    # user straight to the HRFs tab to estimate them.
+    state.subscribe(
+        "navigate_estimate", lambda *_: tabs.set_value(TAB_ESTIMATE)
+    )
+    # The Activity tab publishes ``navigate_hrtree`` when the chosen HRF
+    # source is "HRtree HRF" but none is selected — linking the user to the
+    # HRtree tab to pick one.
+    state.subscribe(
+        "navigate_hrtree", lambda *_: tabs.set_value(TAB_HRTREE)
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/src/hrfunc/gui/state.py
+++ b/src/hrfunc/gui/state.py
@@ -251,6 +251,11 @@ class AppState:
     selected_scan: Optional[ScanEntry] = None
     raw_cache: RawCache = field(default_factory=RawCache)
     processed_cache: RawCache = field(default_factory=RawCache)
+    # LRU(3) of *deconvolved* (neural-activity) Raw objects, keyed per scan.
+    # ``activity_raw`` only holds the single most-recent result; this cache
+    # keeps each scan's deconvolution so channel-wise 3-stage QC (raw vs
+    # hemoglobin vs activity) can read a scan's activity without re-running.
+    activity_cache: RawCache = field(default_factory=RawCache)
     preload_path: Optional[Path] = None
     busy: bool = False
     estimation_progress: Optional[Tuple[int, int, str]] = None
@@ -281,6 +286,12 @@ class AppState:
     # scan B's Raw would silently produce wrong results because the library
     # matches by channel name, not by scan identity.
     montage_source_scan: Optional[ScanEntry] = None
+    # Per-scan estimated montages, keyed by ``ScanEntry.path.resolve()``.
+    # ``montage`` only holds the single most-recent estimate; this cache keeps
+    # each scan's HRFs so toeplitz activity can deconvolve every scan with its
+    # OWN HRFs (single + bulk) instead of erroring "HRFs belong to another
+    # scan". Only real per-channel Montages are stored (never _CanonicalResult).
+    montage_cache: Dict[Path, Any] = field(default_factory=dict)
     # Deconvolved Raw from the most recent estimate_activity call (Sprint 3.4).
     # Typed Any for the same import-graph reason. The Activity panel reads
     # the data + annotations for the lens-style preproc/deconv overlay plot.
@@ -322,6 +333,40 @@ class AppState:
     # full-detail view. None = no channel focused yet (grid renders, no
     # detail view).
     hrf_selected_channel: Optional[str] = None
+    # User-uploaded events for HRF estimation (HRFs tab). Many scans reach
+    # the GUI without usable MNE annotations, so the event picker would be
+    # empty; an uploaded events file supplies onsets instead. ``events_rows``
+    # is a list of ``events_io.EventRow`` (typed Any to keep events_io out of
+    # the state import graph). When set, it OVERRIDES a scan's embedded
+    # annotations for the scans it applies to: the scan recorded in
+    # ``events_source_scan`` always, plus every scan when ``events_apply_all``
+    # is True (paradigms shared across scans). ``events_format`` is
+    # "bids"/"simple" for the source badge; ``events_source_label`` is the
+    # filename. All cleared on reset / project switch.
+    events_rows: Optional[List[Any]] = None
+    # Per-sample 0/1 impulse/design vector (events_io "impulse" format),
+    # mutually exclusive with events_rows. Applied by sample index.
+    events_impulse: Optional[List[int]] = None
+    events_format: Optional[str] = None
+    events_source_label: Optional[str] = None
+    events_apply_all: bool = False
+    events_source_scan: Optional[ScanEntry] = None
+    # True when the current events were auto-matched from a collocated file
+    # (drives the "auto-matched" badge vs an explicit upload).
+    events_is_automatched: bool = False
+    # Resolved scan paths the auto-matcher should leave alone: scans the user
+    # manually set/cleared, or scans where discovery already ran and found
+    # nothing. Prevents re-clobbering a manual choice and avoids re-scanning
+    # the folder every render. Cleared on reset / project switch.
+    events_no_automatch: Set[Path] = field(default_factory=set)
+    # Resolved scan paths whose ``processed_cache`` entry was produced with
+    # the DECONVOLUTION preprocessing pipeline (deconvolution=True). HRF and
+    # neural-activity estimation require deconvolution-preprocessed data, so
+    # the HRFs / Activity tabs gate on membership here; a GLM/hemoglobin
+    # preprocess (deconvolution=False) is intentionally NOT added, which
+    # blocks estimation until the scan is re-preprocessed in deconvolution
+    # mode. Updated wherever a processed Raw is cached; cleared on reset.
+    processed_deconvolved: Set[Path] = field(default_factory=set)
     # Toggles for the MNI fsaverage overlay surfaces on the /library
     # plotly viz. The "brain" toggle controls the pial cortical
     # surface (where the neural activity originates); the "scalp"
@@ -333,6 +378,12 @@ class AppState:
     # cortex-relative position is the scientifically meaningful one.
     library_show_brain: bool = True
     library_show_scalp: bool = True
+    # Toggle for the per-HRF metadata hover popups on the /library viz. When
+    # False the scatter markers use hoverinfo="none" -- the tooltip is hidden
+    # but hover/click events still fire, so ROI clicks and shift-hover paint
+    # keep working. Defaults ON (the popups are the main way to read an HRF's
+    # context); users dealing with dense clouds can switch them off.
+    library_show_info: bool = True
     # Oxygenation filter for the /library viz. ``"both"`` (default)
     # shows HbO + HbR; ``"hbo"`` / ``"hbr"`` hide the other channel.
     # Researchers often want to inspect one haemoglobin at a time;
@@ -771,6 +822,8 @@ class AppState:
         self.selected_scan = None
         self.raw_cache.clear()
         self.processed_cache.clear()
+        self.activity_cache.clear()
+        self.montage_cache.clear()
         self.preload_path = None
         self.busy = False
         self.estimation_progress = None
@@ -785,6 +838,15 @@ class AppState:
         self.montage = None
         self.montage_source_scan = None
         self.activity_raw = None
+        self.events_rows = None
+        self.events_impulse = None
+        self.events_format = None
+        self.events_source_label = None
+        self.events_apply_all = False
+        self.events_source_scan = None
+        self.events_is_automatched = False
+        self.events_no_automatch.clear()
+        self.processed_deconvolved.clear()
         self.activity_source_scan = None
         self.quality_metrics.clear()
         # Note: library_hbo / library_hbr are deliberately NOT cleared by
@@ -796,6 +858,7 @@ class AppState:
         # context overlays when they re-enter the library page.
         self.library_show_brain = True
         self.library_show_scalp = True
+        self.library_show_info = True
         self.library_oxygenation = "both"
         # Per-ROI cluster state lives in ``cluster_rois``. Layout
         # refactor (2026-05-16) made the empty list the default; adding

--- a/src/hrfunc/gui/workers.py
+++ b/src/hrfunc/gui/workers.py
@@ -26,7 +26,69 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from typing import Any, Awaitable, Callable, List, Optional, Sequence, Tuple
+from contextlib import nullcontext
+from typing import Any, Awaitable, Callable, List, Optional, Sequence, Tuple, Union
+
+
+def capture_client():
+    """Return the current NiceGUI client, or None if there's no slot context.
+
+    Call this synchronously inside an event handler / render slot (where a
+    client context exists). The returned client can then be re-entered from a
+    detached ``background_tasks.create`` coroutine via :func:`client_scope`,
+    so UI calls there (``ui.notify``, refreshable ``.refresh()``) have a slot
+    — without it they raise "The current slot cannot be determined ... slot
+    stack is empty".
+    """
+    try:
+        from nicegui import context
+        return context.client
+    except Exception:  # noqa: BLE001 — no slot / headless / tests
+        return None
+
+
+def client_scope(client):
+    """Context manager that re-enters ``client`` (from :func:`capture_client`),
+    or a no-op when it's None. Use inside a background task:
+    ``with client_scope(client): ui.notify(...)``."""
+    return client if client is not None else nullcontext()
+
+
+def client_alive(client) -> bool:
+    """True if a captured client still exists (not deleted / disconnected).
+
+    A long background task can outlive its page client — the user navigates
+    away, reloads, or the native window's client reconnects mid-run. Touching
+    a deleted client (``ui.notify``, ``.refresh()``) trips NiceGUI's "Client
+    has been deleted but is still being used" warning. Guard UI emissions from
+    detached tasks with this so a finished bulk run doesn't warn/raise when
+    its page is gone.
+    """
+    if client is None:
+        return False
+    try:
+        from nicegui import Client
+        return client.id in Client.instances
+    except Exception:  # noqa: BLE001 — nicegui internals / headless / tests
+        return False
+
+
+def notify_if_alive(client, message: str, **kwargs) -> None:
+    """``ui.notify(message, **kwargs)`` only if ``client`` is still alive.
+
+    Re-enters the client's slot context to emit; silently skips (logging at
+    debug) when the page client has been deleted, so a completed background
+    task can report its result without crashing on a stale client.
+    """
+    if not client_alive(client):
+        logger.debug("notify_if_alive: client gone; skipping toast: %s", message)
+        return
+    try:
+        from nicegui import ui
+        with client:
+            ui.notify(message, **kwargs)
+    except Exception as exc:  # noqa: BLE001 — client died between check & emit
+        logger.debug("notify_if_alive: notify failed: %s", exc)
 
 from .state import AppState
 from ..io.manifest import ScanEntry
@@ -121,10 +183,49 @@ async def run_in_background(
 BulkResult = Tuple[List[ScanEntry], List[Tuple[ScanEntry, str]]]
 
 
+def summarize_failures(
+    failures: Sequence[Tuple[ScanEntry, str]], limit: int = 4
+) -> str:
+    """Render a bulk run's failures into a human-readable, reason-first string.
+
+    Bulk summary toasts used to list only scan *names* ("Failed: a, b, c"),
+    which told the user nothing about *why*. This groups failures by their
+    reason so the toast says e.g.::
+
+        2 scans: deconvolution preprocessing produced no output …;
+        1 scan: toeplitz needs estimated HRFs in memory …
+
+    Identical reasons are collapsed with a count; distinct reasons are listed
+    (up to ``limit``) so a mixed batch still shows each failure mode. An
+    example scan name is appended to each reason group so the user can find
+    the offending file.
+    """
+    if not failures:
+        return ""
+    # Preserve first-seen order of reasons while grouping scans under each.
+    grouped: "dict[str, List[ScanEntry]]" = {}
+    for scan, reason in failures:
+        grouped.setdefault(reason or "unknown error", []).append(scan)
+
+    parts: List[str] = []
+    for reason, scans in list(grouped.items())[:limit]:
+        example = scans[0].display_name or scans[0].path.name
+        if len(scans) == 1:
+            parts.append(f"{example}: {reason}")
+        else:
+            parts.append(f"{len(scans)} scans ({example}, …): {reason}")
+    if len(grouped) > limit:
+        parts.append(f"(+{len(grouped) - limit} more failure type(s))")
+    return " | ".join(parts)
+
+
 async def run_bulk_in_background(
     state: AppState,
     scans: Sequence[ScanEntry],
-    build_call: Callable[[ScanEntry], Optional[Tuple[Callable[..., Any], tuple, dict]]],
+    build_call: Callable[
+        [ScanEntry],
+        Union[None, str, Tuple[Callable[..., Any], tuple, dict]],
+    ],
     *,
     on_each_done: Optional[Callable[[ScanEntry, Any], Awaitable[None]]] = None,
     label: str = "bulk run",
@@ -139,9 +240,15 @@ async def run_bulk_in_background(
 
     The per-scan call is built by ``build_call(scan) -> (func, args, kwargs)``
     so each panel can layer its own preflight (e.g. "is the raw cached
-    for this scan?") without duplicating the dispatch machinery. Returning
-    ``None`` from ``build_call`` skips the scan with a "not ready"
-    reason -- counted as skipped, not failed.
+    for this scan?") without duplicating the dispatch machinery.
+
+    A ``build_call`` may decline a scan in two ways, both recorded in the
+    failures bucket so the summary toast can explain why:
+
+    - return ``None`` -- a generic, reasonless skip (legacy behaviour);
+    - return a ``str`` -- an intentional skip carrying that exact reason
+      (e.g. "toeplitz needs estimated HRFs in memory"). Prefer this so the
+      user sees *why* a scan was passed over, not just that it was.
 
     Continue-on-error semantics: per-scan exceptions are caught, logged,
     stamped onto ``state.last_error`` (overwritten per failure), and the
@@ -191,7 +298,13 @@ async def run_bulk_in_background(
                 continue
 
             if built is None:
-                failures.append((scan, "skipped (preflight)"))
+                failures.append(
+                    (scan, "skipped — not eligible for this run (preflight)")
+                )
+                continue
+            if isinstance(built, str):
+                # Intentional skip carrying its own reason.
+                failures.append((scan, built))
                 continue
 
             func, args, kwargs = built

--- a/src/hrfunc/hrfs/hbo_hrfs.json
+++ b/src/hrfunc/hrfs/hbo_hrfs.json
@@ -481,16 +481,23 @@
         "sfreq": 7.8125,
         "context": {
             "method": "toeplitz",
-            "doi": "temp",
-            "study": null,
-            "task": null,
-            "conditions": null,
-            "stimulus": null,
+            "doi": "10.1117/1.NPh.13.S1.S17801",
+            "study": "Parent-Child Anxiety Transmission Study (P-CAT)",
+            "task": "flanker",
+            "conditions": [
+                "congruent",
+                "incongruent",
+                "baseline"
+            ],
+            "stimulus": "directional flanker images",
             "intensity": null,
             "duration": 30.0,
-            "protocol": null,
-            "age_range": null,
-            "demographics": null
+            "protocol": "block design",
+            "age_range": [
+                4,
+                7
+            ],
+            "demographics": "children aged 4-7 (n=79)"
         },
         "estimates": [
             [
@@ -11583,16 +11590,23 @@
         "sfreq": 7.8125,
         "context": {
             "method": "toeplitz",
-            "doi": "temp",
-            "study": null,
-            "task": null,
-            "conditions": null,
-            "stimulus": null,
+            "doi": "10.1117/1.NPh.13.S1.S17801",
+            "study": "Parent-Child Anxiety Transmission Study (P-CAT)",
+            "task": "flanker",
+            "conditions": [
+                "congruent",
+                "incongruent",
+                "baseline"
+            ],
+            "stimulus": "directional flanker images",
             "intensity": null,
             "duration": 30.0,
-            "protocol": null,
-            "age_range": null,
-            "demographics": null
+            "protocol": "block design",
+            "age_range": [
+                4,
+                7
+            ],
+            "demographics": "children aged 4-7 (n=79)"
         },
         "estimates": [
             [
@@ -22685,16 +22699,23 @@
         "sfreq": 7.8125,
         "context": {
             "method": "toeplitz",
-            "doi": "temp",
-            "study": null,
-            "task": null,
-            "conditions": null,
-            "stimulus": null,
+            "doi": "10.1117/1.NPh.13.S1.S17801",
+            "study": "Parent-Child Anxiety Transmission Study (P-CAT)",
+            "task": "flanker",
+            "conditions": [
+                "congruent",
+                "incongruent",
+                "baseline"
+            ],
+            "stimulus": "directional flanker images",
             "intensity": null,
             "duration": 30.0,
-            "protocol": null,
-            "age_range": null,
-            "demographics": null
+            "protocol": "block design",
+            "age_range": [
+                4,
+                7
+            ],
+            "demographics": "children aged 4-7 (n=79)"
         },
         "estimates": [
             [
@@ -33787,16 +33808,23 @@
         "sfreq": 7.8125,
         "context": {
             "method": "toeplitz",
-            "doi": "temp",
-            "study": null,
-            "task": null,
-            "conditions": null,
-            "stimulus": null,
+            "doi": "10.1117/1.NPh.13.S1.S17801",
+            "study": "Parent-Child Anxiety Transmission Study (P-CAT)",
+            "task": "flanker",
+            "conditions": [
+                "congruent",
+                "incongruent",
+                "baseline"
+            ],
+            "stimulus": "directional flanker images",
             "intensity": null,
             "duration": 30.0,
-            "protocol": null,
-            "age_range": null,
-            "demographics": null
+            "protocol": "block design",
+            "age_range": [
+                4,
+                7
+            ],
+            "demographics": "children aged 4-7 (n=79)"
         },
         "estimates": [
             [
@@ -44889,16 +44917,23 @@
         "sfreq": 7.8125,
         "context": {
             "method": "toeplitz",
-            "doi": "temp",
-            "study": null,
-            "task": null,
-            "conditions": null,
-            "stimulus": null,
+            "doi": "10.1117/1.NPh.13.S1.S17801",
+            "study": "Parent-Child Anxiety Transmission Study (P-CAT)",
+            "task": "flanker",
+            "conditions": [
+                "congruent",
+                "incongruent",
+                "baseline"
+            ],
+            "stimulus": "directional flanker images",
             "intensity": null,
             "duration": 30.0,
-            "protocol": null,
-            "age_range": null,
-            "demographics": null
+            "protocol": "block design",
+            "age_range": [
+                4,
+                7
+            ],
+            "demographics": "children aged 4-7 (n=79)"
         },
         "estimates": [
             [
@@ -55991,16 +56026,23 @@
         "sfreq": 7.8125,
         "context": {
             "method": "toeplitz",
-            "doi": "temp",
-            "study": null,
-            "task": null,
-            "conditions": null,
-            "stimulus": null,
+            "doi": "10.1117/1.NPh.13.S1.S17801",
+            "study": "Parent-Child Anxiety Transmission Study (P-CAT)",
+            "task": "flanker",
+            "conditions": [
+                "congruent",
+                "incongruent",
+                "baseline"
+            ],
+            "stimulus": "directional flanker images",
             "intensity": null,
             "duration": 30.0,
-            "protocol": null,
-            "age_range": null,
-            "demographics": null
+            "protocol": "block design",
+            "age_range": [
+                4,
+                7
+            ],
+            "demographics": "children aged 4-7 (n=79)"
         },
         "estimates": [
             [
@@ -67093,16 +67135,23 @@
         "sfreq": 7.8125,
         "context": {
             "method": "toeplitz",
-            "doi": "temp",
-            "study": null,
-            "task": null,
-            "conditions": null,
-            "stimulus": null,
+            "doi": "10.1117/1.NPh.13.S1.S17801",
+            "study": "Parent-Child Anxiety Transmission Study (P-CAT)",
+            "task": "flanker",
+            "conditions": [
+                "congruent",
+                "incongruent",
+                "baseline"
+            ],
+            "stimulus": "directional flanker images",
             "intensity": null,
             "duration": 30.0,
-            "protocol": null,
-            "age_range": null,
-            "demographics": null
+            "protocol": "block design",
+            "age_range": [
+                4,
+                7
+            ],
+            "demographics": "children aged 4-7 (n=79)"
         },
         "estimates": [
             [
@@ -78195,16 +78244,23 @@
         "sfreq": 7.8125,
         "context": {
             "method": "toeplitz",
-            "doi": "temp",
-            "study": null,
-            "task": null,
-            "conditions": null,
-            "stimulus": null,
+            "doi": "10.1117/1.NPh.13.S1.S17801",
+            "study": "Parent-Child Anxiety Transmission Study (P-CAT)",
+            "task": "flanker",
+            "conditions": [
+                "congruent",
+                "incongruent",
+                "baseline"
+            ],
+            "stimulus": "directional flanker images",
             "intensity": null,
             "duration": 30.0,
-            "protocol": null,
-            "age_range": null,
-            "demographics": null
+            "protocol": "block design",
+            "age_range": [
+                4,
+                7
+            ],
+            "demographics": "children aged 4-7 (n=79)"
         },
         "estimates": [
             [
@@ -78934,16 +78990,23 @@
         "sfreq": 7.8125,
         "context": {
             "method": "toeplitz",
-            "doi": "temp",
-            "study": null,
-            "task": null,
-            "conditions": null,
-            "stimulus": null,
+            "doi": "10.1117/1.NPh.13.S1.S17801",
+            "study": "Parent-Child Anxiety Transmission Study (P-CAT)",
+            "task": "flanker",
+            "conditions": [
+                "congruent",
+                "incongruent",
+                "baseline"
+            ],
+            "stimulus": "directional flanker images",
             "intensity": null,
             "duration": 30.0,
-            "protocol": null,
-            "age_range": null,
-            "demographics": null
+            "protocol": "block design",
+            "age_range": [
+                4,
+                7
+            ],
+            "demographics": "children aged 4-7 (n=79)"
         },
         "estimates": [
             [
@@ -90036,16 +90099,23 @@
         "sfreq": 7.8125,
         "context": {
             "method": "toeplitz",
-            "doi": "temp",
-            "study": null,
-            "task": null,
-            "conditions": null,
-            "stimulus": null,
+            "doi": "10.1117/1.NPh.13.S1.S17801",
+            "study": "Parent-Child Anxiety Transmission Study (P-CAT)",
+            "task": "flanker",
+            "conditions": [
+                "congruent",
+                "incongruent",
+                "baseline"
+            ],
+            "stimulus": "directional flanker images",
             "intensity": null,
             "duration": 30.0,
-            "protocol": null,
-            "age_range": null,
-            "demographics": null
+            "protocol": "block design",
+            "age_range": [
+                4,
+                7
+            ],
+            "demographics": "children aged 4-7 (n=79)"
         },
         "estimates": [
             [
@@ -101138,16 +101208,23 @@
         "sfreq": 7.8125,
         "context": {
             "method": "toeplitz",
-            "doi": "temp",
-            "study": null,
-            "task": null,
-            "conditions": null,
-            "stimulus": null,
+            "doi": "10.1117/1.NPh.13.S1.S17801",
+            "study": "Parent-Child Anxiety Transmission Study (P-CAT)",
+            "task": "flanker",
+            "conditions": [
+                "congruent",
+                "incongruent",
+                "baseline"
+            ],
+            "stimulus": "directional flanker images",
             "intensity": null,
             "duration": 30.0,
-            "protocol": null,
-            "age_range": null,
-            "demographics": null
+            "protocol": "block design",
+            "age_range": [
+                4,
+                7
+            ],
+            "demographics": "children aged 4-7 (n=79)"
         },
         "estimates": [
             [

--- a/src/hrfunc/hrfs/hbr_hrfs.json
+++ b/src/hrfunc/hrfs/hbr_hrfs.json
@@ -481,16 +481,23 @@
         "sfreq": 7.8125,
         "context": {
             "method": "toeplitz",
-            "doi": "temp",
-            "study": null,
-            "task": null,
-            "conditions": null,
-            "stimulus": null,
+            "doi": "10.1117/1.NPh.13.S1.S17801",
+            "study": "Parent-Child Anxiety Transmission Study (P-CAT)",
+            "task": "flanker",
+            "conditions": [
+                "congruent",
+                "incongruent",
+                "baseline"
+            ],
+            "stimulus": "directional flanker images",
             "intensity": null,
             "duration": 30.0,
-            "protocol": null,
-            "age_range": null,
-            "demographics": null
+            "protocol": "block design",
+            "age_range": [
+                4,
+                7
+            ],
+            "demographics": "children aged 4-7 (n=79)"
         },
         "estimates": [
             [
@@ -11583,16 +11590,23 @@
         "sfreq": 7.8125,
         "context": {
             "method": "toeplitz",
-            "doi": "temp",
-            "study": null,
-            "task": null,
-            "conditions": null,
-            "stimulus": null,
+            "doi": "10.1117/1.NPh.13.S1.S17801",
+            "study": "Parent-Child Anxiety Transmission Study (P-CAT)",
+            "task": "flanker",
+            "conditions": [
+                "congruent",
+                "incongruent",
+                "baseline"
+            ],
+            "stimulus": "directional flanker images",
             "intensity": null,
             "duration": 30.0,
-            "protocol": null,
-            "age_range": null,
-            "demographics": null
+            "protocol": "block design",
+            "age_range": [
+                4,
+                7
+            ],
+            "demographics": "children aged 4-7 (n=79)"
         },
         "estimates": [
             [
@@ -22685,16 +22699,23 @@
         "sfreq": 7.8125,
         "context": {
             "method": "toeplitz",
-            "doi": "temp",
-            "study": null,
-            "task": null,
-            "conditions": null,
-            "stimulus": null,
+            "doi": "10.1117/1.NPh.13.S1.S17801",
+            "study": "Parent-Child Anxiety Transmission Study (P-CAT)",
+            "task": "flanker",
+            "conditions": [
+                "congruent",
+                "incongruent",
+                "baseline"
+            ],
+            "stimulus": "directional flanker images",
             "intensity": null,
             "duration": 30.0,
-            "protocol": null,
-            "age_range": null,
-            "demographics": null
+            "protocol": "block design",
+            "age_range": [
+                4,
+                7
+            ],
+            "demographics": "children aged 4-7 (n=79)"
         },
         "estimates": [
             [
@@ -33787,16 +33808,23 @@
         "sfreq": 7.8125,
         "context": {
             "method": "toeplitz",
-            "doi": "temp",
-            "study": null,
-            "task": null,
-            "conditions": null,
-            "stimulus": null,
+            "doi": "10.1117/1.NPh.13.S1.S17801",
+            "study": "Parent-Child Anxiety Transmission Study (P-CAT)",
+            "task": "flanker",
+            "conditions": [
+                "congruent",
+                "incongruent",
+                "baseline"
+            ],
+            "stimulus": "directional flanker images",
             "intensity": null,
             "duration": 30.0,
-            "protocol": null,
-            "age_range": null,
-            "demographics": null
+            "protocol": "block design",
+            "age_range": [
+                4,
+                7
+            ],
+            "demographics": "children aged 4-7 (n=79)"
         },
         "estimates": [
             [
@@ -44889,16 +44917,23 @@
         "sfreq": 7.8125,
         "context": {
             "method": "toeplitz",
-            "doi": "temp",
-            "study": null,
-            "task": null,
-            "conditions": null,
-            "stimulus": null,
+            "doi": "10.1117/1.NPh.13.S1.S17801",
+            "study": "Parent-Child Anxiety Transmission Study (P-CAT)",
+            "task": "flanker",
+            "conditions": [
+                "congruent",
+                "incongruent",
+                "baseline"
+            ],
+            "stimulus": "directional flanker images",
             "intensity": null,
             "duration": 30.0,
-            "protocol": null,
-            "age_range": null,
-            "demographics": null
+            "protocol": "block design",
+            "age_range": [
+                4,
+                7
+            ],
+            "demographics": "children aged 4-7 (n=79)"
         },
         "estimates": [
             [
@@ -55991,16 +56026,23 @@
         "sfreq": 7.8125,
         "context": {
             "method": "toeplitz",
-            "doi": "temp",
-            "study": null,
-            "task": null,
-            "conditions": null,
-            "stimulus": null,
+            "doi": "10.1117/1.NPh.13.S1.S17801",
+            "study": "Parent-Child Anxiety Transmission Study (P-CAT)",
+            "task": "flanker",
+            "conditions": [
+                "congruent",
+                "incongruent",
+                "baseline"
+            ],
+            "stimulus": "directional flanker images",
             "intensity": null,
             "duration": 30.0,
-            "protocol": null,
-            "age_range": null,
-            "demographics": null
+            "protocol": "block design",
+            "age_range": [
+                4,
+                7
+            ],
+            "demographics": "children aged 4-7 (n=79)"
         },
         "estimates": [
             [
@@ -67093,16 +67135,23 @@
         "sfreq": 7.8125,
         "context": {
             "method": "toeplitz",
-            "doi": "temp",
-            "study": null,
-            "task": null,
-            "conditions": null,
-            "stimulus": null,
+            "doi": "10.1117/1.NPh.13.S1.S17801",
+            "study": "Parent-Child Anxiety Transmission Study (P-CAT)",
+            "task": "flanker",
+            "conditions": [
+                "congruent",
+                "incongruent",
+                "baseline"
+            ],
+            "stimulus": "directional flanker images",
             "intensity": null,
             "duration": 30.0,
-            "protocol": null,
-            "age_range": null,
-            "demographics": null
+            "protocol": "block design",
+            "age_range": [
+                4,
+                7
+            ],
+            "demographics": "children aged 4-7 (n=79)"
         },
         "estimates": [
             [
@@ -78195,16 +78244,23 @@
         "sfreq": 7.8125,
         "context": {
             "method": "toeplitz",
-            "doi": "temp",
-            "study": null,
-            "task": null,
-            "conditions": null,
-            "stimulus": null,
+            "doi": "10.1117/1.NPh.13.S1.S17801",
+            "study": "Parent-Child Anxiety Transmission Study (P-CAT)",
+            "task": "flanker",
+            "conditions": [
+                "congruent",
+                "incongruent",
+                "baseline"
+            ],
+            "stimulus": "directional flanker images",
             "intensity": null,
             "duration": 30.0,
-            "protocol": null,
-            "age_range": null,
-            "demographics": null
+            "protocol": "block design",
+            "age_range": [
+                4,
+                7
+            ],
+            "demographics": "children aged 4-7 (n=79)"
         },
         "estimates": [
             [
@@ -78934,16 +78990,23 @@
         "sfreq": 7.8125,
         "context": {
             "method": "toeplitz",
-            "doi": "temp",
-            "study": null,
-            "task": null,
-            "conditions": null,
-            "stimulus": null,
+            "doi": "10.1117/1.NPh.13.S1.S17801",
+            "study": "Parent-Child Anxiety Transmission Study (P-CAT)",
+            "task": "flanker",
+            "conditions": [
+                "congruent",
+                "incongruent",
+                "baseline"
+            ],
+            "stimulus": "directional flanker images",
             "intensity": null,
             "duration": 30.0,
-            "protocol": null,
-            "age_range": null,
-            "demographics": null
+            "protocol": "block design",
+            "age_range": [
+                4,
+                7
+            ],
+            "demographics": "children aged 4-7 (n=79)"
         },
         "estimates": [
             [
@@ -90036,16 +90099,23 @@
         "sfreq": 7.8125,
         "context": {
             "method": "toeplitz",
-            "doi": "temp",
-            "study": null,
-            "task": null,
-            "conditions": null,
-            "stimulus": null,
+            "doi": "10.1117/1.NPh.13.S1.S17801",
+            "study": "Parent-Child Anxiety Transmission Study (P-CAT)",
+            "task": "flanker",
+            "conditions": [
+                "congruent",
+                "incongruent",
+                "baseline"
+            ],
+            "stimulus": "directional flanker images",
             "intensity": null,
             "duration": 30.0,
-            "protocol": null,
-            "age_range": null,
-            "demographics": null
+            "protocol": "block design",
+            "age_range": [
+                4,
+                7
+            ],
+            "demographics": "children aged 4-7 (n=79)"
         },
         "estimates": [
             [
@@ -101138,16 +101208,23 @@
         "sfreq": 7.8125,
         "context": {
             "method": "toeplitz",
-            "doi": "temp",
-            "study": null,
-            "task": null,
-            "conditions": null,
-            "stimulus": null,
+            "doi": "10.1117/1.NPh.13.S1.S17801",
+            "study": "Parent-Child Anxiety Transmission Study (P-CAT)",
+            "task": "flanker",
+            "conditions": [
+                "congruent",
+                "incongruent",
+                "baseline"
+            ],
+            "stimulus": "directional flanker images",
             "intensity": null,
             "duration": 30.0,
-            "protocol": null,
-            "age_range": null,
-            "demographics": null
+            "protocol": "block design",
+            "age_range": [
+                4,
+                7
+            ],
+            "demographics": "children aged 4-7 (n=79)"
         },
         "estimates": [
             [

--- a/src/hrfunc/hrfunc.py
+++ b/src/hrfunc/hrfunc.py
@@ -1,4 +1,5 @@
 import scipy.linalg, scipy.stats, json, mne, random, re, os, nilearn, time
+from types import SimpleNamespace
 import numpy as np
 import matplotlib.pyplot as plt
 from .hrtree import tree, HRF, _flatten_context_value
@@ -324,7 +325,7 @@ class montage(tree):
         
         return estimate
 
-    def estimate_hrf(self, nirx_obj, events, duration = 30.0, lmbda = 1e-3, edge_expansion = 0.15, preprocess = True, progress_callback = None):
+    def estimate_hrf(self, nirx_obj, events, duration = 30.0, lmbda = 1e-3, edge_expansion = 0.15, preprocess = True, progress_callback = None, timeout = 30):
         """
         Estimate an HRF subject wise given a nirx object and event impulse series using toeplitz
         deconvolution with regularization.
@@ -342,6 +343,10 @@ class montage(tree):
                 channel_name is the standardized form (matching self.channels keys) so callers
                 see the same naming convention as estimate_activity. Used by GUI/batch tooling to
                 surface progress; exceptions raised by the callback propagate. Default None (no-op).
+            timeout (float) - Seconds to wait for a single channel's lstsq solve before skipping
+                that channel's estimate (the channel contributes no estimate and estimation
+                continues with the rest). Default 30 — a generous ceiling that fires only on
+                pathological matrices.
 
         Returns:
             None
@@ -420,7 +425,25 @@ class montage(tree):
             lhs = X.T @ X + lmbda * np.eye(X.shape[1])
             rhs = X.T @ Y
 
-            hrf_estimate = self.solve_lstsq(lhs, rhs)
+            # Solve with a per-channel timeout so one pathological channel
+            # can't hang the whole estimation; on timeout / solve failure the
+            # channel is skipped (contributes no estimate) and we move on.
+            with ThreadPoolExecutor(max_workers=1) as executor:
+                future = executor.submit(self.solve_lstsq, lhs, rhs)
+                try:
+                    hrf_estimate = future.result(timeout)
+                except TimeoutError:
+                    print(
+                        f"HRF solve exceeded {timeout}s timeout for channel "
+                        f"{channel['ch_name']}; skipping channel"
+                    )
+                    continue
+                except Exception as exc:
+                    print(
+                        f"HRF solve failed for channel {channel['ch_name']}: "
+                        f"{type(exc).__name__}: {exc}; skipping channel"
+                    )
+                    continue
 
             # Denormalize HRF estimate
             #hrf_estimate = hrf_estimate * np.max(np.abs(fnirs_signal))
@@ -439,7 +462,7 @@ class montage(tree):
             optode.locations.append(list(channel['loc'][:3]))
 
 
-    def estimate_activity(self, nirx_obj, lmbda = 1e-4, hrf_model = 'toeplitz', preprocess = True, cond_thresh = None, timeout = 30, progress_callback = None):
+    def estimate_activity(self, nirx_obj, lmbda = 1e-4, hrf_model = 'toeplitz', preprocess = True, cond_thresh = None, timeout = 30, progress_callback = None, library_trace = None, library_oxygenation = True, drop_failed_channels = True):
         """
         Deconvlve a fNIRS scan using estimated HRF's localized to optodes location
         to gain a neural activity estimate
@@ -447,9 +470,24 @@ class montage(tree):
         Arguments:
             nirx_obj (mne raw object) - fNIRS scan loaded through mne
             lmbda (float) - Regularization parameter to apply during deconvolution
-            hrf_model (str) - HRF model to use during deconvolution, either 'toeplitz' for localized HRF's or 'canonical' for a standard canonical HRF
+            hrf_model (str) - HRF model to use during deconvolution: 'toeplitz' for the montage's
+                localized per-channel HRF's, 'canonical' for a standard SPM canonical HRF, or
+                'library' to deconvolve every channel with a single HRF trace supplied in
+                ``library_trace`` (e.g. one selected from the HRtree spatial database)
+            library_trace (sequence of float or None) - 1D HRF kernel used for every channel when
+                hrf_model='library'. Required (and must not be all-zero) in that mode; ignored
+                otherwise. The trace is applied as given to channels whose oxygenation matches
+                ``library_oxygenation`` and sign-flipped for the opposite oxygenation (HbO and HbR
+                responses are inverses).
+            library_oxygenation (bool) - Oxygenation the supplied ``library_trace`` was measured at
+                (True = HbO, False = HbR). Used only when hrf_model='library' to orient the kernel
+                per channel. Default True.
             preprocess (bool) - If True, preprocess the fNIRS data before estimating the neural activity
             cond_thresh (float or None) - Condition number threshold for falling back to pinv in solve_lstsq
+            drop_failed_channels (bool) - If True (default), a channel that errors at any point of
+                deconvolution (solve timeout, singular matrix, malformed input, etc.) is dropped and
+                the scan continues with its surviving channels. If False, the first channel failure
+                raises and aborts the whole scan (all-or-nothing). Default True.
             timeout (float) - Seconds to wait for a single channel's lstsq solve before dropping that channel.
                 Default 30 is a generous ceiling — realistic fNIRS inputs solve in tens of milliseconds,
                 so this fires only on genuinely pathological matrices. Can be tightened once empirical
@@ -466,6 +504,17 @@ class montage(tree):
 
         if lmbda <= 0:
             raise ValueError(f"ERROR: lmbda must be > 0 for Tikhonov regularization, got {lmbda}")
+
+        # Library mode deconvolves every channel with one supplied HRF trace
+        # (e.g. an HRtree selection). Validate + normalize it once up front so
+        # the per-channel loop just orients it by oxygenation.
+        library_kernel = None
+        if hrf_model == 'library':
+            if library_trace is None or len(library_trace) == 0:
+                raise ValueError("ERROR: hrf_model='library' requires a non-empty library_trace")
+            library_kernel = np.asarray(library_trace, dtype=np.float64)
+            if np.max(np.abs(library_kernel)) == 0:
+                raise ValueError("ERROR: library_trace is all zeros; cannot deconvolve")
 
         # Check montage still needs to be configured
         if self.configured is False:
@@ -493,39 +542,65 @@ class montage(tree):
             Y = (nirx - mean) / std
             Y = np.asarray(Y, dtype=float)
 
-            # Pad HRF to match nirx length
+            # Normalize the HRF kernel
             hrf_kernel = hrf.trace / np.max(np.abs(hrf.trace))
             hrf_kernel = np.asarray(hrf_kernel, dtype=float)
 
-            # Construct Toeplitz convolution matrix (design matrix)
             n_time = len(Y)
-            n_hrf = len(hrf_kernel)
+            n_hrf = min(len(hrf_kernel), n_time)  # kernel can't exceed signal
 
-            first_col = np.r_[hrf_kernel, np.zeros(n_time - n_hrf)]
-            first_row = np.r_[hrf_kernel[0], np.zeros(n_time - 1)]
-            A = scipy.linalg.toeplitz(first_col, first_row)
-            A = np.asarray(A, dtype=float)
+            # Build the convolution (Toeplitz) design matrix as a BANDED SPARSE
+            # matrix instead of a dense n_time x n_time array. A[i, i-k] =
+            # hrf_kernel[k] for 0 <= k < n_hrf (lower-triangular, bandwidth
+            # n_hrf) — identical to the previous
+            # ``scipy.linalg.toeplitz(np.r_[hrf_kernel, zeros], [hrf_kernel[0],
+            # zeros])`` but without materializing the (almost entirely zero)
+            # dense matrix. The dense form was O(n_time^2) memory and an
+            # O(n_time^3) solve, which froze on real-length recordings; the
+            # banded solve gives the SAME regularized result in ~O(n_time *
+            # n_hrf).
+            import scipy.sparse as _sp
 
-            # Solve the inverse problem with regularization
-            lhs = A.T @ A + float(lmbda) * np.eye(A.shape[1])
+            offsets = -np.arange(n_hrf)
+            diag_data = np.repeat(
+                hrf_kernel[:n_hrf].reshape(-1, 1), n_time, axis=1
+            )
+            A = _sp.dia_matrix(
+                (diag_data, offsets), shape=(n_time, n_time)
+            ).tocsr()
+
+            # Tikhonov-regularized normal equations: (AᵀA + λI) x = Aᵀy.
+            # AᵀA + λI is symmetric positive-definite (λ > 0) and banded with
+            # half-bandwidth n_hrf-1. Solve with LAPACK's banded Cholesky
+            # (scipy.linalg.solveh_banded): O(n_time * n_hrf²), linear in the
+            # scan length, vs the old dense O(n_time³) that froze on real
+            # recordings. Same regularized result as the dense solve.
+            AtA = A.T @ A + float(lmbda) * _sp.identity(n_time, format="csr")
             rhs = A.T @ Y
 
+            def _solve():
+                kd = n_hrf - 1
+                ab = np.zeros((kd + 1, n_time))  # LAPACK upper-banded storage
+                for d in range(kd + 1):
+                    ab[kd - d, d:] = AtA.diagonal(d)
+                return scipy.linalg.solveh_banded(ab, rhs)
+
             with ThreadPoolExecutor(max_workers=1) as executor:
-                future = executor.submit(self.solve_lstsq, lhs, rhs, cond_thresh)
+                future = executor.submit(_solve)
                 try:
-                    deconvolved_signal = future.result(timeout)
+                    deconvolved_signal = np.asarray(future.result(timeout))
                     success = True
                 except TimeoutError:
-                    print(f"lstsq exceeded {timeout}s timeout, dropping channel")
+                    print(f"solve exceeded {timeout}s timeout, dropping channel")
                     deconvolved_signal = nirx
                     success = False
                 except Exception as exc:
-                    # Any other solve failure (numpy LinAlgError, ValueError on
-                    # malformed inputs, etc.) should be treated as a channel
-                    # drop, not propagated out of estimate_activity. Matching
-                    # M4's "no orphans after failure" contract — if we let the
-                    # exception escape, the outer loop's cleanup never runs.
-                    print(f"lstsq failed for channel: {type(exc).__name__}: {exc}; dropping channel")
+                    # Any solve failure (singular system, malformed inputs,
+                    # etc.) drops the channel rather than propagating out of
+                    # estimate_activity. Matching M4's "no orphans after
+                    # failure" contract — if the exception escaped, the outer
+                    # loop's cleanup would never run.
+                    print(f"solve failed for channel: {type(exc).__name__}: {exc}; dropping channel")
                     deconvolved_signal = nirx
                     success = False
 
@@ -545,78 +620,113 @@ class montage(tree):
 
             if 'global' in ch_name: continue # Skip if global hrf estimate
 
-            # Detect degenerate HRF traces that would produce NaN (zero-length,
-            # missing, or all-zeros) so we fall back to canonical instead of
-            # silently dividing by zero in the deconvolution closure (H1).
-            trace_invalid = (
-                hrf.trace is None
-                or len(hrf.trace) == 0
-                or np.max(np.abs(hrf.trace)) == 0
-            )
-            if trace_invalid and hrf_model != 'canonical':
-                print(
-                    f"WARNING: HRF trace for channel {ch_name} is empty or all-zero; "
-                    "falling back to canonical HRF"
-                )
-
-            # If canonical HRF requested (or forced by a degenerate trace)
-            if hrf_model == 'canonical' or trace_invalid:
-                print(f"WARNING: Using canonical HRF for channel {ch_name} in {nirx_obj}")
-                estimate_hrf = hrf # Temporarily replace HRF
-                # S4: fetch a canonical generated at the scan's own sfreq
-                # (and the montage's duration context) rather than the
-                # old hardcoded root.right sentinel which was locked to
-                # 7.81 Hz / 30 s regardless of the calling scan.
-                canonical_duration = float(self.context.get('duration', 30.0))
-                if _is_oxygenated(ch_name):
-                    hrf = self.hbo_tree.get_canonical_hrf(
-                        True, self.sfreq, canonical_duration
-                    )
-                else:
-                    hrf = self.hbr_tree.get_canonical_hrf(
-                        False, self.sfreq, canonical_duration
-                    )
-
-            # Figure out which channel to apply to. Track the match explicitly:
-            # a bare for/break leaves nirx_channel bound to the LAST iterated
-            # channel when ch_name matches nothing, which would silently apply
-            # this HRF's deconvolution to an unrelated channel. self.channels
-            # can legitimately contain a channel absent from this scan — e.g. a
-            # montage loaded via load_montage (configured=True, so configure()
-            # is skipped), or estimate_activity reused across scans with
-            # differing layouts — so a no-match must skip, not act on a stale
-            # loop variable.
+            # matched_channel is bound inside the try below; pre-bind so the
+            # except path can reference it safely if a failure happens early.
             matched_channel = None
-            for nirx_channel in nirx_obj.info['chs']:
-                if ch_name == standardize_name(nirx_channel['ch_name']):
-                    matched_channel = nirx_channel
-                    break
-            if matched_channel is None:
-                print(
-                    f"WARNING: channel {ch_name} not found in scan {nirx_obj}; "
-                    "skipping deconvolution for it"
+
+            # Per-channel resilience: any failure (solve timeout/singularity,
+            # malformed input, apply_function error) drops just this channel
+            # when drop_failed_channels is True, instead of aborting the whole
+            # scan. Set it False for all-or-nothing behaviour.
+            try:
+                # Detect degenerate HRF traces that would produce NaN (zero-length,
+                # missing, or all-zeros) so we fall back to canonical instead of
+                # silently dividing by zero in the deconvolution closure (H1).
+                trace_invalid = (
+                    hrf.trace is None
+                    or len(hrf.trace) == 0
+                    or np.max(np.abs(hrf.trace)) == 0
                 )
-                continue
+                if trace_invalid and hrf_model not in ('canonical', 'library'):
+                    print(
+                        f"WARNING: HRF trace for channel {ch_name} is empty or all-zero; "
+                        "falling back to canonical HRF"
+                    )
 
-            print(f"Deconvolving channel {ch_name}...") # Apply deconvolution
-            nirx_obj.apply_function(deconvolution, picks = [matched_channel['ch_name']]) # Apply deconvolution for channel
+                # If a library HRF was supplied, deconvolve every channel with it.
+                # Orient it by oxygenation (as-given for the source's oxygenation,
+                # sign-flipped for the opposite), mirroring how the canonical path
+                # signs HbO vs HbR. Takes precedence over the canonical fallback.
+                if hrf_model == 'library':
+                    estimate_hrf = hrf  # save original; restored after the channel
+                    oriented = (
+                        library_kernel
+                        if _is_oxygenated(ch_name) == bool(library_oxygenation)
+                        else -library_kernel
+                    )
+                    hrf = SimpleNamespace(trace=oriented)
 
-            # Remove channel if neural activity estimation failed to converge.
-            # M4: also drop the orphaned entry from self.channels and the
-            # hbo/hbr channel lists so downstream iterators (correlate_hrf,
-            # generate_distribution) don't trip on a stale pointer. The
-            # spatial tree copy of the HRF is left in place for now — the
-            # broken tree.delete path is fixed in fix/tree-delete-filter, and
-            # tree orphans are harmless until that lands because nothing in
-            # this release iterates the full tree except montage.branch()
-            # which rebuilds from self.channels.
-            if success is False:
-                nirx_obj.drop_channels([matched_channel['ch_name']])
+                # If canonical HRF requested (or forced by a degenerate trace)
+                elif hrf_model == 'canonical' or trace_invalid:
+                    print(f"WARNING: Using canonical HRF for channel {ch_name} in {nirx_obj}")
+                    estimate_hrf = hrf # Temporarily replace HRF
+                    # S4: fetch a canonical generated at the scan's own sfreq
+                    # (and the montage's duration context) rather than the
+                    # old hardcoded root.right sentinel which was locked to
+                    # 7.81 Hz / 30 s regardless of the calling scan.
+                    canonical_duration = float(self.context.get('duration', 30.0))
+                    if _is_oxygenated(ch_name):
+                        hrf = self.hbo_tree.get_canonical_hrf(
+                            True, self.sfreq, canonical_duration
+                        )
+                    else:
+                        hrf = self.hbr_tree.get_canonical_hrf(
+                            False, self.sfreq, canonical_duration
+                        )
+
+                # Figure out which channel to apply to. Track the match
+                # explicitly: a bare for/break leaves the loop variable bound
+                # to the LAST iterated channel when ch_name matches nothing,
+                # which would silently apply this HRF's deconvolution to an
+                # unrelated channel. self.channels can legitimately contain a
+                # channel absent from this scan (a montage loaded via
+                # load_montage, or estimate_activity reused across scans with
+                # differing layouts) — so a no-match must skip, not act on a
+                # stale loop variable.
+                for nirx_channel in nirx_obj.info['chs']:
+                    if ch_name == standardize_name(nirx_channel['ch_name']):
+                        matched_channel = nirx_channel
+                        break
+                if matched_channel is None:
+                    print(
+                        f"WARNING: channel {ch_name} not found in scan {nirx_obj}; "
+                        "skipping deconvolution for it"
+                    )
+                    continue
+
+                print(f"Deconvolving channel {ch_name}...") # Apply deconvolution
+                nirx_obj.apply_function(deconvolution, picks = [matched_channel['ch_name']]) # Apply deconvolution for channel
+
+                # Remove channel if neural activity estimation failed to converge.
+                # M4: also drop the orphaned entry from self.channels and the
+                # hbo/hbr channel lists so downstream iterators (correlate_hrf,
+                # generate_distribution) don't trip on a stale pointer. The
+                # spatial tree copy of the HRF is left in place for now — the
+                # broken tree.delete path is fixed in fix/tree-delete-filter, and
+                # tree orphans are harmless until that lands because nothing in
+                # this release iterates the full tree except montage.branch()
+                # which rebuilds from self.channels.
+                if success is False:
+                    nirx_obj.drop_channels([matched_channel['ch_name']])
+                    dropped_channels.append(ch_name)
+
+                # Replace the canonical / library HRF temporarily used with the
+                # original per-channel HRF (so self.channels is never disturbed).
+                if hrf_model in ('canonical', 'library'):
+                    hrf = estimate_hrf # Replace the original HRF
+            except Exception as exc:  # noqa: BLE001 — per-channel drop guard
+                if not drop_failed_channels:
+                    raise
+                print(
+                    f"WARNING: dropping channel {ch_name} after a deconvolution "
+                    f"error: {type(exc).__name__}: {exc}"
+                )
+                if (
+                    matched_channel is not None
+                    and matched_channel['ch_name'] in nirx_obj.ch_names
+                ):
+                    nirx_obj.drop_channels([matched_channel['ch_name']])
                 dropped_channels.append(ch_name)
-
-            # Replace the canonical HRF estimate temporarily used with the HRF estimate
-            if hrf_model == 'canonical':
-                hrf = estimate_hrf # Replace the original HRF
 
         for ch_name in dropped_channels:
             self.channels.pop(ch_name, None)

--- a/tests/test_gui_activity_panel.py
+++ b/tests/test_gui_activity_panel.py
@@ -58,6 +58,8 @@ class TestActivityOptions:
         assert opts.hrf_model == activity_panel.MODEL_TOEPLITZ
         assert opts.lmbda == 1e-4  # library default
         assert opts.preview_channel == 0
+        assert opts.timeout == 30.0  # estimate_activity default
+        assert opts.drop_failed_channels is True
 
     def test_is_dataclass(self):
         import dataclasses
@@ -180,6 +182,78 @@ class TestRunActivitySync:
         assert constructed == []
         assert called_estimate == [existing]
 
+    def test_library_mode_passes_trace_and_builds_fresh_montage(self, monkeypatch):
+        """Library mode ignores existing_montage, builds a fresh one, and
+        forwards the supplied trace + oxygenation to estimate_activity."""
+        from hrfunc import hrfunc as hrf_module
+
+        raw = _make_fake_raw()
+        constructed = []
+        captured = {}
+
+        class _FakeMontage:
+            def __init__(self, nirx_obj=None):
+                constructed.append(nirx_obj)
+                self.channels = {}
+
+            def estimate_activity(self, nirx_obj, **kwargs):
+                captured.update(kwargs)
+                return nirx_obj
+
+        monkeypatch.setattr(hrf_module, "montage", _FakeMontage)
+
+        opts = activity_panel.ActivityOptions(
+            hrf_model=activity_panel.MODEL_LIBRARY,
+            library_trace=[0.0, 0.5, 1.0, 0.5, 0.0],
+            library_oxygenation=False,
+        )
+        activity_panel.run_activity_sync(raw, opts, existing_montage=object())
+
+        assert len(constructed) == 1  # fresh montage despite existing_montage
+        assert captured["hrf_model"] == activity_panel.MODEL_LIBRARY
+        assert captured["library_trace"] == [0.0, 0.5, 1.0, 0.5, 0.0]
+        assert captured["library_oxygenation"] is False
+
+
+class TestLibraryKernelHelpers:
+    """Pure helpers backing the HRtree (library) deconvolution source."""
+
+    def test_kernel_none_when_no_selection(self):
+        st = AppState()
+        st.library_selected_hrf = None
+        assert activity_panel._library_kernel_from_state(st) is None
+
+    def test_kernel_none_when_trace_empty(self):
+        st = AppState()
+        st.library_selected_hrf = {"hrf_mean": [], "oxygenation": True}
+        assert activity_panel._library_kernel_from_state(st) is None
+
+    def test_kernel_reads_trace_and_oxygenation(self):
+        st = AppState()
+        st.library_selected_hrf = {"hrf_mean": [1.0, 2.0], "oxygenation": True}
+        trace, oxy = activity_panel._library_kernel_from_state(st)
+        assert trace == [1.0, 2.0]
+        assert oxy is True
+
+    def test_snapshot_captures_library_kernel(self):
+        st = AppState()
+        st.library_selected_hrf = {"hrf_mean": [0.1, 0.2], "oxygenation": False}
+        opts = activity_panel.ActivityOptions(
+            hrf_model=activity_panel.MODEL_LIBRARY
+        )
+        snap = activity_panel._snapshot_options(st, opts)
+        assert snap.library_trace == [0.1, 0.2]
+        assert snap.library_oxygenation is False
+
+    def test_snapshot_no_kernel_for_canonical(self):
+        st = AppState()
+        st.library_selected_hrf = {"hrf_mean": [0.1], "oxygenation": True}
+        opts = activity_panel.ActivityOptions(
+            hrf_model=activity_panel.MODEL_CANONICAL
+        )
+        snap = activity_panel._snapshot_options(st, opts)
+        assert snap.library_trace is None
+
     def test_forwards_preprocess_false(self, monkeypatch):
         from hrfunc import hrfunc as hrf_module
 
@@ -204,6 +278,32 @@ class TestRunActivitySync:
         assert kwargs_seen[0]["preprocess"] is False
         assert kwargs_seen[0]["lmbda"] == 5e-5
         assert kwargs_seen[0]["hrf_model"] == "canonical"
+
+    def test_forwards_timeout_and_drop_failed_channels(self, monkeypatch):
+        from hrfunc import hrfunc as hrf_module
+
+        raw = _make_fake_raw()
+        kwargs_seen = []
+
+        class _FakeMontage:
+            def __init__(self, nirx_obj=None):
+                self.channels = {}
+
+            def estimate_activity(self, nirx_obj, **kwargs):
+                kwargs_seen.append(kwargs)
+                return nirx_obj
+
+        monkeypatch.setattr(hrf_module, "montage", _FakeMontage)
+
+        opts = activity_panel.ActivityOptions(
+            hrf_model=activity_panel.MODEL_CANONICAL,
+            timeout=12.0,
+            drop_failed_channels=False,
+        )
+        activity_panel.run_activity_sync(raw, opts)
+
+        assert kwargs_seen[0]["timeout"] == 12.0
+        assert kwargs_seen[0]["drop_failed_channels"] is False
 
 
 class TestMontageStateProtection:
@@ -306,9 +406,10 @@ class TestStateMontageSourceScan:
 async def test_panel_toeplitz_rejects_cross_scan_montage(
     user: User, tmp_path
 ):
-    """Toeplitz mode must refuse when state.montage came from a different
-    scan than the one currently selected — applying scan A's HRFs to scan
-    B's Raw would silently produce wrong results."""
+    """Toeplitz mode must refuse when only ANOTHER scan's HRFs exist —
+    applying scan A's HRFs to scan B's Raw would silently produce wrong
+    results. With per-scan montage caching, selecting scan B (whose HRFs
+    aren't cached) reports it has no estimated HRFs of its own."""
     scan_a = ScanEntry(
         format="snirf", path=tmp_path / "a.snirf", display_name="scan_a"
     )
@@ -320,12 +421,12 @@ async def test_panel_toeplitz_rejects_cross_scan_montage(
     global_state.manifest = Manifest(root=tmp_path, scans=(scan_a, scan_b))
     global_state.selected_scan = scan_b
     global_state.processed_cache._cache[scan_b.path.resolve()] = raw
-    # Stash a non-CanonicalResult, non-None montage tagged to scan A
+    # A real montage tagged to scan A only (not in scan B's cache).
     global_state.montage = object()  # Stand-in for a real Montage
     global_state.montage_source_scan = scan_a
 
     await user.open("/")
-    await user.should_see("estimated from scan_a")
+    await user.should_see("No estimated HRFs for this scan")
 
 
 # ---------------------------------------------------------------------------
@@ -371,9 +472,11 @@ async def test_panel_toeplitz_needs_hrfs_first(user: User, tmp_path):
     global_state.manifest = Manifest(root=tmp_path, scans=(scan,))
     global_state.selected_scan = scan
     global_state.processed_cache._cache[scan.path.resolve()] = raw
-    # No montage set → toeplitz mode should prompt for HRFs first
+    # No montage set → toeplitz mode should prompt for HRFs first, and offer
+    # a jump to the HRFs tab so the user can accomplish it.
     await user.open("/")
     await user.should_see("Toeplitz mode requires estimated HRFs")
+    await user.should_see("Go to HRFs tab")
 
 
 async def test_panel_toeplitz_rejects_canonical_result_montage(
@@ -427,3 +530,41 @@ async def test_workspace_subscribes_activity_panel(user: User, tmp_path):
     assert "hrf_estimated" in global_state.subscribers
     # hrf_estimated has both HRFs tab + Activity tab subscribers
     assert len(global_state.subscribers["hrf_estimated"]) >= 2
+
+
+class TestMontageForScan:
+    """Per-scan montage resolution backing toeplitz activity."""
+
+    def _scan(self, p):
+        return ScanEntry(format="snirf", path=Path(p), display_name=Path(p).stem)
+
+    def test_none_when_nothing_estimated(self):
+        st = AppState()
+        assert activity_panel._montage_for_scan(st, self._scan("/tmp/x.snirf")) is None
+
+    def test_uses_cached_montage(self):
+        st = AppState()
+        scan = self._scan("/tmp/x.snirf")
+        m = object()
+        st.montage_cache[scan.path.resolve()] = m
+        assert activity_panel._montage_for_scan(st, scan) is m
+
+    def test_falls_back_to_single_montage_when_source_matches(self):
+        st = AppState()
+        scan = self._scan("/tmp/x.snirf")
+        m = object()
+        st.montage = m
+        st.montage_source_scan = scan
+        assert activity_panel._montage_for_scan(st, scan) is m
+
+    def test_ignores_single_montage_for_other_scan(self):
+        st = AppState()
+        st.montage = object()
+        st.montage_source_scan = self._scan("/tmp/a.snirf")
+        assert activity_panel._montage_for_scan(st, self._scan("/tmp/b.snirf")) is None
+
+    def test_montage_cache_cleared_on_reset(self):
+        st = AppState()
+        st.montage_cache[Path("/tmp/x")] = object()
+        st.reset()
+        assert st.montage_cache == {}

--- a/tests/test_gui_events_io.py
+++ b/tests/test_gui_events_io.py
@@ -1,0 +1,242 @@
+"""Unit tests for ``hrfunc.gui.events_io``.
+
+Covers:
+- format auto-detection (BIDS events.tsv vs simple onset,label).
+- ``needs_simple_confirm`` only set for the simple shape.
+- impulse construction (onset -> sample, out-of-range dropped).
+- coverage_report counts (past-end, edge window, usable).
+- parse errors on empty / non-numeric junk.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hrfunc.gui.events_io import (
+    EventsParseError,
+    build_impulse_from_rows,
+    build_impulse_from_vector,
+    coverage_report,
+    coverage_report_vector,
+    discover_collocated_events,
+    find_event_files,
+    parse_events_file,
+)
+
+
+def _write(tmp_path: Path, name: str, content: str) -> Path:
+    p = tmp_path / name
+    p.write_text(content)
+    return p
+
+
+def test_parse_bids_tsv(tmp_path):
+    f = _write(
+        tmp_path, "sub-01_events.tsv",
+        "onset\tduration\ttrial_type\n5.0\t1.0\tcongruent\n12.5\t1.0\tincongruent\n",
+    )
+    parsed = parse_events_file(f)
+    assert parsed.fmt == "bids"
+    assert parsed.needs_simple_confirm is False
+    assert parsed.labels() == ["congruent", "incongruent"]
+    assert len(parsed.rows) == 2
+    assert parsed.rows[0].onset == 5.0
+
+
+def test_parse_simple_csv_with_header(tmp_path):
+    f = _write(tmp_path, "ev.csv", "onset,label\n3,stim\n9,rest\n")
+    parsed = parse_events_file(f)
+    assert parsed.fmt == "simple"
+    assert parsed.needs_simple_confirm is True
+    assert parsed.labels() == ["rest", "stim"]
+
+
+def test_parse_simple_csv_headerless(tmp_path):
+    f = _write(tmp_path, "ev.csv", "2.0,a\n4.0,b\n")
+    parsed = parse_events_file(f)
+    assert parsed.fmt == "simple"
+    assert parsed.needs_simple_confirm is True
+    assert parsed.labels() == ["a", "b"]
+
+
+def test_parse_onset_duration_defaults_label_and_warns(tmp_path):
+    f = _write(tmp_path, "d.tsv", "onset\tduration\n1\t0\n2\t0\n")
+    parsed = parse_events_file(f)
+    assert parsed.fmt == "bids"  # duration column marks it structured
+    assert parsed.labels() == ["event"]
+    assert parsed.warnings  # warned about missing label column
+
+
+def test_parse_na_label_normalized(tmp_path):
+    f = _write(
+        tmp_path, "na.tsv",
+        "onset\tduration\ttrial_type\n1\t0\tn/a\n2\t0\tgo\n",
+    )
+    assert parse_events_file(f).labels() == ["event", "go"]
+
+
+def test_parse_skips_non_numeric_onset_rows(tmp_path):
+    f = _write(tmp_path, "ev.csv", "onset,label\n3,stim\nbad,rest\n9,stim\n")
+    parsed = parse_events_file(f)
+    assert len(parsed.rows) == 2
+    assert any("Skipped" in w for w in parsed.warnings)
+
+
+def test_parse_empty_raises(tmp_path):
+    with pytest.raises(EventsParseError):
+        parse_events_file(_write(tmp_path, "empty.csv", "\n\n"))
+
+
+def test_parse_garbage_raises(tmp_path):
+    with pytest.raises(EventsParseError):
+        parse_events_file(_write(tmp_path, "bad.csv", "hello world\nfoo bar\n"))
+
+
+def test_build_impulse_places_and_drops(tmp_path):
+    f = _write(
+        tmp_path, "e.tsv",
+        "onset\tduration\ttrial_type\n5\t1\tA\n12.5\t1\tA\n20\t1\tB\n",
+    )
+    rows = parse_events_file(f).rows
+    # sfreq=10 Hz, 100 samples = 10 s scan. Only the 5 s onset lands.
+    imp = build_impulse_from_rows(rows, ["A", "B"], sfreq=10.0, n_samples=100)
+    assert int(imp.sum()) == 1
+    assert imp[50] == 1
+
+
+def test_build_impulse_label_filter(tmp_path):
+    f = _write(tmp_path, "e.csv", "onset,label\n1,A\n2,B\n")
+    rows = parse_events_file(f).rows
+    imp = build_impulse_from_rows(rows, ["A"], sfreq=10.0, n_samples=100)
+    assert int(imp.sum()) == 1
+    assert imp[10] == 1  # only the A onset at 1 s
+
+
+def test_parse_impulse_vector(tmp_path):
+    # per-sample 0/1 design vector (the tests/data/sNIRF_formatted/events.txt shape)
+    lines = "\n".join(["0"] * 5 + ["1"] + ["0"] * 3 + ["1"]) + "\n"
+    parsed = parse_events_file(_write(tmp_path, "events.txt", lines))
+    assert parsed.fmt == "impulse"
+    assert parsed.needs_simple_confirm is False
+    assert parsed.labels() == ["events"]
+    assert parsed.impulse is not None
+    assert len(parsed.impulse) == 10
+    assert sum(parsed.impulse) == 2
+
+
+def test_impulse_not_confused_with_onsets(tmp_path):
+    # values beyond 0/1 -> onset interpretation, NOT impulse
+    parsed = parse_events_file(_write(tmp_path, "e.txt", "5\n12\n20\n"))
+    assert parsed.fmt == "simple"
+    assert parsed.impulse is None
+
+
+def test_build_impulse_from_vector_truncates_and_pads(tmp_path):
+    vec = [0, 1, 0, 1, 0, 1]
+    # scan shorter than vector -> truncated (last 1 at index 5 dropped)
+    short = build_impulse_from_vector(vec, 4)
+    assert int(short.sum()) == 2 and len(short) == 4
+    # scan longer -> zero-padded
+    long = build_impulse_from_vector(vec, 10)
+    assert int(long.sum()) == 3 and len(long) == 10
+
+
+def test_coverage_report_vector_flags_overrun(tmp_path):
+    vec = [0] * 10
+    vec[2] = 1   # in edge (if edge=5)
+    vec[7] = 1   # placed
+    vec[12:13] = []  # noop
+    vec += [0, 1]   # index 11 -> past end of an 11-sample scan
+    cov = coverage_report_vector(vec, sfreq=10.0, n_samples=11, edge_samples=5)
+    assert cov.in_edge == 1
+    assert cov.placed == 1
+    assert cov.past_end == 1
+
+
+def test_find_event_files_glob_and_substring(tmp_path):
+    (tmp_path / "events.txt").write_text("0\n1\n")
+    (tmp_path / "sub-01_events.tsv").write_text("onset\n1\n")
+    (tmp_path / "notes.md").write_text("x")
+    sub = tmp_path / ".venv"
+    sub.mkdir()
+    (sub / "events.txt").write_text("0\n")  # in a skipped dir
+    names = lambda pat: sorted(p.name for p in find_event_files(tmp_path, pat))
+    # glob
+    assert names("*events*") == ["events.txt", "sub-01_events.tsv"]
+    # bare term -> substring
+    assert names("events") == ["events.txt", "sub-01_events.tsv"]
+    # extension glob
+    assert names("*.tsv") == ["sub-01_events.tsv"]
+    # empty -> all event-extension files (md excluded)
+    assert "notes.md" not in names("")
+    # .venv is skipped (only one events.txt, the top-level one)
+    assert names("*events*").count("events.txt") == 1
+
+
+def test_find_event_files_no_match(tmp_path):
+    (tmp_path / "events.txt").write_text("0\n")
+    assert find_event_files(tmp_path, "zzz*") == []
+
+
+def test_discover_bids_strict(tmp_path):
+    scan = tmp_path / "sub-01_task-flanker_nirs.snirf"
+    scan.write_text("x")
+    ev = tmp_path / "sub-01_task-flanker_events.tsv"
+    ev.write_text("onset\tduration\ttrial_type\n1\t0\tgo\n")
+    # a decoy events file that should NOT win over the BIDS-entity match
+    (tmp_path / "other_events.tsv").write_text("onset\n2\n")
+    assert discover_collocated_events(scan, [scan]) == ev
+
+
+def test_discover_lone_file_fallback(tmp_path):
+    scan = tmp_path / "recording.snirf"
+    scan.write_text("x")
+    ev = tmp_path / "onsets.csv"
+    ev.write_text("onset,label\n1,go\n")
+    assert discover_collocated_events(scan, [scan]) == ev
+
+
+def test_discover_ambiguous_returns_none(tmp_path):
+    scan = tmp_path / "recording.snirf"
+    scan.write_text("x")
+    (tmp_path / "a.csv").write_text("onset\n1\n")
+    (tmp_path / "b.tsv").write_text("onset\n2\n")
+    # two event files, not BIDS -> ambiguous -> no match
+    assert discover_collocated_events(scan, [scan]) is None
+
+
+def test_discover_multiple_scans_blocks_lone_fallback(tmp_path):
+    scan_a = tmp_path / "a.snirf"
+    scan_a.write_text("x")
+    scan_b = tmp_path / "b.snirf"
+    scan_b.write_text("x")
+    (tmp_path / "onsets.csv").write_text("onset\n1\n")
+    # lone event file but two scans in the folder -> don't guess
+    assert discover_collocated_events(scan_a, [scan_a, scan_b]) is None
+
+
+def test_discover_txt_requires_event_like_name(tmp_path):
+    scan = tmp_path / "recording.snirf"
+    scan.write_text("x")
+    (tmp_path / "README.txt").write_text("hello")
+    # a plain .txt that isn't event/onset-named is ignored -> no match
+    assert discover_collocated_events(scan, [scan]) is None
+    (tmp_path / "events.txt").write_text("1\n2\n")
+    assert discover_collocated_events(scan, [scan]).name == "events.txt"
+
+
+def test_coverage_report_counts(tmp_path):
+    f = _write(
+        tmp_path, "e.tsv",
+        "onset\tduration\ttrial_type\n0.5\t1\tA\n5\t1\tA\n20\t1\tA\n",
+    )
+    rows = parse_events_file(f).rows
+    # sfreq=10, 100 samples (10 s), edge window = first 10 samples (1 s).
+    cov = coverage_report(rows, ["A"], sfreq=10.0, n_samples=100, edge_samples=10)
+    assert cov.past_end == 1   # 20 s onset
+    assert cov.in_edge == 1    # 0.5 s onset (sample 5 < 10)
+    assert cov.placed == 1     # 5 s onset
+    assert cov.max_onset_s == 20.0
+    assert cov.scan_seconds == 10.0

--- a/tests/test_gui_events_panel.py
+++ b/tests/test_gui_events_panel.py
@@ -1,0 +1,279 @@
+"""Unit tests for the HRFs-tab events plumbing (feat/hrf-events-upload).
+
+Exercises the pure decision helpers in ``hrf_panel`` that resolve which
+events drive a scan's estimation — the regression-prone logic behind
+upload / auto-match / apply-to-all / impulse-vs-onset. These don't need a
+NiceGUI render context (no ``user`` fixture); they operate on a fresh
+AppState + lightweight ScanEntry stubs.
+
+Covers:
+- ``_file_applies_to_scan``: none / source-scan / apply-all / impulse.
+- ``_apply_parsed_events``: loads onset rows vs impulse vector correctly.
+- ``_event_labels_for_scan`` / ``_event_counts_for_scan`` for a loaded file.
+- ``_maybe_automatch_events``: BIDS-strict load, opt-out via
+  ``events_no_automatch``, and "found nothing" memoization.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("nicegui")
+
+from hrfunc.gui.components import hrf_panel  # noqa: E402
+from hrfunc.gui.components.hrf_panel import EstimationOptions  # noqa: E402
+from hrfunc.gui.events_io import parse_events_file  # noqa: E402
+from hrfunc.gui.state import AppState  # noqa: E402
+from hrfunc.io.manifest import Manifest, ScanEntry  # noqa: E402
+
+
+def _scan(tmp_path: Path, name: str) -> ScanEntry:
+    return ScanEntry(format="snirf", path=tmp_path / name, display_name=name)
+
+
+# ---------------------------------------------------------------------------
+# _file_applies_to_scan
+# ---------------------------------------------------------------------------
+
+
+def test_file_applies_none_loaded(tmp_path):
+    st = AppState()
+    assert hrf_panel._file_applies_to_scan(st, _scan(tmp_path, "a.snirf")) is False
+
+
+def test_file_applies_only_to_source_scan(tmp_path):
+    st = AppState()
+    a, b = _scan(tmp_path, "a.snirf"), _scan(tmp_path, "b.snirf")
+    st.events_rows = [object()]  # non-None marks "loaded"
+    st.events_source_scan = a
+    assert hrf_panel._file_applies_to_scan(st, a) is True
+    assert hrf_panel._file_applies_to_scan(st, b) is False
+
+
+def test_file_applies_all_when_apply_all(tmp_path):
+    st = AppState()
+    a, b = _scan(tmp_path, "a.snirf"), _scan(tmp_path, "b.snirf")
+    st.events_rows = [object()]
+    st.events_source_scan = a
+    st.events_apply_all = True
+    assert hrf_panel._file_applies_to_scan(st, b) is True
+
+
+def test_file_applies_with_impulse(tmp_path):
+    st = AppState()
+    a = _scan(tmp_path, "a.snirf")
+    st.events_impulse = [0, 1, 0]
+    st.events_source_scan = a
+    assert hrf_panel._file_applies_to_scan(st, a) is True
+
+
+# ---------------------------------------------------------------------------
+# _apply_parsed_events (onset vs impulse)
+# ---------------------------------------------------------------------------
+
+
+def test_apply_parsed_onset_rows(tmp_path):
+    st, opts = AppState(), EstimationOptions()
+    a = _scan(tmp_path, "a.snirf")
+    f = tmp_path / "ev.csv"
+    f.write_text("onset,label\n1,go\n2,stop\n")
+    parsed = parse_events_file(f)
+    hrf_panel._apply_parsed_events(st, opts, a, parsed, is_auto=False)
+    assert st.events_rows is not None and st.events_impulse is None
+    assert st.events_source_scan is a
+    assert set(opts.selected_events) == {"go", "stop"}
+
+
+def test_apply_parsed_impulse(tmp_path):
+    st, opts = AppState(), EstimationOptions()
+    a = _scan(tmp_path, "a.snirf")
+    f = tmp_path / "events.txt"
+    f.write_text("0\n1\n0\n1\n")
+    parsed = parse_events_file(f)
+    hrf_panel._apply_parsed_events(st, opts, a, parsed, is_auto=True)
+    assert st.events_impulse == [0, 1, 0, 1]
+    assert st.events_rows is None
+    assert st.events_is_automatched is True
+    assert opts.selected_events == ("events",)
+
+
+# ---------------------------------------------------------------------------
+# label / count helpers for a loaded file
+# ---------------------------------------------------------------------------
+
+
+def test_labels_and_counts_for_impulse(tmp_path):
+    st = AppState()
+    a = _scan(tmp_path, "a.snirf")
+    st.events_impulse = [0, 1, 0, 1, 1]
+    st.events_source_scan = a
+    assert hrf_panel._event_labels_for_scan(st, a, None) == ["events"]
+    assert hrf_panel._event_counts_for_scan(st, a, None) == {"events": 3}
+
+
+def test_labels_and_counts_for_onset_rows(tmp_path):
+    st, opts = AppState(), EstimationOptions()
+    a = _scan(tmp_path, "a.snirf")
+    f = tmp_path / "ev.csv"
+    f.write_text("onset,label\n1,go\n2,go\n3,stop\n")
+    hrf_panel._apply_parsed_events(st, opts, a, parse_events_file(f), is_auto=False)
+    assert hrf_panel._event_labels_for_scan(st, a, None) == ["go", "stop"]
+    assert hrf_panel._event_counts_for_scan(st, a, None) == {"go": 2, "stop": 1}
+
+
+# ---------------------------------------------------------------------------
+# _maybe_automatch_events
+# ---------------------------------------------------------------------------
+
+
+def test_automatch_bids_strict(tmp_path):
+    scan_path = tmp_path / "sub-01_task-x_nirs.snirf"
+    scan_path.write_text("x")
+    (tmp_path / "sub-01_task-x_events.tsv").write_text(
+        "onset\tduration\ttrial_type\n1\t0\tgo\n"
+    )
+    scan = ScanEntry(format="snirf", path=scan_path, display_name="sub-01")
+    st, opts = AppState(), EstimationOptions()
+    st.manifest = Manifest(root=tmp_path, scans=(scan,))
+    hrf_panel._maybe_automatch_events(st, scan, opts)
+    assert st.events_rows is not None
+    assert st.events_is_automatched is True
+    assert st.events_source_label == "sub-01_task-x_events.tsv"
+
+
+def test_automatch_respects_opt_out(tmp_path):
+    scan_path = tmp_path / "sub-01_task-x_nirs.snirf"
+    scan_path.write_text("x")
+    (tmp_path / "sub-01_task-x_events.tsv").write_text(
+        "onset\tduration\ttrial_type\n1\t0\tgo\n"
+    )
+    scan = ScanEntry(format="snirf", path=scan_path, display_name="sub-01")
+    st, opts = AppState(), EstimationOptions()
+    st.manifest = Manifest(root=tmp_path, scans=(scan,))
+    st.events_no_automatch.add(scan_path.resolve())
+    hrf_panel._maybe_automatch_events(st, scan, opts)
+    assert st.events_rows is None  # opted out -> nothing loaded
+
+
+def test_automatch_memoizes_when_nothing_found(tmp_path):
+    scan_path = tmp_path / "lonely.snirf"
+    scan_path.write_text("x")
+    # two scans in folder, no events file -> no match, and remembered
+    other = tmp_path / "other.snirf"
+    other.write_text("x")
+    scan = ScanEntry(format="snirf", path=scan_path, display_name="lonely")
+    other_entry = ScanEntry(format="snirf", path=other, display_name="other")
+    st, opts = AppState(), EstimationOptions()
+    st.manifest = Manifest(root=tmp_path, scans=(scan, other_entry))
+    hrf_panel._maybe_automatch_events(st, scan, opts)
+    assert st.events_rows is None and st.events_impulse is None
+    assert scan_path.resolve() in st.events_no_automatch
+
+
+# ---------------------------------------------------------------------------
+# _resolve_bulk_events — per-scan events for a bulk HRF run
+# ---------------------------------------------------------------------------
+
+
+class _FakeAnnotations:
+    """Minimal stand-in for mne Annotations: iterable of dict-likes + len."""
+
+    def __init__(self, descriptions):
+        self._items = [{"description": d, "onset": 1.0} for d in descriptions]
+
+    def __iter__(self):
+        return iter(self._items)
+
+    def __len__(self):
+        return len(self._items)
+
+
+class _FakeRaw:
+    def __init__(self, descriptions=None):
+        self.annotations = (
+            _FakeAnnotations(descriptions) if descriptions is not None else None
+        )
+
+
+def test_resolve_bulk_events_manual_applies(tmp_path):
+    # An uploaded file set to apply-to-all drives every scan; the user's
+    # label selection is preserved across the batch.
+    scan = _scan(tmp_path, "sub-01_nirs.snirf")
+    st = AppState()
+    sentinel_rows = [object()]
+    st.events_rows = sentinel_rows
+    st.events_apply_all = True
+    snapshot = EstimationOptions(selected_events=("go",))
+    rows, impulse, selected = hrf_panel._resolve_bulk_events(
+        st, scan, _FakeRaw(["ignored"]), snapshot
+    )
+    assert rows is sentinel_rows
+    assert impulse is None
+    assert selected == ("go",)
+
+
+def test_resolve_bulk_events_collocated_sidecar(tmp_path):
+    # No manual file -> discover this scan's own BIDS sidecar and use all of
+    # its conditions (not the UI scan's selection).
+    scan_path = tmp_path / "sub-02_task-x_nirs.snirf"
+    scan_path.write_text("x")
+    (tmp_path / "sub-02_task-x_events.tsv").write_text(
+        "onset\tduration\ttrial_type\n1\t0\tgo\n2\t0\tstop\n"
+    )
+    scan = ScanEntry(format="snirf", path=scan_path, display_name="sub-02")
+    st = AppState()
+    st.manifest = Manifest(root=tmp_path, scans=(scan,))
+    snapshot = EstimationOptions(selected_events=("unrelated",))
+    rows, impulse, selected = hrf_panel._resolve_bulk_events(
+        st, scan, _FakeRaw(None), snapshot
+    )
+    assert rows is not None and impulse is None
+    assert set(selected) == {"go", "stop"}
+
+
+def test_resolve_bulk_events_annotation_fallback(tmp_path):
+    # No manual file, no sidecar -> fall back to the scan's own annotations,
+    # selecting every description.
+    scan_path = tmp_path / "plain.snirf"
+    scan_path.write_text("x")
+    scan = ScanEntry(format="snirf", path=scan_path, display_name="plain")
+    st = AppState()
+    st.manifest = Manifest(root=tmp_path, scans=(scan,))
+    snapshot = EstimationOptions(selected_events=())
+    rows, impulse, selected = hrf_panel._resolve_bulk_events(
+        st, scan, _FakeRaw(["stim_b", "stim_a"]), snapshot
+    )
+    assert rows is None and impulse is None
+    assert selected == ("stim_a", "stim_b")  # sorted, de-duplicated
+
+
+def test_resolve_bulk_events_none_anywhere(tmp_path):
+    # No manual file, no sidecar, no annotations -> empty tuple so the caller
+    # fails the scan with a clear reason instead of estimating on nothing.
+    scan_path = tmp_path / "empty.snirf"
+    scan_path.write_text("x")
+    scan = ScanEntry(format="snirf", path=scan_path, display_name="empty")
+    st = AppState()
+    st.manifest = Manifest(root=tmp_path, scans=(scan,))
+    snapshot = EstimationOptions(selected_events=())
+    rows, impulse, selected = hrf_panel._resolve_bulk_events(
+        st, scan, _FakeRaw(None), snapshot
+    )
+    assert rows is None and impulse is None and selected == ()
+
+
+# ---------------------------------------------------------------------------
+# EstimationOptions — configurable per-channel timeout
+# ---------------------------------------------------------------------------
+
+
+def test_estimation_options_timeout_default():
+    opts = EstimationOptions()
+    assert opts.timeout == 30.0  # mirrors montage.estimate_hrf default
+
+
+def test_estimation_options_timeout_override():
+    opts = EstimationOptions(timeout=5.0)
+    assert opts.timeout == 5.0

--- a/tests/test_gui_library.py
+++ b/tests/test_gui_library.py
@@ -297,6 +297,37 @@ class TestBuildPlotlyFigure:
         assert len(fig.data) == 0
 
 
+class TestShowInfoToggle:
+    """``show_info`` controls the per-HRF metadata hover popups: ``True``
+    (default) -> hoverinfo "text"; ``False`` -> "none" (tooltip hidden but
+    hover/click events still fire so ROI clicks + paint keep working)."""
+
+    def _hrfs(self):
+        return {
+            "h1": {"location": [1, 2, 3], "oxygenation": True, "context": {}},
+            "h2": {"location": [4, 5, 6], "oxygenation": False, "context": {}},
+        }
+
+    def test_show_info_default_text(self):
+        fig = library.build_plotly_figure(self._hrfs())
+        hrf_traces = [t for t in fig.data if t.name in ("HbO", "HbR")]
+        assert hrf_traces
+        assert all(t.hoverinfo == "text" for t in hrf_traces)
+
+    def test_show_info_false_hides_tooltip(self):
+        fig = library.build_plotly_figure(self._hrfs(), show_info=False)
+        hrf_traces = [t for t in fig.data if t.name in ("HbO", "HbR")]
+        assert hrf_traces
+        assert all(t.hoverinfo == "none" for t in hrf_traces)
+
+    def test_roi_trace_follows_show_info(self):
+        fig = library.build_plotly_figure(
+            self._hrfs(), show_info=False, roi_keys=["h1"],
+        )
+        roi = [t for t in fig.data if (t.name or "").startswith("ROI")]
+        assert roi and all(t.hoverinfo == "none" for t in roi)
+
+
 # ---------------------------------------------------------------------------
 # MNI brain overlay
 # ---------------------------------------------------------------------------

--- a/tests/test_gui_quality_panel.py
+++ b/tests/test_gui_quality_panel.py
@@ -126,6 +126,85 @@ class TestComputePerScanSync:
 
 
 # ---------------------------------------------------------------------------
+# Channel-wise QC helpers (3-stage table)
+# ---------------------------------------------------------------------------
+
+
+class TestChannelWiseHelpers:
+    def test_sd_prefix(self):
+        assert quality_panel._sd_prefix("S1_D1 hbo") == "S1_D1"
+        assert quality_panel._sd_prefix("S1_D1 760") == "S1_D1"
+        assert quality_panel._sd_prefix("nospace") == "nospace"
+
+    def test_nanmean_or_none(self):
+        assert quality_panel._nanmean_or_none(None) is None
+        assert quality_panel._nanmean_or_none({}) is None
+        assert quality_panel._nanmean_or_none({"a": 2.0, "b": 4.0}) == 3.0
+
+    def test_raw_value_for_averages_sd_pair(self):
+        # Two raw wavelength channels share the S1_D1 pair; their mean is the
+        # raw reference for the S1_D1 hbo/hbr haemoglobin channels.
+        raw_by = {"S1_D1 760": 2.0, "S1_D1 850": 4.0, "S2_D1 760": 10.0}
+        assert quality_panel._raw_value_for(raw_by, "S1_D1 hbo") == 3.0
+        assert quality_panel._raw_value_for(raw_by, "S2_D1 hbr") == 10.0
+        assert quality_panel._raw_value_for(raw_by, "S9_D9 hbo") is None
+        assert quality_panel._raw_value_for(None, "S1_D1 hbo") is None
+
+    def test_per_channel_dicts_populated(self):
+        raw = _make_fake_raw()
+        result = quality_panel.compute_per_scan_sync(None, raw, None)
+        m = result[quality_panel.STAGE_PREPROCESSED]
+        # Per-channel breakdowns keyed by channel name; means still present.
+        assert m.skew_by_channel is not None
+        assert set(m.skew_by_channel.keys()) == set(raw.ch_names)
+        assert m.variance_by_channel is not None
+        assert set(m.variance_by_channel.keys()) == set(raw.ch_names)
+        assert m.variance_mean is not None
+        assert m.kurtosis_by_channel is not None
+
+    def test_channel_bar_png_returns_data_uri(self):
+        pytest.importorskip("matplotlib")
+        hemo = quality_panel.QualityMetrics(
+            variance_by_channel={"S1_D1 hbo": 1.0, "S1_D1 hbr": 2.0},
+        )
+        act = quality_panel.QualityMetrics(
+            variance_by_channel={"S1_D1 hbo": 0.5, "S1_D1 hbr": 3.0},
+        )
+        png = quality_panel._render_channel_bar_png(
+            "variance_by_channel", "Variance",
+            ["S1_D1 hbo", "S1_D1 hbr"], None, hemo, act,
+        )
+        assert png is not None
+        assert png.startswith("data:image/png;base64,")
+
+    def test_channel_bar_png_none_when_no_data(self):
+        pytest.importorskip("matplotlib")
+        hemo = quality_panel.QualityMetrics(variance_by_channel={})
+        png = quality_panel._render_channel_bar_png(
+            "variance_by_channel", "Variance", [], None, hemo, None,
+        )
+        assert png is None
+
+
+# ---------------------------------------------------------------------------
+# state.activity_cache lifecycle (per-scan deconvolution for 3-stage QC)
+# ---------------------------------------------------------------------------
+
+
+class TestStateActivityCache:
+    def test_field_exists_and_empty(self):
+        s = AppState()
+        assert s.activity_cache is not None
+        assert len(s.activity_cache._cache) == 0
+
+    def test_reset_clears_activity_cache(self):
+        s = AppState()
+        s.activity_cache._cache[Path("/tmp/x")] = object()
+        s.reset()
+        assert len(s.activity_cache._cache) == 0
+
+
+# ---------------------------------------------------------------------------
 # compute_dataset_sync — manifest loop
 # ---------------------------------------------------------------------------
 

--- a/tests/test_gui_workers_client.py
+++ b/tests/test_gui_workers_client.py
@@ -1,0 +1,49 @@
+"""Unit tests for the background-task client-liveness guards.
+
+A long bulk run can outlive its page client (the user navigates away,
+reloads, or the native window reconnects). Touching a deleted client via
+``ui.notify`` then trips NiceGUI's "Client has been deleted but is still
+being used" warning. ``client_alive`` / ``notify_if_alive`` guard against
+that. These tests don't need a running server — they exercise the pure
+liveness check and the no-op path with stand-in clients.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("nicegui")
+
+from hrfunc.gui import workers  # noqa: E402
+
+
+class _FakeClient:
+    def __init__(self, client_id: str):
+        self.id = client_id
+
+
+def test_client_alive_none_is_false():
+    assert workers.client_alive(None) is False
+
+
+def test_client_alive_unknown_id_is_false():
+    # A client whose id isn't in nicegui's registry is treated as gone.
+    assert workers.client_alive(_FakeClient("not-a-real-client")) is False
+
+
+def test_notify_if_alive_noop_when_dead(caplog):
+    # Must not raise when the client is gone (the bug this guards against).
+    workers.notify_if_alive(None, "hello")
+    workers.notify_if_alive(_FakeClient("gone"), "hello", type="warning")
+
+
+def test_client_alive_true_for_registered(monkeypatch):
+    # A client present in nicegui's instances registry reads as alive.
+    from nicegui import Client
+
+    fake = _FakeClient("live-id")
+    monkeypatch.setitem(Client.instances, "live-id", fake)
+    try:
+        assert workers.client_alive(fake) is True
+    finally:
+        Client.instances.pop("live-id", None)


### PR DESCRIPTION
Consolidated v1.3.x GUI + core arc (one PR per maintainer request; integrates several feature branches into a single reviewable change).

## Activity tab
- **HRF-source picker** — choose **Estimated HRFs** (toeplitz), **Canonical reference**, or an **HRtree-selected HRF** as the deconvolution kernel. Per-source readiness + a "Go to HRFs/HRtree tab" jump when the chosen source isn't ready.
- **Per-scan montage cache** — each scan deconvolves with its *own* estimated HRFs (single + bulk), fixing the "HRFs belong to another scan" error.
- **Two-button layout** (Estimate + Save); save options folded into the Deconvolution card. **Save is independent of Estimate** (writes the cached result, never re-estimates). **Batch Save** confirms and writes each scan **colocated** with its source file.
- **Configurable per-channel timeout** + **"Drop failed channels"** toggle (a failing channel is dropped, not the whole scan).

## Quality tab
- **Channel-wise 3-stage QC** (raw -> hemoglobin -> activity): per-metric tabs (SNR / variance / skewness / kurtosis), **delta + ratio** columns, and a per-channel **grouped bar chart** (raw=orange, hemoglobin=red, activity=blue). Backed by a new per-scan activity cache.

## HRFs / HRtree / shell
- **Events upload** (BIDS / simple / impulse), glob find-window, auto-collocation; bulk HRF estimation discovers each scan's own events.
- Per-channel HRF preview column; HRtree selection updates the detail pane immediately.
- Dataset-tree checkboxes stay in sync across tabs; `navigate_estimate` / `navigate_hrtree` hops.

## Core library (`hrfunc.py`)
- **`estimate_activity`: banded-Cholesky solve** (`solveh_banded`) replaces the dense `n_time x n_time` Toeplitz solve — **numerically identical** (max abs diff ~1e-9, `np.allclose` True), O(n) not O(n^3), **fixing the freeze** on real recordings. Adds `hrf_model='library'` and a per-channel `drop_failed_channels` guard. Also folds in main's explicit no-match channel guard.
- **`estimate_hrf`: per-channel solve timeout.**

## Other
- **SNIRF** written via `mne-nirs` (core MNE has no SNIRF writer).
- Bulk-completion toasts guarded against a deleted page client.
- Thorough per-scan failure reasons in bulk runs.

## Tests
events IO/panel, activity (sources, montage resolution, timeout/drop), quality (channel-wise helpers, activity cache), client-liveness guards.

## Notes
- Reconciled with current `main` (PRs #65-71), keeping their core-science fixes and `RawCache.put()` LRU bound.
- Validated by byte-compile + targeted numerical checks; full `pytest` should be run in the GUI env (mne / nicegui).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
