### PR TITLE
feat: per-channel HRtree deconvolution, project group montage, HRF-page UX

### DIFF
--- a/src/hrfunc/gui/components/activity_panel.py
+++ b/src/hrfunc/gui/components/activity_panel.py
@@ -112,6 +112,13 @@ def _snapshot_options(state: AppState, opts: "ActivityOptions") -> "ActivityOpti
         drop_failed_channels=opts.drop_failed_channels,
         library_trace=kernel[0] if kernel else None,
         library_oxygenation=kernel[1] if kernel else True,
+        # Per-channel matching settings travel with the snapshot; the actual
+        # ``library_traces`` map is computed per scan at run time (it depends
+        # on each scan's channel geometry), not captured here.
+        library_per_channel=opts.library_per_channel,
+        library_strategy=opts.library_strategy,
+        library_radius_mm=opts.library_radius_mm,
+        library_uncovered=opts.library_uncovered,
     )
 
 
@@ -136,6 +143,46 @@ class ActivityOptions:
     # selection changes mid-run. None in other modes.
     library_trace: Optional[list] = None
     library_oxygenation: bool = True
+    # Per-channel HRtree mapping (hrf_model == MODEL_LIBRARY). When
+    # ``library_per_channel`` is True and the user's ROIs yield candidates,
+    # each channel is deconvolved with its OWN spatially-matched HRF instead
+    # of one shared kernel. ``library_strategy`` picks individual-HRF vs
+    # ROI-mean matching; ``library_radius_mm`` is the max match distance;
+    # ``library_uncovered`` is 'skip' (drop unmatched channels) or 'canonical'.
+    # ``library_traces`` is the computed {ch_name: trace} map, filled per scan
+    # at run time (None until then; differs per scan so it is NOT snapshotted
+    # at the panel level).
+    library_per_channel: bool = True
+    library_strategy: str = "individual"
+    library_radius_mm: float = 20.0
+    library_uncovered: str = "skip"
+    library_traces: Optional[dict] = None
+
+
+def _compute_library_traces(
+    state: AppState, raw, opts: "ActivityOptions"
+) -> Optional[dict]:
+    """Per-channel HRtree ``{ch_name: trace}`` map for ONE scan's raw, or None.
+
+    Returns None — telling the run path to fall back to the single shared
+    kernel — when not in per-channel library mode, when the spatial match
+    raises, or when no channel found a same-oxygenation HRF within range.
+    Computed per scan because each scan's channel geometry differs.
+    """
+    if opts.hrf_model != MODEL_LIBRARY or not opts.library_per_channel:
+        return None
+    try:
+        from .hrtree_match import match_channels_to_hrtree
+        res = match_channels_to_hrtree(
+            state, raw,
+            strategy=opts.library_strategy,
+            radius_mm=opts.library_radius_mm,
+        )
+    except Exception as exc:  # noqa: BLE001 — never break a run on a match error
+        logger.warning("HRtree per-channel match failed: %s", exc)
+        return None
+    traces = res.library_traces()
+    return traces or None
 
 
 def render(state: AppState) -> None:
@@ -206,6 +253,12 @@ def _render_body(state: AppState, opts: ActivityOptions) -> None:
                         f"Bulk run on {len(checked_scans)} checked scan"
                         f"{'s' if len(checked_scans) != 1 else ''}."
                     ).classes("text-sm font-mono opacity-70")
+                    # Bulk preprocess readiness + one-click "Preprocess all
+                    # checked" (the deconvolution the bulk run needs). The
+                    # bulk run preprocesses on demand too, so this is a
+                    # readout + convenience, not a prerequisite.
+                    from .preprocess_panel import render_preprocess_all_checked
+                    render_preprocess_all_checked(state, checked_scans)
                 elif scan is not None:
                     ui.label(scan.display_name or scan.path.name).classes(
                         "text-sm font-mono opacity-70"
@@ -422,7 +475,7 @@ def _render_hrf_source_column(
     if opts.hrf_model == MODEL_TOEPLITZ:
         _render_estimated_source_status(state, scan, bulk_mode)
     elif opts.hrf_model == MODEL_LIBRARY:
-        _render_library_source_status(state)
+        _render_library_source_status(state, scan, opts, bulk_mode)
     else:
         _render_canonical_source_status(state, scan)
 
@@ -449,13 +502,201 @@ def _go_to_hrtree_button(state: AppState) -> None:
         ).props("flat dense color=primary")
 
 
-def _render_library_source_status(state: AppState) -> None:
+def _visible_roi_count(state: AppState) -> int:
+    """Number of visible ROIs the user has built in the HRtree (0 on error)."""
+    try:
+        from .hrtree_panel import _visible_shapes
+        return len(_visible_shapes(state))
+    except Exception:  # noqa: BLE001
+        return 0
+
+
+def _render_library_source_status(
+    state: AppState,
+    scan: Optional[ScanEntry],
+    opts: "ActivityOptions",
+    bulk_mode: bool,
+) -> None:
     """Status + preview for the "HRtree HRF" (library) source.
 
-    Uses the HRF currently selected in the HRtree tab
-    (``state.library_selected_hrf``) as the single deconvolution kernel for
-    every channel. Prompts the user to the HRtree tab when nothing is picked.
+    Two sub-modes:
+    - **Per-channel** (default when the user has built ROIs): each scan channel
+      is matched to its own HRtree HRF; shows coverage counts + a per-channel
+      assignment column.
+    - **Single HRF**: one selected HRF applied to every channel (the original
+      behaviour), used when there are no ROIs.
     """
+    n_rois = _visible_roi_count(state)
+    has_single = _library_kernel_from_state(state) is not None
+
+    # Nothing to work with at all -> point the user at the HRtree tab.
+    if n_rois == 0 and not has_single:
+        ui.label("No HRtree HRFs selected yet.").classes("text-sm opacity-70")
+        ui.label(
+            "Open the HRtree tab and build ROIs from a montage (per-channel "
+            "matching), or click a single HRF to use as one shared kernel."
+        ).classes("text-xs opacity-60")
+        _go_to_hrtree_button(state)
+        return
+
+    # Mode toggle (only meaningful once ROIs exist).
+    if n_rois > 0:
+        def _set_mode(value) -> None:
+            opts.library_per_channel = bool(value)
+            state.publish("scan_selected", state.selected_scan)
+
+        ui.radio(
+            {True: "Per-channel (from ROIs)", False: "Single HRF"},
+            value=opts.library_per_channel,
+            on_change=lambda e: _set_mode(e.value),
+        ).props("inline dense").classes("text-sm")
+
+    if opts.library_per_channel and n_rois > 0:
+        _render_library_per_channel_status(state, scan, opts, bulk_mode, n_rois)
+    else:
+        _render_library_single_status(state)
+
+
+def _render_library_per_channel_status(
+    state: AppState,
+    scan: Optional[ScanEntry],
+    opts: "ActivityOptions",
+    bulk_mode: bool,
+    n_rois: int,
+) -> None:
+    """Per-channel HRtree matching: controls + coverage counts + assignment."""
+    from .hrtree_match import (
+        STRATEGY_INDIVIDUAL,
+        STRATEGY_ROI_MEAN,
+        match_channels_to_hrtree,
+    )
+
+    def _rerender() -> None:
+        state.publish("scan_selected", state.selected_scan)
+
+    # ── Matching strategy (the user picks between the two approaches).
+    def _set_strategy(value) -> None:
+        opts.library_strategy = value
+        _rerender()
+
+    ui.radio(
+        {STRATEGY_INDIVIDUAL: "Nearest HRF", STRATEGY_ROI_MEAN: "ROI mean"},
+        value=opts.library_strategy,
+        on_change=lambda e: _set_strategy(e.value),
+    ).props("inline dense").classes("text-xs")
+
+    # ── Match radius (mm).
+    def _set_radius(value) -> None:
+        try:
+            opts.library_radius_mm = max(1.0, float(value))
+        except (TypeError, ValueError):
+            opts.library_radius_mm = 20.0
+        _rerender()
+
+    ui.number(
+        "Match radius (mm)",
+        value=opts.library_radius_mm,
+        min=1.0, max=200.0, step=1.0, format="%.0f",
+        on_change=lambda e: _set_radius(e.value),
+    ).props("dense").classes("w-40")
+
+    # ── Uncovered-channel handling (lives here in the right column, per the
+    # request). Default 'skip' fails loudly; user can switch to canonical.
+    def _set_uncovered(value) -> None:
+        opts.library_uncovered = value
+        _rerender()
+
+    ui.radio(
+        {"skip": "Skip uncovered", "canonical": "Canonical fallback"},
+        value=opts.library_uncovered,
+        on_change=lambda e: _set_uncovered(e.value),
+    ).props("inline dense").classes("text-xs")
+    _go_to_hrtree_button(state)
+
+    # ── Coverage needs a single, preprocessed scan to match against. In bulk
+    # mode each scan matches its own geometry at run time, so just summarise.
+    preview_scan = scan if not bulk_mode else None
+    if preview_scan is None or preview_scan not in state.processed_cache:
+        ui.label(
+            f"{n_rois} ROI{'s' if n_rois != 1 else ''} selected. Coverage is "
+            "computed per scan at run time — select a single preprocessed scan "
+            "to preview which channels match."
+        ).classes("text-sm opacity-70")
+        return
+
+    raw = state.processed_cache.get(preview_scan)
+    try:
+        res = match_channels_to_hrtree(
+            state, raw,
+            strategy=opts.library_strategy,
+            radius_mm=opts.library_radius_mm,
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("HRtree coverage preview failed: %s", exc)
+        ui.label("Coverage preview unavailable.").classes("text-sm opacity-60")
+        return
+
+    n_cov = len(res.covered)
+    n_unc = len(res.uncovered)
+    total = len(res.matches)
+    # ── Headline counts at the top.
+    ui.label(
+        f"{n_cov}/{total} channels covered · {n_unc} uncovered · "
+        f"{res.n_candidate_hrfs} HRF{'s' if res.n_candidate_hrfs != 1 else ''} "
+        f"across {res.n_rois} ROI{'s' if res.n_rois != 1 else ''}"
+    ).classes("text-sm font-medium")
+    if n_unc:
+        if opts.library_uncovered == "skip":
+            ui.label(
+                f"{n_unc} uncovered channel{'s' if n_unc != 1 else ''} will be "
+                "DROPPED from the output (switch to canonical to keep them)."
+            ).classes("text-xs text-amber-400")
+        else:
+            ui.label(
+                f"{n_unc} uncovered channel{'s' if n_unc != 1 else ''} will use "
+                "the canonical HRF."
+            ).classes("text-xs opacity-60")
+
+    _render_match_gallery(res)
+
+
+def _render_match_gallery(res) -> None:
+    """Per-channel assignment column: each channel + its matched HRF or
+    'uncovered' (mirrors the per-channel HRF columns on the other tabs)."""
+    from types import SimpleNamespace
+
+    ui.label("Per-channel HRF assignment").classes(
+        "text-xs uppercase opacity-60 tracking-wide mt-2"
+    )
+    with ui.column().classes(
+        "w-full gap-1 max-h-96 overflow-auto border border-slate-700 "
+        "rounded p-2"
+    ):
+        for m in res.matches:
+            with ui.row().classes("items-center gap-2 w-full no-wrap"):
+                if m.matched:
+                    try:
+                        from .hrf_panel import _render_mini_hrf_png
+                        png = _render_mini_hrf_png(
+                            SimpleNamespace(trace=m.trace)
+                        )
+                    except Exception:  # noqa: BLE001
+                        png = None
+                    if png is not None:
+                        ui.image(png).style("width:3rem;height:2rem;")
+                    ui.label(m.ch_name).classes("text-xs font-mono")
+                    dist = f"  ({m.distance_mm:.0f} mm)" if m.distance_mm is not None else ""
+                    ui.label(f"→ {m.source}{dist}").classes(
+                        "text-xs opacity-60 truncate"
+                    )
+                else:
+                    ui.icon("block").classes("text-amber-500")
+                    ui.label(m.ch_name).classes("text-xs font-mono opacity-70")
+                    ui.label("uncovered").classes("text-xs text-amber-500")
+
+
+def _render_library_single_status(state: AppState) -> None:
+    """Single-kernel HRtree source: one selected HRF for every channel."""
     hrf = getattr(state, "library_selected_hrf", None)
     kernel = _library_kernel_from_state(state)
 
@@ -523,7 +764,40 @@ def _render_estimated_source_status(
     HRFs are cached per scan (``state.montage_cache``), so each scan is
     deconvolved with its OWN HRFs — single or bulk. Reports this scan's
     readiness (single mode) or a batch summary (bulk mode).
+
+    When a pooled group montage exists (≥2 subjects estimated on the HRFs
+    tab), a toggle lets the user deconvolve every scan with the GROUP HRFs
+    instead — matched by channel name, so it also covers scans that weren't
+    individually estimated.
     """
+    n_group = _group_subject_count(state)
+    group_available = (
+        state.project_montage is not None
+        and not isinstance(state.project_montage, _CanonicalResult)
+        and n_group >= 2
+    )
+    if group_available:
+        def _set_group(event) -> None:
+            state.activity_use_group_hrfs = bool(event.value)
+            state.publish("scan_selected", state.selected_scan)
+
+        ui.radio(
+            {False: "Each scan's own HRFs", True: f"Group HRFs ({n_group})"},
+            value=state.activity_use_group_hrfs,
+            on_change=_set_group,
+        ).props("inline dense").classes("text-xs")
+    elif state.activity_use_group_hrfs:
+        # Group montage went away (project reset / re-estimate) — fall back.
+        state.activity_use_group_hrfs = False
+
+    if state.activity_use_group_hrfs and group_available:
+        ui.label(
+            f"Deconvolving every scan with the GROUP HRFs ({n_group} subjects), "
+            "matched by channel name."
+        ).classes("text-sm opacity-70")
+        _safe_render_gallery(state, state.project_montage)
+        return
+
     if bulk_mode:
         n_cached = len(state.montage_cache)
         ui.label(
@@ -837,6 +1111,14 @@ def _run_dispatch(
         _run(state, selected, opts)
 
 
+def _group_subject_count(state: AppState) -> int:
+    """Number of scans pooled into the group montage (non-canonical cache)."""
+    return sum(
+        1 for m in state.montage_cache.values()
+        if m is not None and not isinstance(m, _CanonicalResult)
+    )
+
+
 def _montage_for_scan(state: AppState, scan: Optional[ScanEntry]):
     """The per-channel Montage to use for toeplitz activity on ``scan``.
 
@@ -845,6 +1127,15 @@ def _montage_for_scan(state: AppState, scan: Optional[ScanEntry]):
     runs. Falls back to the single most-recent ``state.montage`` when it was
     estimated for this exact scan. Returns None when neither applies.
     """
+    # Group mode: deconvolve EVERY scan with the pooled project montage
+    # (matched by channel name in estimate_activity), so a group HRF can be
+    # applied even to scans that weren't individually estimated.
+    if (
+        getattr(state, "activity_use_group_hrfs", False)
+        and state.project_montage is not None
+        and not isinstance(state.project_montage, _CanonicalResult)
+    ):
+        return state.project_montage
     if scan is None:
         return None
     cached = state.montage_cache.get(scan.path.resolve())
@@ -916,7 +1207,10 @@ def _run_bulk(
                 return reason  # intentional skip carrying its reason
             existing_montage = _montage_for_scan(state, scan)
         elif snapshot.hrf_model == MODEL_LIBRARY:
-            if snapshot.library_trace is None:
+            # Per-channel mode resolves each scan's own HRtree match in the
+            # worker below, so it doesn't need a single selected kernel here;
+            # single-kernel mode still does.
+            if not snapshot.library_per_channel and snapshot.library_trace is None:
                 return (
                     "no HRtree HRF selected — pick one in the HRtree tab to "
                     "use as the deconvolution kernel"
@@ -935,7 +1229,23 @@ def _run_bulk(
             # ensure_deconvolved_raw raises a specific reason on failure.
             from .preprocess_panel import ensure_deconvolved_raw
             raw = ensure_deconvolved_raw(state, scan)
-            return run_activity_sync(raw, snapshot, existing_montage, progress_cb)
+            scan_snapshot = snapshot
+            if snapshot.hrf_model == MODEL_LIBRARY and snapshot.library_per_channel:
+                # Match THIS scan's channels to the HRtree ROIs.
+                import dataclasses
+                traces = _compute_library_traces(state, raw, snapshot)
+                scan_snapshot = dataclasses.replace(
+                    snapshot, library_traces=traces
+                )
+                if not traces and snapshot.library_trace is None:
+                    raise RuntimeError(
+                        "no HRtree HRFs matched any channel of this scan within "
+                        f"{snapshot.library_radius_mm:.0f} mm — widen the radius, "
+                        "add ROIs, or select a single HRF as a fallback"
+                    )
+            return run_activity_sync(
+                raw, scan_snapshot, existing_montage, progress_cb
+            )
 
         return (_pp_and_estimate, (), {})
 
@@ -1112,17 +1422,22 @@ def _run(
                 "HRFs tab (toeplitz mode), or switch the source to canonical."
             )
             return
-    elif opts.hrf_model == MODEL_LIBRARY:
-        if _library_kernel_from_state(state) is None:
+    raw = state.processed_cache.get(scan)
+
+    library_traces = None
+    if opts.hrf_model == MODEL_LIBRARY:
+        # Per-channel HRtree map for this scan (None => single-kernel fallback).
+        library_traces = _compute_library_traces(state, raw, opts)
+        if not library_traces and _library_kernel_from_state(state) is None:
             state.last_error = (
-                "Select an HRF in the HRtree tab to use as the deconvolution "
-                "kernel first."
+                "No HRtree HRFs to deconvolve with. Build ROIs in the HRtree "
+                "for per-channel matching, or select a single HRF there first."
             )
             return
 
     snapshot = _snapshot_options(state, opts)
+    snapshot.library_traces = library_traces
 
-    raw = state.processed_cache.get(scan)
     progress_cb = make_progress_callback(state)
     existing_montage = (
         _montage_for_scan(state, scan)
@@ -1207,8 +1522,14 @@ def run_activity_sync(
         "drop_failed_channels": opts.drop_failed_channels,
     }
     if opts.hrf_model == MODEL_LIBRARY:
-        estimate_kwargs["library_trace"] = opts.library_trace
-        estimate_kwargs["library_oxygenation"] = opts.library_oxygenation
+        if opts.library_traces:
+            # Per-channel HRtree map (already matched per this scan's channels).
+            estimate_kwargs["library_traces"] = opts.library_traces
+            estimate_kwargs["library_uncovered"] = opts.library_uncovered
+        else:
+            # Single-kernel fallback (one selected HRF for every channel).
+            estimate_kwargs["library_trace"] = opts.library_trace
+            estimate_kwargs["library_oxygenation"] = opts.library_oxygenation
 
     try:
         result = m.estimate_activity(

--- a/src/hrfunc/gui/components/hrf_panel.py
+++ b/src/hrfunc/gui/components/hrf_panel.py
@@ -475,10 +475,11 @@ def _render_body(state: AppState, opts: EstimationOptions) -> None:
 
 
 def _project_montages(state: AppState) -> list:
-    """Real per-scan montages from the cache (skips canonical results)."""
+    """Real per-scan montages in the group pool (skips canonical + excluded)."""
     return [
-        m for m in state.montage_cache.values()
+        m for path, m in state.montage_cache.items()
         if m is not None and not isinstance(m, _CanonicalResult)
+        and path not in state.project_group_excluded
     ]
 
 
@@ -486,44 +487,47 @@ def _project_subject_count(state: AppState) -> int:
     return len(_project_montages(state))
 
 
-def _build_project_montage(montages: list):
-    """Pool per-scan montages into one GROUP montage.
+def _build_project_montage(sourced_montages: list):
+    """Pool per-scan montages into one GROUP montage, tagging provenance.
 
-    Each group channel collects EVERY contributing subject's estimate, then
-    ``generate_distribution`` re-means/re-stds across them — so ``trace_std``
-    becomes the genuine between-subject variability (a single scan's montage
-    has one estimate → std 0). Returns None when nothing poolable.
-
-    Reuses the cached per-scan montages (keyed by scan path), so re-estimating
-    a scan replaces its contribution on the next rebuild with no double count,
-    and no re-estimation is needed here. Duck-typed (``.channels`` of nodes
-    with ``.estimates`` + a ``.generate_distribution()``) so tests can pass
+    ``sourced_montages`` is a list of ``(source_id, montage)`` pairs. Each group
+    channel collects EVERY contributing subject's estimate (tagging each with
+    its ``source_id`` in ``estimate_sources``), then ``generate_distribution``
+    re-means/re-stds across them — so ``trace_std`` becomes the genuine
+    between-subject variability (a single scan's montage has one estimate → std
+    0). Tagging lets a saved+reloaded group montage still report / remove a
+    specific subject (see ``montage.remove_source``). Returns None when nothing
+    poolable. Duck-typed (``.channels`` of nodes with ``.estimates`` /
+    ``.estimate_sources`` + a ``.generate_distribution()``) so tests can pass
     lightweight fakes.
     """
     import copy
 
     real = [
-        m for m in montages
+        (sid, m) for sid, m in sourced_montages
         if m is not None and not isinstance(m, _CanonicalResult)
     ]
     if not real:
         return None
 
-    group = copy.deepcopy(real[0])
+    group = copy.deepcopy(real[0][1])
     # Union of channels: graft in any channel present in a later subject but
     # absent from the base (heterogeneous montage layouts across subjects).
-    for m in real[1:]:
+    for _sid, m in real[1:]:
         for ch, node in getattr(m, "channels", {}).items():
             if ch not in group.channels:
                 group.channels[ch] = copy.deepcopy(node)
-    # Pool every subject's estimate into each channel.
+    # Pool every subject's estimate into each channel, tagged by source.
     for ch, gnode in group.channels.items():
-        pooled = []
-        for m in real:
+        pooled, sources = [], []
+        for sid, m in real:
             other = getattr(m, "channels", {}).get(ch)
             if other is not None and getattr(other, "estimates", None):
-                pooled.extend(other.estimates)
+                for est in other.estimates:
+                    pooled.append(est)
+                    sources.append(sid)
         gnode.estimates = pooled
+        gnode.estimate_sources = sources
     try:
         group.generate_distribution()
     except Exception as exc:  # noqa: BLE001 — never break the panel on a pool error
@@ -532,9 +536,21 @@ def _build_project_montage(montages: list):
     return group
 
 
+def _sourced_project_montages(state: AppState) -> list:
+    """``(source_id, montage)`` pairs for the group pool — source id is the
+    scan's resolved path string (stable, unique, survives manifest rebuilds)."""
+    return [
+        (str(path), m) for path, m in state.montage_cache.items()
+        if m is not None and not isinstance(m, _CanonicalResult)
+        and path not in state.project_group_excluded
+    ]
+
+
 def _rebuild_project_montage(state: AppState) -> None:
     """Refresh ``state.project_montage`` from the current per-scan cache."""
-    state.project_montage = _build_project_montage(_project_montages(state))
+    state.project_montage = _build_project_montage(
+        _sourced_project_montages(state)
+    )
 
 
 def _render_preview_view_toggle(state: AppState, n_subjects: int) -> None:
@@ -559,6 +575,7 @@ def _group_subject_names(state: AppState) -> list:
     contributing = {
         path for path, m in state.montage_cache.items()
         if m is not None and not isinstance(m, _CanonicalResult)
+        and path not in state.project_group_excluded
     }
     by_path = {}
     if state.manifest is not None:
@@ -599,16 +616,66 @@ async def _save_group_montage(state: AppState) -> None:
         ui.notify(state.last_error, type="negative")
 
 
+def _group_subject_entries(state: AppState) -> list:
+    """``(path, name, excluded)`` for every non-canonical cached scan."""
+    by_path = {}
+    if state.manifest is not None:
+        by_path = {s.path.resolve(): s for s in state.manifest.scans}
+    out = []
+    for path, m in state.montage_cache.items():
+        if m is None or isinstance(m, _CanonicalResult):
+            continue
+        scan = by_path.get(path)
+        name = (scan.display_name or scan.path.name) if scan else path.stem
+        out.append((path, name, path in state.project_group_excluded))
+    return sorted(out, key=lambda e: e[1])
+
+
+def _set_group_excluded(state: AppState, path, excluded: bool) -> None:
+    if excluded:
+        state.project_group_excluded.add(path)
+    else:
+        state.project_group_excluded.discard(path)
+    _rebuild_project_montage(state)
+    state.publish("hrf_selection_changed")
+
+
 def _render_group_subjects(state: AppState) -> None:
-    """Contributing-subjects readout + a Save-group action for the group view."""
-    names = _group_subject_names(state)
-    if names:
-        shown = ", ".join(names[:8]) + (
-            f", +{len(names) - 8} more" if len(names) > 8 else ""
-        )
-        ui.label(f"Contributing scans: {shown}").classes(
-            "text-xs opacity-60 break-all"
-        )
+    """Contributing-subjects readout, per-subject remove/restore, + Save."""
+    entries = _group_subject_entries(state)
+    included = [e for e in entries if not e[2]]
+    excluded = [e for e in entries if e[2]]
+
+    ui.label(f"Contributing scans ({len(included)})").classes(
+        "text-xs uppercase opacity-60 tracking-wide"
+    )
+    with ui.row().classes("items-center gap-1 flex-wrap"):
+        for path, name, _ in included:
+            with ui.row().classes(
+                "items-center gap-1 px-2 py-0.5 rounded bg-slate-700/40"
+            ):
+                ui.label(name).classes("text-xs")
+                # Keep at least 2 subjects so it stays a group (and the view +
+                # restore controls remain reachable).
+                if len(included) > 2:
+                    ui.button(
+                        icon="close",
+                        on_click=lambda p=path: _set_group_excluded(
+                            state, p, True
+                        ),
+                    ).props("flat dense round size=xs").tooltip(
+                        "Remove this subject from the group"
+                    )
+
+    if excluded:
+        with ui.row().classes("items-center gap-2 flex-wrap"):
+            ui.label(
+                "Excluded: " + ", ".join(e[1] for e in excluded)
+            ).classes("text-xs opacity-50")
+            ui.button(
+                "Restore all",
+                on_click=lambda: _set_group_excluded_restore_all(state),
+            ).props("flat dense size=xs color=primary")
 
     async def _on_save() -> None:
         await _save_group_montage(state)
@@ -621,6 +688,12 @@ def _render_group_subjects(state: AppState) -> None:
             "Saves the pooled multi-subject HRFs (mean + std) as a "
             "tree.load_hrfs JSON — the submission form below can share it."
         ).classes("text-xs opacity-50")
+
+
+def _set_group_excluded_restore_all(state: AppState) -> None:
+    state.project_group_excluded.clear()
+    _rebuild_project_montage(state)
+    state.publish("hrf_selection_changed")
 
 
 def _render_preview_column(

--- a/src/hrfunc/gui/components/hrf_panel.py
+++ b/src/hrfunc/gui/components/hrf_panel.py
@@ -81,10 +81,19 @@ from ..workers import (
 )
 from ...io.manifest import ScanEntry
 
-# Library default edge-expansion fraction in montage.estimate_hrf. Used to
-# estimate the dropped start-of-scan window for the coverage warning so it
-# matches what the core actually discards.
-_EDGE_EXPANSION = 0.15
+# GUI default edge-expansion fraction passed to montage.estimate_hrf. The
+# core library default is 0.15; the GUI defaults a touch higher (0.2) because
+# a slightly wider pad reduces edge-instability in practice, and exposes it as
+# a user control. Used both as the estimate_hrf kwarg and to estimate the
+# dropped start-of-scan window for the coverage warning so it matches what the
+# core actually discards for the user's chosen value.
+DEFAULT_EDGE_EXPANSION = 0.2
+
+# Edge-instability QC defaults: flag a channel when its HRF trace's local std
+# over the outer DEFAULT_EDGE_STD_FRAC (each end) exceeds DEFAULT_EDGE_STD_RATIO
+# × the center std. Both are exposed as user controls.
+DEFAULT_EDGE_STD_FRAC = 0.15
+DEFAULT_EDGE_STD_RATIO = 2.0
 
 
 def _file_applies_to_scan(state: AppState, scan: Optional[ScanEntry]) -> bool:
@@ -282,6 +291,17 @@ class EstimationOptions:
     # Per-channel lstsq solve timeout (seconds), forwarded to
     # montage.estimate_hrf. A channel that exceeds it is skipped.
     timeout: float = DEFAULT_TIMEOUT
+    # Edge-expansion fraction forwarded to montage.estimate_hrf: each event
+    # onset is shifted back by ``edge_expansion * duration`` seconds so the
+    # estimation window captures the pre-onset baseline / ramp. A wider pad
+    # reduces edge instability but drops more early-scan events.
+    edge_expansion: float = DEFAULT_EDGE_EXPANSION
+    # Edge-instability QC sensitivity (post-estimation check): a channel is
+    # flagged when its HRF trace's local std over the outer ``edge_std_frac``
+    # (each end) exceeds ``edge_std_ratio`` × the center std. Both are
+    # user-tunable so the check can be made stricter / looser.
+    edge_std_frac: float = DEFAULT_EDGE_STD_FRAC
+    edge_std_ratio: float = DEFAULT_EDGE_STD_RATIO
 
 
 def render(state: AppState) -> None:
@@ -305,6 +325,10 @@ def render(state: AppState) -> None:
     state.subscribe("scan_selected", _refresh)
     state.subscribe("scan_loaded", _refresh)
     state.subscribe("preprocess_done", _refresh)
+    # Rebuild the pooled project (group) montage BEFORE the body re-renders,
+    # so the group preview reflects the scan that just finished. Registered
+    # ahead of the _refresh subscription below so it runs first.
+    state.subscribe("hrf_estimated", lambda *_: _rebuild_project_montage(state))
     state.subscribe("hrf_estimated", _refresh)
     # Dedicated event for gallery channel-pick refreshes — fires only the
     # HRFs-tab body re-render, avoiding the 6-subscriber re-render
@@ -359,10 +383,24 @@ def _render_body(state: AppState, opts: EstimationOptions) -> None:
         ui.label("HRFs").classes("text-2xl font-semibold")
 
         if scan is None and not bulk_mode:
-            ui.label(
-                "Select a scan from the dataset tree, or tick scans "
-                "for a bulk run."
-            ).classes("text-sm opacity-60")
+            # Disclaimer callout: nothing can be estimated until a scan is
+            # picked, so make the next step obvious rather than a faint line.
+            with ui.row().classes(
+                "w-full items-center gap-3 p-4 rounded border "
+                "border-amber-500/40 bg-amber-500/10"
+            ):
+                ui.icon("arrow_back", size="1.5rem").classes("text-amber-400")
+                with ui.column().classes("gap-0"):
+                    ui.label(
+                        "Select a scan to start estimating HRFs"
+                    ).classes("text-sm font-medium text-amber-300")
+                    ui.label(
+                        "Pick a scan from the dataset tree on the left, or "
+                        "tick several scans there for a bulk run."
+                    ).classes("text-xs opacity-70")
+            # Submission stays available with no scan selected so users who
+            # only want to share an existing HRF JSON they have on disk can.
+            _render_submission_section(state)
             return
 
         # Two-column workspace: estimation controls on the left, the
@@ -407,19 +445,182 @@ def _render_body(state: AppState, opts: EstimationOptions) -> None:
                         if scan is not None:
                             _render_toeplitz_controls(state, opts, scan)
                         else:
-                            ui.label(
-                                "Pick one of the checked scans to populate the "
-                                "event picker / lambda / duration controls."
-                            ).classes("text-sm opacity-60")
+                            # Bulk: scans ticked, no row selected. Show the
+                            # global lambda / duration / timeout controls so
+                            # the batch can be tuned, plus a preprocess-
+                            # readiness summary + "Preprocess all checked"
+                            # button. Per-scan events are auto-discovered at
+                            # run time (see the bulk note above), so there's
+                            # no event picker in this branch.
+                            from .preprocess_panel import (
+                                render_preprocess_all_checked,
+                            )
+                            _render_toeplitz_global_params(opts)
+                            render_preprocess_all_checked(
+                                state, checked_scans
+                            )
                     else:
                         _render_canonical_note()
 
-                # ── Run button + progress / error display
+                # ── Run button (+ Save when ready) + progress / error display
                 _render_run_row(state, scan, checked_scans, opts)
 
-            # ── Right column: per-channel HRF visualization + save / submit
+                # ── Submission — directly below Estimate, always present so an
+                # existing HRF JSON can be shared without estimating first.
+                _render_submission_section(state)
+
+            # ── Right column: per-channel HRF visualization
             with ui.column().classes("flex-1 min-w-0 gap-3"):
                 _render_preview_column(state, scan, opts, bulk_mode)
+
+
+def _project_montages(state: AppState) -> list:
+    """Real per-scan montages from the cache (skips canonical results)."""
+    return [
+        m for m in state.montage_cache.values()
+        if m is not None and not isinstance(m, _CanonicalResult)
+    ]
+
+
+def _project_subject_count(state: AppState) -> int:
+    return len(_project_montages(state))
+
+
+def _build_project_montage(montages: list):
+    """Pool per-scan montages into one GROUP montage.
+
+    Each group channel collects EVERY contributing subject's estimate, then
+    ``generate_distribution`` re-means/re-stds across them — so ``trace_std``
+    becomes the genuine between-subject variability (a single scan's montage
+    has one estimate → std 0). Returns None when nothing poolable.
+
+    Reuses the cached per-scan montages (keyed by scan path), so re-estimating
+    a scan replaces its contribution on the next rebuild with no double count,
+    and no re-estimation is needed here. Duck-typed (``.channels`` of nodes
+    with ``.estimates`` + a ``.generate_distribution()``) so tests can pass
+    lightweight fakes.
+    """
+    import copy
+
+    real = [
+        m for m in montages
+        if m is not None and not isinstance(m, _CanonicalResult)
+    ]
+    if not real:
+        return None
+
+    group = copy.deepcopy(real[0])
+    # Union of channels: graft in any channel present in a later subject but
+    # absent from the base (heterogeneous montage layouts across subjects).
+    for m in real[1:]:
+        for ch, node in getattr(m, "channels", {}).items():
+            if ch not in group.channels:
+                group.channels[ch] = copy.deepcopy(node)
+    # Pool every subject's estimate into each channel.
+    for ch, gnode in group.channels.items():
+        pooled = []
+        for m in real:
+            other = getattr(m, "channels", {}).get(ch)
+            if other is not None and getattr(other, "estimates", None):
+                pooled.extend(other.estimates)
+        gnode.estimates = pooled
+    try:
+        group.generate_distribution()
+    except Exception as exc:  # noqa: BLE001 — never break the panel on a pool error
+        logger.warning("project montage generate_distribution failed: %s", exc)
+        return None
+    return group
+
+
+def _rebuild_project_montage(state: AppState) -> None:
+    """Refresh ``state.project_montage`` from the current per-scan cache."""
+    state.project_montage = _build_project_montage(_project_montages(state))
+
+
+def _render_preview_view_toggle(state: AppState, n_subjects: int) -> None:
+    """Radio toggle between the selected scan's HRFs and the group montage."""
+    def _set(event) -> None:
+        state.hrf_preview_group = bool(event.value)
+        state.publish("hrf_selection_changed")
+
+    ui.radio(
+        {False: "This scan", True: f"Group ({n_subjects} subjects)"},
+        value=state.hrf_preview_group,
+        on_change=_set,
+    ).props("inline dense").classes("text-xs")
+
+
+def _group_subject_names(state: AppState) -> list:
+    """Display names of the scans contributing to the group montage.
+
+    Maps the (non-canonical) ``montage_cache`` keys back to manifest scans;
+    falls back to the path stem when a key isn't in the current manifest.
+    """
+    contributing = {
+        path for path, m in state.montage_cache.items()
+        if m is not None and not isinstance(m, _CanonicalResult)
+    }
+    by_path = {}
+    if state.manifest is not None:
+        by_path = {s.path.resolve(): s for s in state.manifest.scans}
+    names = []
+    for path in contributing:
+        scan = by_path.get(path)
+        names.append(
+            (scan.display_name or scan.path.name) if scan is not None
+            else path.stem
+        )
+    return sorted(names)
+
+
+async def _save_group_montage(state: AppState) -> None:
+    """Save the pooled group montage to JSON (reuses the Export save path)."""
+    import asyncio
+
+    montage = state.project_montage
+    if montage is None:
+        state.last_error = "No group montage to save."
+        return
+    from .export_panel import _pick_save_path, save_montage_sync
+
+    path = await _pick_save_path(
+        suggested="group_hrfs.json", title="Save group HRFs"
+    )
+    if path is None:
+        return
+    try:
+        await asyncio.get_event_loop().run_in_executor(
+            None, save_montage_sync, montage, path
+        )
+        ui.notify(f"Saved group HRFs: {path.name}", type="positive")
+    except Exception as exc:  # noqa: BLE001
+        state.last_error = f"Save failed: {type(exc).__name__}: {exc}"
+        logger.exception("group montage save failed: %s", exc)
+        ui.notify(state.last_error, type="negative")
+
+
+def _render_group_subjects(state: AppState) -> None:
+    """Contributing-subjects readout + a Save-group action for the group view."""
+    names = _group_subject_names(state)
+    if names:
+        shown = ", ".join(names[:8]) + (
+            f", +{len(names) - 8} more" if len(names) > 8 else ""
+        )
+        ui.label(f"Contributing scans: {shown}").classes(
+            "text-xs opacity-60 break-all"
+        )
+
+    async def _on_save() -> None:
+        await _save_group_montage(state)
+
+    with ui.row().classes("items-center gap-2"):
+        ui.button(
+            "Save group HRFs", icon="save", on_click=_on_save,
+        ).props("flat dense color=primary")
+        ui.label(
+            "Saves the pooled multi-subject HRFs (mean + std) as a "
+            "tree.load_hrfs JSON — the submission form below can share it."
+        ).classes("text-xs opacity-50")
 
 
 def _render_preview_column(
@@ -428,16 +629,17 @@ def _render_preview_column(
     opts: EstimationOptions,
     bulk_mode: bool,
 ) -> None:
-    """Right-hand column: the per-channel HRF visualization + save/submit.
+    """Right-hand column: the per-channel HRF visualization.
 
     Kept in its own column (mirroring the HRtree detail pane) so the channel
     accordion has horizontal room and the estimation controls on the left stay
-    compact. Shows a placeholder until a montage exists.
+    compact. Shows a placeholder until a montage exists. The Save button and
+    submission form live in the left column (next to / below Estimate).
 
     Bulk mode overwrites ``state.montage`` scan-by-scan, so during a run the
     preview would just flash whichever scan landed last -- we gate on
     ``not state.busy`` so it only appears once the batch FINISHES, and point
-    the preview/save at the scan that actually produced the montage
+    the preview at the scan that actually produced the montage
     (``montage_source_scan``) rather than the UI selection.
     """
     ui.label("HRF preview").classes(
@@ -447,6 +649,21 @@ def _render_preview_column(
     if state.busy:
         ui.label("Estimating…").classes("text-sm opacity-60")
         return
+
+    # Group view: once ≥2 scans have HRFs, offer a toggle between the selected
+    # scan's HRFs and the pooled project (group) montage, whose ±std band is
+    # the genuine between-subject variability.
+    n_subjects = _project_subject_count(state)
+    if n_subjects >= 2 and state.project_montage is not None:
+        _render_preview_view_toggle(state, n_subjects)
+        if state.hrf_preview_group:
+            ui.label(
+                f"Group HRF — {n_subjects} subjects (between-subject ± std)."
+            ).classes("text-sm font-medium")
+            _render_group_subjects(state)
+            _render_edge_qc(state.project_montage, opts)
+            _render_toeplitz_gallery(state, state.project_montage)
+            return
 
     preview_scan = scan if not bulk_mode else state.montage_source_scan
     if state.montage is None or preview_scan is None:
@@ -460,36 +677,57 @@ def _render_preview_column(
         ui.label(
             f"Showing HRFs for the last-estimated scan: {shown}. "
             "A bulk run keeps only the most recent scan's HRFs in memory — "
-            "save each scan's HRFs (below or via mass-save), or select a "
-            "single scan to view or re-estimate it."
+            "save each scan's HRFs (the Save button by Estimate, or mass-"
+            "save), or select a single scan to view or re-estimate it."
         ).classes("text-xs opacity-70 italic")
 
     _render_hrf_preview(state, preview_scan, opts)
 
-    # Save the estimated HRFs to JSON right here (same action as the Export
-    # tab's "Save montage HRFs"). Only meaningful for a real toeplitz montage.
-    if not isinstance(state.montage, _CanonicalResult):
-        async def _on_save_hrfs(_scan=preview_scan) -> None:
-            from .export_panel import _save_montage
-            await _save_montage(state, _scan)
 
-        with ui.row().classes("items-center gap-2"):
-            ui.button(
-                "Save",
-                icon="save",
-                on_click=_on_save_hrfs,
-            ).props("color=primary")
-            ui.label(
-                "Saves the per-channel estimated HRFs as a tree.load_hrfs "
-                "JSON file."
-            ).classes("text-xs opacity-60")
+def _render_save_button(
+    state: AppState, scan: Optional[ScanEntry], bulk_mode: bool
+) -> None:
+    """Save-HRFs button, shown beside Estimate only when there's a real
+    (toeplitz) montage to save — same pop-in-when-ready behaviour it had in
+    the preview column, just relocated next to the Estimate button.
 
-    # Submission card -- same form the Export tab renders. Surfaced here so
-    # users who finish an estimation can go straight to sharing without
-    # hopping to Export. The file picker defaults to state.last_saved_roi_path
-    # (set by the Cluster sub-tab's Save montage flow); if the user hasn't
-    # saved yet, they pick the JSON manually.
-    ui.separator()
+    Bulk mode points the save at the scan that produced the in-memory montage
+    (``montage_source_scan``), matching the preview. Canonical results aren't
+    saveable here (no per-channel estimates), so the button stays hidden.
+    """
+    if state.busy:
+        return
+    save_scan = scan if not bulk_mode else state.montage_source_scan
+    if (
+        state.montage is None
+        or save_scan is None
+        or isinstance(state.montage, _CanonicalResult)
+    ):
+        return
+
+    async def _on_save_hrfs(_scan=save_scan) -> None:
+        from .export_panel import _save_montage
+        await _save_montage(state, _scan)
+
+    ui.button(
+        "Save",
+        icon="save",
+        on_click=_on_save_hrfs,
+    ).props("color=primary").tooltip(
+        "Saves the per-channel estimated HRFs as a tree.load_hrfs JSON file."
+    )
+
+
+def _render_submission_section(state: AppState) -> None:
+    """HRF submission form — same form the Export tab renders, surfaced right
+    below the Estimate button.
+
+    Always rendered (not gated on an in-memory montage) so a user who just
+    wants to share an existing HRF JSON they have on disk can do it here
+    without first estimating. The file picker defaults to
+    ``state.last_saved_roi_path`` (set by a prior save / the Cluster sub-tab);
+    otherwise they pick the JSON manually.
+    """
     with ui.card().classes("w-full"):
         from ..submission import render_submission_panel
         render_submission_panel(
@@ -991,7 +1229,7 @@ async def _estimate_clicked(
             raw = state.processed_cache.get(scan)
             sfreq = float(raw.info["sfreq"])
             n_samples = int(raw.n_times)
-            edge_samples = int(round(_EDGE_EXPANSION * opts.duration * sfreq))
+            edge_samples = int(round(opts.edge_expansion * opts.duration * sfreq))
             if state.events_impulse is not None:
                 cov = coverage_report_vector(
                     state.events_impulse, sfreq, n_samples, edge_samples,
@@ -1090,6 +1328,17 @@ def _render_toeplitz_controls(
                     on_change=(lambda e, n=name: _toggle(n, bool(e.value))),
                 )
 
+    _render_toeplitz_global_params(opts)
+
+
+def _render_toeplitz_global_params(opts: EstimationOptions) -> None:
+    """Lambda / duration / timeout controls + edge advisory for toeplitz mode.
+
+    These are all ``opts``-global (no per-scan dependency), so they render in
+    both the single-scan path (inside ``_render_toeplitz_controls``) and the
+    bulk path (no row selected, scans ticked) — letting a bulk run be tuned
+    without first clicking a scan.
+    """
     # ── Lambda slider (log scale)
     ui.label("Regularization (lambda)").classes(
         "text-xs uppercase opacity-60 tracking-wide"
@@ -1149,17 +1398,80 @@ def _render_toeplitz_controls(
         "Seconds to wait for one channel's solve before skipping it."
     )
 
-    # ── Edge-expansion advisory (library default 0.15 of duration)
-    # estimate_hrf shifts every event onset back by edge_expansion*duration
-    # seconds and silently drops events that would fall before t=0. With
-    # the library default (0.15) and the user's current duration, that
-    # means events in the first ``edge_seconds`` of the scan are lost.
-    edge_seconds = 0.15 * opts.duration
+    # ── Edge expansion (forwarded to estimate_hrf). Each onset is shifted
+    # back by ``edge_expansion * duration`` s so the window captures the
+    # pre-onset baseline; widen it if the estimated HRFs are noisy/unstable
+    # at their edges (the QC check below flags that).
+    ui.label("Edge expansion (fraction of duration)").classes(
+        "text-xs uppercase opacity-60 tracking-wide"
+    )
+
+    def _on_edge_expansion(event) -> None:
+        try:
+            opts.edge_expansion = max(0.0, min(1.0, float(event.value)))
+        except (TypeError, ValueError):
+            opts.edge_expansion = DEFAULT_EDGE_EXPANSION
+
+    ui.number(
+        value=opts.edge_expansion,
+        min=0.0, max=1.0, step=0.05,
+        format="%.2f",
+        on_change=_on_edge_expansion,
+    ).tooltip(
+        "Pads each event's estimation window back by this fraction of the "
+        "duration. Higher = more stable HRF edges, but events in the first "
+        "edge_expansion × duration seconds are dropped."
+    )
+
+    # ── Edge-expansion advisory: estimate_hrf shifts every event onset back
+    # by edge_expansion*duration seconds and silently drops events that would
+    # fall before t=0, so events in the first ``edge_seconds`` are lost.
+    edge_seconds = opts.edge_expansion * opts.duration
     ui.label(
         f"Note: events in the first ~{edge_seconds:.1f} s of the scan are "
-        f"dropped by the toeplitz edge-expansion window (library default "
-        f"0.15 × duration). Consider this when designing trial-onset timing."
+        f"dropped by the toeplitz edge-expansion window "
+        f"({opts.edge_expansion:.2f} × duration). Consider this when "
+        "designing trial-onset timing."
     ).classes("text-xs opacity-60 italic")
+
+    # ── Edge-noise QC sensitivity (drives the post-estimation warning).
+    ui.label("Edge-noise QC sensitivity").classes(
+        "text-xs uppercase opacity-60 tracking-wide"
+    )
+
+    def _on_qc_frac(event) -> None:
+        try:
+            opts.edge_std_frac = max(0.01, min(0.49, float(event.value)))
+        except (TypeError, ValueError):
+            opts.edge_std_frac = DEFAULT_EDGE_STD_FRAC
+
+    def _on_qc_ratio(event) -> None:
+        try:
+            opts.edge_std_ratio = max(1.0, float(event.value))
+        except (TypeError, ValueError):
+            opts.edge_std_ratio = DEFAULT_EDGE_STD_RATIO
+
+    with ui.row().classes("w-full items-center gap-3 no-wrap"):
+        ui.number(
+            "Edge window (frac)",
+            value=opts.edge_std_frac,
+            min=0.01, max=0.49, step=0.05,
+            format="%.2f",
+            on_change=_on_qc_frac,
+        ).props("dense").classes("flex-1").tooltip(
+            "Fraction of the HRF (each end) treated as 'edge' when comparing "
+            "its local noise to the center."
+        )
+        ui.number(
+            "Flag ratio (×)",
+            value=opts.edge_std_ratio,
+            min=1.0, max=10.0, step=0.5,
+            format="%.1f",
+            on_change=_on_qc_ratio,
+        ).props("dense").classes("flex-1").tooltip(
+            "Warn when a channel's edge std exceeds this multiple of its "
+            "center std. Lower = stricter."
+        )
 
 
 def _render_canonical_note() -> None:
@@ -1219,6 +1531,9 @@ def _render_run_row(
             run_label,
             on_click=_on_estimate,
         ).props(f"color=primary {'disable' if not can_run else ''}")
+        # Save sits immediately to the right of Estimate, popping in only once
+        # there's a real montage to save (see _render_save_button).
+        _render_save_button(state, scan, bulk_mode)
         if state.busy:
             _render_busy_progress(state)
         elif (
@@ -1339,6 +1654,7 @@ def _run_bulk(
         duration=opts.duration,
         selected_events=opts.selected_events,
         timeout=opts.timeout,
+        edge_expansion=opts.edge_expansion,
     )
 
     def _build(scan: ScanEntry):
@@ -1375,6 +1691,7 @@ def _run_bulk(
                     duration=snapshot.duration,
                     selected_events=selected,
                     timeout=snapshot.timeout,
+                    edge_expansion=snapshot.edge_expansion,
                 )
                 return run_toeplitz_sync(
                     raw, scan_opts, progress_cb, event_rows, event_impulse
@@ -1461,6 +1778,7 @@ def _run(
         duration=opts.duration,
         selected_events=opts.selected_events,
         timeout=opts.timeout,
+        edge_expansion=opts.edge_expansion,
     )
 
     if snapshot.model == MODEL_TOEPLITZ:
@@ -1559,6 +1877,7 @@ def run_toeplitz_sync(
         events=events.tolist(),
         duration=opts.duration,
         lmbda=opts.lmbda,
+        edge_expansion=opts.edge_expansion,
         preprocess=False,
         progress_callback=progress_callback,
         timeout=opts.timeout,
@@ -1725,7 +2044,89 @@ def _render_hrf_preview(
         ).classes("text-sm opacity-60")
         return
 
+    _render_edge_qc(result, opts)
     _render_toeplitz_gallery(state, result)
+
+
+def _edge_unstable_channels(
+    montage,
+    *,
+    edge_frac: float = DEFAULT_EDGE_STD_FRAC,
+    ratio: float = DEFAULT_EDGE_STD_RATIO,
+) -> list:
+    """Channel names whose HRF TRACE wobbles more at its edges than its center.
+
+    Compares the local standard deviation of the estimated HRF ``trace`` over
+    its outer ``edge_frac`` (each end) to the std of its center. A clean HRF
+    has its response in the center (high local std) and a flat baseline at the
+    edges (low local std), so ``edge_std > ratio × center_std`` flags edges
+    that fluctuate more than the response itself — a sign the estimation
+    window is too tight (raise ``edge_expansion``).
+
+    NB: this reads ``node.trace`` (the estimate itself), NOT ``node.trace_std``
+    — that field is the ACROSS-SUBJECT std and is all-zero for a single-scan
+    estimate, so it can't drive a per-scan QC. Channels without a usable trace,
+    too-short traces, or a flat center (std 0) are skipped. Pure + module-level
+    so tests can call it directly.
+    """
+    import numpy as np
+
+    flagged: list = []
+    channels = getattr(montage, "channels", {})
+    for ch_name, node in channels.items():
+        if "global" in str(ch_name):
+            continue
+        trace = getattr(node, "trace", None)
+        if trace is None:
+            continue
+        arr = np.asarray(trace, dtype=float)
+        n = arr.size
+        if n < 6 or not np.all(np.isfinite(arr)):
+            continue
+        k = max(1, int(round(n * edge_frac)))
+        if n <= 2 * k:
+            continue
+        edge_std = float(np.std(np.concatenate([arr[:k], arr[-k:]])))
+        center_std = float(np.std(arr[k:-k]))
+        if center_std > 0 and edge_std > ratio * center_std:
+            flagged.append(ch_name)
+    return flagged
+
+
+def _render_edge_qc(montage, opts: EstimationOptions) -> None:
+    """Warn when estimated HRFs fluctuate more at their edges than their center.
+
+    Surfaces an amber callout (with the offending channels) suggesting a larger
+    edge_expansion when enough channels trip the configurable edge-noise ratio.
+    """
+    flagged = _edge_unstable_channels(
+        montage,
+        edge_frac=opts.edge_std_frac,
+        ratio=opts.edge_std_ratio,
+    )
+    if not flagged:
+        return
+    n = len(flagged)
+    preview = ", ".join(str(c) for c in flagged[:6])
+    if n > 6:
+        preview += f", +{n - 6} more"
+    with ui.row().classes(
+        "w-full items-start gap-2 p-3 rounded border "
+        "border-amber-500/40 bg-amber-500/10"
+    ):
+        ui.icon("warning", size="1.25rem").classes("text-amber-400 shrink-0")
+        with ui.column().classes("gap-0"):
+            ui.label(
+                f"{n} channel{'s' if n != 1 else ''} fluctuate more at the "
+                f"edges than the center (edge std > {opts.edge_std_ratio:g}× "
+                "center)."
+            ).classes("text-sm font-medium text-amber-300")
+            ui.label(
+                f"This often means the estimation window is too tight — try "
+                f"raising Edge expansion (currently {opts.edge_expansion:.2f}) "
+                "and re-estimating."
+            ).classes("text-xs opacity-70")
+            ui.label(preview).classes("text-xs font-mono opacity-50")
 
 
 def _render_toeplitz_gallery(state: AppState, montage) -> None:
@@ -1747,9 +2148,38 @@ def _render_toeplitz_gallery(state: AppState, montage) -> None:
         "open a channel to view its estimated response."
     ).classes("text-xs opacity-60")
 
+    # Explain the absent ±std band so it's not read as a bug: trace_std is the
+    # ACROSS-SUBJECT std (needs ≥2 pooled estimates), so a single-scan estimate
+    # has none. Only shown when every channel's std is empty/zero.
+    if _std_is_all_zero(montage):
+        ui.label(
+            "No ±std band shown — the band is across-subject variance, which "
+            "needs ≥2 pooled estimates; a single-scan estimate has none. Pool "
+            "scans or use the HRtree library to get a variability band."
+        ).classes("text-xs opacity-50 italic")
+
     with ui.column().classes("w-full gap-1 max-w-2xl"):
         for index, (ch_name, node) in enumerate(channels.items()):
             _render_channel_dropdown(node, ch_name, open_default=(index == 0))
+
+
+def _std_is_all_zero(montage) -> bool:
+    """True when every channel's ``trace_std`` is empty / all-zero.
+
+    That's the single-scan case: ``trace_std`` is the across-subject std
+    (``np.std`` over the per-subject estimates), so one estimate yields zeros.
+    Used to caption the preview rather than leave an invisible band unexplained.
+    """
+    import numpy as np
+
+    for node in getattr(montage, "channels", {}).values():
+        std = getattr(node, "trace_std", None)
+        if std is None:
+            continue
+        arr = np.asarray(std, dtype=float)
+        if arr.size and np.any(np.isfinite(arr) & (np.abs(arr) > 0)):
+            return False
+    return True
 
 
 def _render_channel_dropdown(node, ch_name: str, open_default: bool) -> None:

--- a/src/hrfunc/gui/components/hrtree_match.py
+++ b/src/hrfunc/gui/components/hrtree_match.py
@@ -1,0 +1,269 @@
+"""Match a scan's channels to HRtree HRFs for per-channel deconvolution.
+
+The Activity tab's "HRtree HRF" source can deconvolve each channel with its
+OWN spatially-matched HRF (instead of one shared kernel) using the ROIs the
+user built in the HRtree. This module does the matching and reports coverage
+so the UI can show how many channels are covered vs. uncovered.
+
+Both the scan's channel locations (read straight from ``raw.info['chs']``)
+and the HRtree HRF locations are in **MNE head coordinates (meters)**, so the
+nearest-neighbour match is a plain Euclidean distance in meters — no MNI
+alignment needed (that only matters for atlas lookups). Matching is
+oxygenation-respecting: HbO channels match only HbO HRFs, HbR only HbR, so
+the matched trace is used as-given (no sign flip).
+
+Two strategies (user-selectable):
+- ``"individual"`` — each channel takes the single nearest member HRF across
+  all visible ROIs.
+- ``"roi_mean"`` — each channel takes the mean trace of the nearest visible
+  ROI (ROI location = the head-coords centroid of its member HRFs, so this is
+  also alignment-free).
+
+Channels with no same-oxygenation candidate within ``radius_mm`` are
+"uncovered" and reported; the caller decides whether to skip or canonical-fill
+them (``estimate_activity(library_uncovered=...)``).
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Tuple
+
+import numpy as np
+
+from ..state import AppState
+
+STRATEGY_INDIVIDUAL = "individual"
+STRATEGY_ROI_MEAN = "roi_mean"
+
+
+@dataclass
+class ChannelMatch:
+    """One scan channel's match outcome."""
+
+    ch_name: str  # standardized name (matches estimate_activity's channel keys)
+    oxygenation: bool  # True = HbO, False = HbR
+    matched: bool
+    trace: Optional[List[float]] = None  # the kernel for this channel, or None
+    source: Optional[str] = None  # which HRF key / ROI name supplied the trace
+    distance_mm: Optional[float] = None
+
+
+@dataclass
+class MatchResult:
+    """Per-channel matching outcome + headline counts for the UI."""
+
+    matches: List[ChannelMatch] = field(default_factory=list)
+    n_candidate_hrfs: int = 0  # HRFs available across visible ROIs
+    n_rois: int = 0  # visible ROIs that contributed candidates
+    strategy: str = STRATEGY_INDIVIDUAL
+    radius_mm: float = 20.0
+
+    @property
+    def covered(self) -> List[ChannelMatch]:
+        return [m for m in self.matches if m.matched]
+
+    @property
+    def uncovered(self) -> List[ChannelMatch]:
+        return [m for m in self.matches if not m.matched]
+
+    def library_traces(self) -> Dict[str, List[float]]:
+        """The ``{ch_name: trace}`` map for ``estimate_activity(library_traces=...)``."""
+        return {
+            m.ch_name: m.trace
+            for m in self.matches
+            if m.matched and m.trace
+        }
+
+
+# Internal candidate: (label, oxygenation, location_m (3,), trace list)
+_Candidate = Tuple[str, bool, "np.ndarray", List[float]]
+
+
+def _channel_geometry(raw) -> List[Tuple[str, bool, "np.ndarray"]]:
+    """Read (standardized_name, oxygenation, location_m) for each fNIRS channel.
+
+    Channels whose name can't be parsed for oxygenation, or that carry no
+    usable location (all-zero / non-finite ``loc``), are skipped — they can't
+    be matched spatially and would otherwise masquerade as covered.
+    """
+    from ..._utils import _is_oxygenated, standardize_name
+
+    out: List[Tuple[str, bool, np.ndarray]] = []
+    for ch in raw.info["chs"]:
+        raw_name = ch.get("ch_name", "")
+        try:
+            std = standardize_name(raw_name)
+            oxy = _is_oxygenated(std)
+        except Exception:  # noqa: BLE001 — non-fNIRS / unparsable name
+            continue
+        loc = np.asarray(ch.get("loc", [])[:3], dtype=float)
+        if loc.shape != (3,) or not np.all(np.isfinite(loc)) or np.allclose(loc, 0.0):
+            # No usable location -> can't match; record as uncovered geometry.
+            out.append((std, oxy, None))
+            continue
+        out.append((std, oxy, loc))
+    return out
+
+
+def _hrf_loc_trace(hrf: Dict[str, Any]) -> Optional[Tuple["np.ndarray", List[float], bool]]:
+    """Pull (location_m, trace, oxygenation) from a gathered HRF dict, or None."""
+    loc = hrf.get("location")
+    trace = hrf.get("hrf_mean")
+    if not loc or len(loc) < 3 or trace is None or len(trace) == 0:
+        return None
+    arr = np.asarray(loc[:3], dtype=float)
+    if not np.all(np.isfinite(arr)):
+        return None
+    return arr, list(trace), bool(hrf.get("oxygenation"))
+
+
+def _individual_candidates(
+    state: AppState, all_hrfs: Dict[str, Dict[str, Any]]
+) -> Tuple[List[_Candidate], int]:
+    """Each member HRF across visible ROIs becomes a candidate."""
+    from .hrtree_panel import _visible_roi_keys
+
+    union_keys, pairs = _visible_roi_keys(state, all_hrfs)
+    candidates: List[_Candidate] = []
+    for key in union_keys:
+        hrf = all_hrfs.get(key)
+        if hrf is None:
+            continue
+        parsed = _hrf_loc_trace(hrf)
+        if parsed is None:
+            continue
+        loc, trace, oxy = parsed
+        candidates.append((key, oxy, loc, trace))
+    return candidates, len(pairs)
+
+
+def _roi_mean_candidates(
+    state: AppState, all_hrfs: Dict[str, Dict[str, Any]]
+) -> Tuple[List[_Candidate], int]:
+    """Each visible ROI becomes one candidate at its member-centroid (head
+    coords), carrying the ROI's mean trace."""
+    from .hrtree_panel import (
+        _alignment_for_shape,
+        _visible_shapes,
+        compute_roi_average,
+        compute_roi_keys_by_shape,
+    )
+
+    pairs = _visible_shapes(state)
+    candidates: List[_Candidate] = []
+    contributing = 0
+    for slot, shape in pairs:
+        anchor = slot.anchor
+        alignment = _alignment_for_shape(state, shape)
+        roi_contributed = False
+        # Oxygenation-pure: build a SEPARATE mean per haemoglobin so an ROI
+        # spanning both never averages HbO and HbR together (they're inverses
+        # — pooling them cancels the response). A channel then matches only the
+        # same-oxygenation ROI candidate, mirroring the individual strategy's
+        # hard same-oxygenation rule. Oxygenations absent from the (already
+        # filtered) set yield empty keys and are skipped.
+        for oxy in (True, False):
+            keys = compute_roi_keys_by_shape(
+                all_hrfs, shape, slot.painted,
+                oxygenation_filter=oxy,
+                alignment_affine=alignment,
+            )
+            locs = []
+            for key in keys:
+                hrf = all_hrfs.get(key)
+                if hrf is None:
+                    continue
+                parsed = _hrf_loc_trace(hrf)
+                if parsed is not None:
+                    locs.append(parsed[0])
+            if not locs:
+                continue
+            centroid = np.mean(np.vstack(locs), axis=0)
+            # ROI kernel: prefer the subject-weighted grand mean; fall back to
+            # the anchor's own trace ONLY when it matches this oxygenation, so
+            # the fallback never crosses haemoglobins.
+            avg = compute_roi_average(all_hrfs, keys)
+            if avg is not None:
+                trace = list(np.asarray(avg[0], dtype=float))
+            elif (
+                anchor is not None
+                and anchor.get("hrf_mean")
+                and bool(anchor.get("oxygenation")) == oxy
+            ):
+                trace = list(anchor["hrf_mean"])
+            else:
+                continue
+            label = f"{slot.name} ({'HbO' if oxy else 'HbR'})"
+            candidates.append((label, oxy, centroid, trace))
+            roi_contributed = True
+        if roi_contributed:
+            contributing += 1
+    return candidates, contributing
+
+
+def match_channels_to_hrtree(
+    state: AppState,
+    raw,
+    *,
+    strategy: str = STRATEGY_INDIVIDUAL,
+    radius_mm: float = 20.0,
+) -> MatchResult:
+    """Match each scan channel to an HRtree HRF from the user's ROIs.
+
+    :param raw: the (preprocessed) MNE Raw whose channels to match.
+    :param strategy: ``"individual"`` (nearest member HRF) or ``"roi_mean"``
+        (nearest ROI's mean trace).
+    :param radius_mm: max match distance; channels with no same-oxygenation
+        candidate within this radius are uncovered.
+    """
+    from .hrtree_panel import (
+        apply_filter,
+        filter_by_oxygenation,
+        gather_library_hrfs,
+    )
+
+    # Use the SAME filtered HRF set the Cluster view operates on, so the
+    # context filters (task / doi / demographics …) and the HbO/HbR/Both
+    # oxygenation choice scope the deconvolution candidates exactly as they
+    # scope what the user sees — Filter and Cluster stay complementary.
+    all_hrfs = filter_by_oxygenation(
+        apply_filter(gather_library_hrfs(state), state.library_filter),
+        state.library_oxygenation,
+    )
+    if strategy == STRATEGY_ROI_MEAN:
+        candidates, n_rois = _roi_mean_candidates(state, all_hrfs)
+    else:
+        strategy = STRATEGY_INDIVIDUAL
+        candidates, n_rois = _individual_candidates(state, all_hrfs)
+
+    radius_m = float(radius_mm) / 1000.0
+    geom = _channel_geometry(raw)
+    matches: List[ChannelMatch] = []
+    for ch_name, oxy, loc in geom:
+        if loc is None:
+            matches.append(ChannelMatch(ch_name, oxy, matched=False))
+            continue
+        # Restrict to same-oxygenation candidates so the trace applies as-given.
+        pool = [c for c in candidates if c[1] == oxy]
+        best = None
+        best_dist = None
+        for label, _c_oxy, c_loc, trace in pool:
+            dist = float(np.linalg.norm(loc - c_loc))
+            if best_dist is None or dist < best_dist:
+                best_dist, best = dist, (label, trace)
+        if best is not None and best_dist is not None and best_dist <= radius_m:
+            label, trace = best
+            matches.append(ChannelMatch(
+                ch_name, oxy, matched=True, trace=trace, source=label,
+                distance_mm=best_dist * 1000.0,
+            ))
+        else:
+            matches.append(ChannelMatch(ch_name, oxy, matched=False))
+
+    return MatchResult(
+        matches=matches,
+        n_candidate_hrfs=len(candidates),
+        n_rois=n_rois,
+        strategy=strategy,
+        radius_mm=float(radius_mm),
+    )

--- a/src/hrfunc/gui/components/hrtree_panel.py
+++ b/src/hrfunc/gui/components/hrtree_panel.py
@@ -483,7 +483,7 @@ def _ensure_shift_tracker_injected() -> None:
     _PAINT_HOOK_HEAD_INJECTED = True
 
 
-def _install_paint_hook(plot_id: int) -> None:
+def _install_paint_hook(plot_id: int, anchor=None) -> None:
     """Hook the freshly-rendered plotly element's ``plotly_hover`` event.
 
     Plotly's native hover event includes the points data; what we need
@@ -493,7 +493,11 @@ def _install_paint_hook(plot_id: int) -> None:
     handler via the element's ``$emit``.
 
     A small ``ui.timer`` delay gives plotly's render cycle time to attach
-    the underlying div to the DOM before we query it.
+    the underlying div to the DOM before we query it. The timer is parked on
+    ``anchor`` (a stable element OUTSIDE the refreshable viz body) when given,
+    so a rapid ``_viz_body.refresh()`` — e.g. the user clicking through HRFs
+    faster than 0.5 s — can't delete the slot the pending timer lives in and
+    crash it with "parent slot of the element has been deleted".
     """
     _ensure_shift_tracker_injected()
 
@@ -511,7 +515,12 @@ if (el && el.on && !el._hrfPaintHooked) {{
 }}
 """
 
-    ui.timer(0.5, lambda: ui.run_javascript(js), once=True)
+    cb = lambda: ui.run_javascript(js)  # noqa: E731
+    if anchor is not None and not anchor.is_deleted:
+        with anchor:
+            ui.timer(0.5, cb, once=True)
+    else:
+        ui.timer(0.5, cb, once=True)
 
 
 # ---------------------------------------------------------------------------
@@ -561,6 +570,31 @@ SUBTAB_CLUSTER = "Cluster"
 SUBTAB_NAMES = (SUBTAB_FILTER, SUBTAB_CLUSTER)
 
 
+def _render_oxygenation_radio(state: AppState) -> None:
+    """HbO / HbR / Both oxygenation filter.
+
+    Rendered above the Filter / Cluster sub-tabs (not inside Filter) so it
+    applies to BOTH sub-tabs and stays changeable while viewing either. It
+    publishes ``hrtree_filter_changed`` so the viz, detail pane, ROI
+    membership, and per-channel deconvolution matching all re-scope to the
+    chosen oxygenation.
+    """
+
+    def _on_change(event) -> None:
+        state.library_oxygenation = event.value or "both"
+        state.publish("hrtree_filter_changed", state.library_filter)
+
+    with ui.row().classes("items-center gap-2 w-full"):
+        ui.label("Oxygenation").classes(
+            "text-xs uppercase opacity-60 tracking-wide"
+        )
+        ui.radio(
+            {"both": "Both", "hbo": "HbO only", "hbr": "HbR only"},
+            value=state.library_oxygenation,
+            on_change=_on_change,
+        ).props("inline dense")
+
+
 def _render_left_pane(state: AppState) -> None:
     """Wordmark + sub-tabs at the top, active sub-tab content below.
 
@@ -577,6 +611,12 @@ def _render_left_pane(state: AppState) -> None:
         ui.label(
             "3D spatial database of literature HRFs."
         ).classes("text-xs opacity-60")
+
+        # Oxygenation filter sits ABOVE the sub-tabs so it applies to both
+        # Filter and Cluster and stays changeable on either — it scopes
+        # everything downstream (visible HRFs, ROI membership, per-channel
+        # deconvolution matching), not just the Filter sub-tab.
+        _render_oxygenation_radio(state)
 
         # Sub-tabs.
         with ui.tabs().props("dense").classes("w-full") as subtabs:
@@ -614,20 +654,9 @@ def _render_filter_subtab(state: AppState) -> None:
     filtered. "Apply" then refreshes the dependent viz + detail panes.
     """
     with ui.column().classes("w-full gap-3"):
-        # -- Oxygenation radio (frequently toggled, top placement)
-
-        def _on_oxygenation_change(event) -> None:
-            state.library_oxygenation = event.value or "both"
-            state.publish("hrtree_filter_changed", state.library_filter)
-
-        ui.radio(
-            {"both": "Both", "hbo": "HbO only", "hbr": "HbR only"},
-            value=state.library_oxygenation,
-            on_change=_on_oxygenation_change,
-        ).props("inline dense")
-
-        # ── Context inputs (set-once / refine-slowly)
-        ui.separator()
+        # ── Context inputs (set-once / refine-slowly). The oxygenation radio
+        # moved up to the left pane (above the sub-tabs) so it applies to both
+        # Filter and Cluster.
         inputs: Dict[str, Any] = {}
         for field in FILTER_FIELDS:
             initial = str(state.library_filter.get(field, ""))
@@ -1847,6 +1876,14 @@ def _render_viz_pane(state: AppState) -> None:
     after the first call so the body fills the available height.
     """
 
+    # Stable, zero-footprint anchor for deferred ``once=True`` timers (the
+    # plotly resize hook + the on-selection viz re-centre). It lives OUTSIDE
+    # ``_viz_body`` so a ``_viz_body.refresh()`` can't delete the slot a
+    # pending timer is parented to — which is what raised "parent slot of the
+    # element has been deleted" when clicking through HRFs quickly.
+    _deferred_anchor = ui.element("div").style("display:none")
+    _pending_viz_timer: dict = {"timer": None}
+
     @ui.refreshable
     def _viz_body() -> None:
         all_hrfs = gather_library_hrfs(state)
@@ -1970,7 +2007,7 @@ def _render_viz_pane(state: AppState) -> None:
             # plotly element has rendered. Slight delay so the
             # underlying div is queryable in the DOM. once=True so
             # the hook isn't registered repeatedly on each refresh.
-            _install_paint_hook(plot.id)
+            _install_paint_hook(plot.id, _deferred_anchor)
 
             # MNI overlay toggles under the viz — they control what's
             # rendered above (brain mesh, scalp mesh), so visual
@@ -2054,9 +2091,22 @@ def _render_viz_pane(state: AppState) -> None:
         # pane (which refreshes later in the same ``publish``) then wouldn't
         # repaint until the user's NEXT interaction (e.g. toggling a switch).
         # Deferring lets the click event finish and flush first, then we
-        # rebuild the viz to re-centre the ROI shape overlay on the new
-        # anchor. once=True so the timer cleans itself up after firing.
-        ui.timer(0.05, _refresh_viz, once=True)
+        # rebuild the viz to re-centre the ROI shape overlay on the new anchor.
+        #
+        # Cancel any still-pending deferred refresh first: clicking through
+        # HRFs faster than 0.05 s would otherwise stack timers, and a fired
+        # one's ``_viz_body.refresh()`` could delete a sibling timer's slot
+        # mid-flight. The timer is parked on the stable ``_deferred_anchor``
+        # (not the refreshable body) so it survives the rebuild it triggers.
+        prev = _pending_viz_timer["timer"]
+        if prev is not None and not prev.is_deleted:
+            prev.cancel()
+        if _deferred_anchor.is_deleted:
+            return
+        with _deferred_anchor:
+            _pending_viz_timer["timer"] = ui.timer(
+                0.05, _refresh_viz, once=True
+            )
 
     state.subscribe("hrtree_filter_changed", _refresh_viz)
     # Selection comes from a plotly click inside this body, so defer (above).
@@ -2097,6 +2147,11 @@ def _render_detail_pane(state: AppState) -> None:
             ui.label("Detail").classes(
                 "text-xs uppercase opacity-60 tracking-wide"
             )
+            # When an ROI is the current selection, lead with the ROI's
+            # aggregate HRF (its averaged trace) instead of a single anchor
+            # HRF — that's the thing the user picked.
+            if _showing_active_roi(state) and _render_active_roi_detail(state):
+                return
             if hrf is None:
                 ui.label("Click an HRF in the viz to inspect.").classes(
                     "text-sm opacity-60"
@@ -2164,6 +2219,80 @@ def _render_detail_pane(state: AppState) -> None:
     # viz already listens there; the detail pane needs to refresh too
     # so the ROI-average plot updates when the user widens the radius.
     state.subscribe("hrtree_filter_changed", _refresh_detail)
+
+
+def _showing_active_roi(state: AppState) -> bool:
+    """True when the detail pane should lead with the active ROI's HRF.
+
+    The user "selected an ROI" (vs. clicking a lone HRF) when the current
+    selection IS that ROI's own anchor object — selecting a slot re-seeds
+    ``library_selected_hrf = active.anchor`` (same identity). An anchorless
+    shape ROI selects with ``library_selected_hrf = None`` while still having
+    members, so a ``None`` selection with an active ROI also counts. Clicking
+    a different individual HRF makes a fresh dict, so identity differs and the
+    single-HRF detail shows instead.
+    """
+    active = state.active_roi
+    if active is None:
+        return False
+    sel = state.library_selected_hrf
+    return sel is None or sel is active.anchor
+
+
+def _render_active_roi_detail(state: AppState) -> bool:
+    """Render the active ROI's aggregate HRF as the primary detail.
+
+    Returns True when it rendered (the ROI has an averageable HRF), False when
+    there's nothing to show — the caller then falls back to the single-HRF
+    detail. Mirrors :func:`_render_roi_average`'s membership computation but
+    leads with ROI-level metadata (name, member/pool counts) instead of a
+    single optode's location/context.
+    """
+    active = state.active_roi
+    if active is None:
+        return False
+    all_hrfs = gather_library_hrfs(state)
+    matched = filter_by_oxygenation(
+        apply_filter(all_hrfs, state.library_filter),
+        state.library_oxygenation,
+    )
+    shape = _build_current_shape(state)
+    oxy_filter = _resolve_cluster_oxygenation(state)
+    alignment = _alignment_for_shape(state, shape)
+    roi_keys = compute_roi_keys_by_shape(
+        matched, shape, state.library_roi_painted,
+        oxygenation_filter=oxy_filter,
+        alignment_affine=alignment,
+    )
+    result = compute_roi_average(matched, roi_keys)
+    if result is None:
+        return False
+    mean, std, n_subjects, n_channels = result
+    anchor = state.library_selected_hrf
+    sfreq = _resolve_roi_sfreq(anchor, matched, roi_keys)
+
+    name = getattr(active, "name", None) or "ROI"
+    ui.label(name).classes("text-lg font-mono break-all")
+    if oxy_filter is True:
+        oxy_text = "HbO"
+    elif oxy_filter is False:
+        oxy_text = "HbR"
+    else:
+        oxy_text = "HbO + HbR"
+    _kv("oxygenation", oxy_text)
+    _kv("members", f"{len(roi_keys)} HRF{'s' if len(roi_keys) != 1 else ''}")
+    _kv("pooled", f"{n_subjects} subjects · {n_channels} channels")
+    if isinstance(anchor, dict) and anchor.get("_key"):
+        _kv("anchored on", anchor["_key"])
+
+    ui.separator()
+    ui.label("ROI HRF (averaged trace)").classes(
+        "text-xs uppercase opacity-60 tracking-wide"
+    )
+    png = _render_roi_average_png(mean, std, sfreq, n_subjects)
+    if png is not None:
+        ui.image(png).classes("max-w-md shrink-0")
+    return True
 
 
 def _render_roi_average(state: AppState) -> None:

--- a/src/hrfunc/gui/components/preprocess_panel.py
+++ b/src/hrfunc/gui/components/preprocess_panel.py
@@ -167,6 +167,109 @@ def ensure_deconvolved_raw(state: AppState, scan):
     return result
 
 
+def scan_is_deconvolved(state: AppState, scan: ScanEntry) -> bool:
+    """True when ``scan`` has a deconvolution-preprocessed Raw cached.
+
+    The same readiness gate HRF / activity estimation use: present in
+    ``processed_cache`` AND recorded in ``processed_deconvolved`` (a
+    GLM/haemoglobin preprocess does not count). Shared so the HRFs and
+    Activity tabs report bulk readiness consistently.
+    """
+    return (
+        scan in state.processed_cache
+        and scan.path.resolve() in state.processed_deconvolved
+    )
+
+
+def preprocess_all_checked(state: AppState, scans: list) -> None:
+    """Deconvolution-preprocess every not-yet-ready scan in ``scans`` as one
+    background batch — the bulk analog of the HRFs tab's single-scan
+    "Preprocess now".
+
+    Reuses ``ensure_deconvolved_raw`` via ``run_bulk_in_background`` so the
+    busy gate, per-scan progress, and continue-on-error semantics match the
+    bulk estimate flows. Already-deconvolved scans are filtered out so the
+    toast counts reflect real work. Shared by the HRFs and Activity tabs.
+    """
+    if state.busy:
+        return
+    targets = [s for s in scans if not scan_is_deconvolved(state, s)]
+    if not targets:
+        ui.notify("All checked scans are already preprocessed.", type="info")
+        return
+
+    def _build(scan: ScanEntry):
+        # ensure_deconvolved_raw loads + deconvolution-preprocesses + caches +
+        # records processed_deconvolved itself, raising with a specific reason
+        # on failure; the worker turns that into a per-scan failure.
+        return (ensure_deconvolved_raw, (state, scan), {})
+
+    async def _on_each(scan: ScanEntry, _result) -> None:
+        state.publish("preprocess_done", scan)
+
+    async def _run() -> None:
+        result = await run_bulk_in_background(
+            state, targets, _build,
+            on_each_done=_on_each, label="bulk preprocess",
+        )
+        if result is None:
+            return
+        successes, failures = result
+        if failures:
+            ui.notify(
+                f"Preprocessed {len(successes)} scan(s); "
+                f"{len(failures)} failed — see the latest error.",
+                type="warning",
+            )
+        else:
+            ui.notify(
+                f"Preprocessed {len(successes)} scan(s).", type="positive"
+            )
+
+    ui.notify("Preprocessing checked scans…", type="info")
+    background_tasks.create(_run())
+
+
+def render_preprocess_all_checked(state: AppState, scans: list) -> None:
+    """Bulk preprocess affordance: readiness summary + one-click run.
+
+    Mirrors the HRFs tab's single-scan "Preprocess now" for the checked set.
+    The bulk estimate already preprocesses each scan on demand, so this is a
+    convenience / pre-warm plus a clear readiness readout — not a
+    prerequisite. Shared by the HRFs and Activity tabs.
+    """
+    if state.busy:
+        with ui.row().classes("items-center gap-2"):
+            ui.spinner(size="sm")
+            ui.label("Preprocessing…").classes("text-sm opacity-70")
+        return
+
+    n_total = len(scans)
+    not_ready = [s for s in scans if not scan_is_deconvolved(state, s)]
+    plural = "s" if n_total != 1 else ""
+    if not not_ready:
+        ui.label(
+            f"All {n_total} checked scan{plural} are deconvolution-"
+            "preprocessed and ready."
+        ).classes("text-sm text-emerald-400")
+        return
+
+    ui.label(
+        f"{len(not_ready)} of {n_total} checked scan{plural} aren't "
+        "deconvolution-preprocessed yet. The bulk run preprocesses each scan "
+        "automatically — or preprocess them all now."
+    ).classes("text-sm opacity-70")
+    with ui.row().classes("items-center gap-2"):
+        ui.button(
+            "Preprocess all checked",
+            icon="play_arrow",
+            on_click=lambda: preprocess_all_checked(state, scans),
+        ).props("color=primary")
+        ui.label(
+            "Uses default settings — for custom options use the Preprocess tab."
+        ).classes("text-xs opacity-60")
+
+
 def _resolve_checked_scans(state: AppState) -> list:
     """Resolve ``state.checked_scan_paths`` to ScanEntries in manifest order.
 

--- a/src/hrfunc/gui/pages/shell.py
+++ b/src/hrfunc/gui/pages/shell.py
@@ -383,6 +383,27 @@ def _render_data_tab(
     state.subscribe("project_changed", lambda _m=None: _body.refresh())
 
 
+def _demo_data_path() -> Optional[Path]:
+    """Resolve the bundled sample SNIRF folder for the 'Demo data' button.
+
+    Walks up from the ``hrfunc`` package to the repo root and looks for
+    ``tests/data/sNIRF_formatted``. Returns None when it's absent (e.g. an
+    installed wheel that doesn't ship the test data) so the button hides
+    rather than pointing at nothing.
+    """
+    try:
+        import hrfunc
+
+        pkg = Path(hrfunc.__file__).resolve().parent  # …/src/hrfunc
+        # src/hrfunc → src → repo root
+        candidate = pkg.parents[1] / "tests" / "data" / "sNIRF_formatted"
+        if candidate.is_dir() and any(candidate.glob("*.snirf")):
+            return candidate
+    except Exception as exc:  # noqa: BLE001 — best-effort; hide on any failure
+        logger.debug("demo data path unavailable: %s", exc)
+    return None
+
+
 def _render_empty_state(state: AppState, *, verb: str) -> None:
     """Render the centered no-project prompt for a data-dependent tab.
 
@@ -429,6 +450,32 @@ def _render_empty_state(state: AppState, *, verb: str) -> None:
             icon="folder_open",
             on_click=_on_click,
         ).props("color=primary")
+
+        # Demo data: one-click load of the bundled sample SNIRF scans so a
+        # first-time user can explore the app without their own data. Only
+        # shown when the test data is actually present (a source checkout);
+        # an installed wheel that doesn't ship tests/ hides it.
+        demo_path = _demo_data_path()
+        if demo_path is not None:
+            async def _on_demo() -> None:
+                if state.busy:
+                    ui.notify(
+                        "A task is still running — wait for it to finish "
+                        "before loading the demo data.",
+                        type="warning",
+                    )
+                    return
+                await dataset_picker.open_project_path(state, demo_path)
+
+            ui.button(
+                "Try the rock-paper-scissors demo",
+                icon="science",
+                on_click=_on_demo,
+            ).props("flat color=primary")
+            ui.label(
+                "Loads a bundled rock-paper-scissors fNIRS dataset (the events "
+                "are rock / paper / scissors trials) to explore the app."
+            ).classes("text-xs opacity-50")
 
 
 def _on_scan_selected(state: AppState, scan: Optional[ScanEntry]) -> None:

--- a/src/hrfunc/gui/state.py
+++ b/src/hrfunc/gui/state.py
@@ -303,6 +303,11 @@ class AppState:
     # subjects exist, so a single-subject project still shows that scan's HRFs.
     project_montage: Optional[Any] = None
     hrf_preview_group: bool = True
+    # Resolved scan paths the user has excluded from the group montage (the
+    # in-session "remove subject" control). Filtered out of the pool when the
+    # group montage is rebuilt; kept separate from ``montage_cache`` so the
+    # per-scan HRFs stay available for single-scan / Activity use.
+    project_group_excluded: Set[Path] = field(default_factory=set)
     # When True, the Activity tab's toeplitz source deconvolves EVERY scan with
     # the pooled ``project_montage`` (group HRFs, matched by channel name)
     # instead of each scan's own estimated HRFs. Lets a user apply a group HRF
@@ -842,6 +847,7 @@ class AppState:
         self.montage_cache.clear()
         self.project_montage = None
         self.hrf_preview_group = True
+        self.project_group_excluded.clear()
         self.activity_use_group_hrfs = False
         self.preload_path = None
         self.busy = False

--- a/src/hrfunc/gui/state.py
+++ b/src/hrfunc/gui/state.py
@@ -292,6 +292,22 @@ class AppState:
     # OWN HRFs (single + bulk) instead of erroring "HRFs belong to another
     # scan". Only real per-channel Montages are stored (never _CanonicalResult).
     montage_cache: Dict[Path, Any] = field(default_factory=dict)
+    # Project-wide GROUP montage: the per-scan montages in ``montage_cache``
+    # pooled into one so each channel holds EVERY contributing subject's
+    # estimate, then re-distributed so ``trace_std`` is the genuine BETWEEN-
+    # subject std (a single scan's montage has one estimate → std 0). Rebuilt
+    # whenever a scan is (re)estimated; None until ≥1 scan has HRFs. The HRFs
+    # tab can preview this group HRF + variability band. ``hrf_preview_group``
+    # toggles the preview between the selected scan and this group view, and
+    # defaults to the GROUP view — but the group branch only renders once ≥2
+    # subjects exist, so a single-subject project still shows that scan's HRFs.
+    project_montage: Optional[Any] = None
+    hrf_preview_group: bool = True
+    # When True, the Activity tab's toeplitz source deconvolves EVERY scan with
+    # the pooled ``project_montage`` (group HRFs, matched by channel name)
+    # instead of each scan's own estimated HRFs. Lets a user apply a group HRF
+    # to scans that weren't individually estimated.
+    activity_use_group_hrfs: bool = False
     # Deconvolved Raw from the most recent estimate_activity call (Sprint 3.4).
     # Typed Any for the same import-graph reason. The Activity panel reads
     # the data + annotations for the lens-style preproc/deconv overlay plot.
@@ -824,6 +840,9 @@ class AppState:
         self.processed_cache.clear()
         self.activity_cache.clear()
         self.montage_cache.clear()
+        self.project_montage = None
+        self.hrf_preview_group = True
+        self.activity_use_group_hrfs = False
         self.preload_path = None
         self.busy = False
         self.estimation_progress = None

--- a/src/hrfunc/hrfunc.py
+++ b/src/hrfunc/hrfunc.py
@@ -108,6 +108,7 @@ def load_montage(json_filename, rich = False, **kwargs):
             if rich == False:
                 channel['estimates'] = []
                 channel['locations'] = []
+                channel['estimate_sources'] = []
             else:
                 for field in ('estimates', 'locations'):
                     if field not in channel:
@@ -115,6 +116,10 @@ def load_montage(json_filename, rich = False, **kwargs):
                             f"entry {key!r} is missing required field "
                             f"{field!r} (rich=True)"
                         )
+                # Provenance is optional for back-compat: bundled HRFs and
+                # saves made before it existed have no estimate_sources. HRF
+                # pads to align with estimates.
+                channel.setdefault('estimate_sources', [])
 
             # Create an HRF node from the saved channel. We must pass
             # channel['context'] through — pre-fix this was omitted, so
@@ -136,6 +141,7 @@ def load_montage(json_filename, rich = False, **kwargs):
                 channel['estimates'],
                 channel['locations'],
                 channel['context'],
+                estimate_sources=channel['estimate_sources'],
             )
 
             # Insert hrf into tree and attach pointer to channel. Populate
@@ -325,7 +331,7 @@ class montage(tree):
         
         return estimate
 
-    def estimate_hrf(self, nirx_obj, events, duration = 30.0, lmbda = 1e-3, edge_expansion = 0.15, preprocess = True, progress_callback = None, timeout = 30):
+    def estimate_hrf(self, nirx_obj, events, duration = 30.0, lmbda = 1e-3, edge_expansion = 0.15, preprocess = True, progress_callback = None, timeout = 30, source_id = None):
         """
         Estimate an HRF subject wise given a nirx object and event impulse series using toeplitz
         deconvolution with regularization.
@@ -456,10 +462,27 @@ class montage(tree):
 
             # Append estimate to channel estimates
             optode = self.channels[standardize_name(channel['ch_name'])]
+            # Provenance: keep estimate_sources parallel to estimates and, when
+            # a source_id is given, REPLACE that source's prior estimate so
+            # re-estimating the same subject doesn't double-count it.
+            if not hasattr(optode, 'estimate_sources'):
+                optode.estimate_sources = []
+            while len(optode.estimate_sources) < len(optode.estimates):
+                optode.estimate_sources.append(None)
+            if source_id is not None:
+                for idx in reversed([
+                    i for i, s in enumerate(optode.estimate_sources)
+                    if s == source_id
+                ]):
+                    del optode.estimates[idx]
+                    if idx < len(optode.locations):
+                        del optode.locations[idx]
+                    del optode.estimate_sources[idx]
             optode.estimates.append(list(hrf_estimate))
 
             # Calculate new centroid for optode given locations used for estimate
             optode.locations.append(list(channel['loc'][:3]))
+            optode.estimate_sources.append(source_id)
 
 
     def estimate_activity(self, nirx_obj, lmbda = 1e-4, hrf_model = 'toeplitz', preprocess = True, cond_thresh = None, timeout = 30, progress_callback = None, library_trace = None, library_oxygenation = True, library_traces = None, library_uncovered = 'skip', drop_failed_channels = True):
@@ -889,6 +912,33 @@ class montage(tree):
                 self.channels['global_hbo'] = self.insert(global_hrf)
             else:
                 self.channels['global_hbr'] = self.insert(global_hrf)
+
+    def remove_source(self, source_id, regenerate = True):
+        """Drop every estimate contributed by ``source_id`` from all channels.
+
+        Provenance-based removal for a multi-subject montage — e.g. drop one
+        subject from a group montage (including one saved then reloaded, since
+        ``estimate_sources`` round-trips through save/load). Keeps estimates /
+        locations / estimate_sources parallel. When ``regenerate`` (default),
+        re-runs ``generate_distribution`` so trace + trace_std reflect the
+        remaining subjects. Returns the number of estimates removed.
+        """
+        removed = 0
+        for optode in self.channels.values():
+            sources = getattr(optode, 'estimate_sources', None)
+            if not sources:
+                continue
+            for idx in reversed([
+                i for i, s in enumerate(sources) if s == source_id
+            ]):
+                del optode.estimates[idx]
+                if idx < len(optode.locations):
+                    del optode.locations[idx]
+                del optode.estimate_sources[idx]
+                removed += 1
+        if regenerate and removed:
+            self.generate_distribution()
+        return removed
 
     def correlate_hrf(self, plot_filename = "montage_correlation.png"):
         """

--- a/src/hrfunc/hrfunc.py
+++ b/src/hrfunc/hrfunc.py
@@ -462,7 +462,7 @@ class montage(tree):
             optode.locations.append(list(channel['loc'][:3]))
 
 
-    def estimate_activity(self, nirx_obj, lmbda = 1e-4, hrf_model = 'toeplitz', preprocess = True, cond_thresh = None, timeout = 30, progress_callback = None, library_trace = None, library_oxygenation = True, drop_failed_channels = True):
+    def estimate_activity(self, nirx_obj, lmbda = 1e-4, hrf_model = 'toeplitz', preprocess = True, cond_thresh = None, timeout = 30, progress_callback = None, library_trace = None, library_oxygenation = True, library_traces = None, library_uncovered = 'skip', drop_failed_channels = True):
         """
         Deconvlve a fNIRS scan using estimated HRF's localized to optodes location
         to gain a neural activity estimate
@@ -480,8 +480,18 @@ class montage(tree):
                 ``library_oxygenation`` and sign-flipped for the opposite oxygenation (HbO and HbR
                 responses are inverses).
             library_oxygenation (bool) - Oxygenation the supplied ``library_trace`` was measured at
-                (True = HbO, False = HbR). Used only when hrf_model='library' to orient the kernel
-                per channel. Default True.
+                (True = HbO, False = HbR). Used only when hrf_model='library' to orient the single
+                kernel per channel. Ignored when ``library_traces`` is given. Default True.
+            library_traces (dict or None) - Per-channel HRtree map: ``{standardized_ch_name: trace}``.
+                When provided (hrf_model='library'), each channel is deconvolved with ITS OWN trace
+                from the map (already oriented by the caller's spatial match) instead of one shared
+                kernel — used by the GUI's per-channel HRtree matching. Channels absent from the map
+                are "uncovered" and handled per ``library_uncovered``. Takes precedence over
+                ``library_trace`` when both are set. Default None (single-kernel mode).
+            library_uncovered (str) - How to treat channels with no entry in ``library_traces``:
+                'skip' (default) drops them from the output so coverage is honest; 'canonical'
+                deconvolves them with the SPM canonical HRF instead. Only used when
+                ``library_traces`` is given.
             preprocess (bool) - If True, preprocess the fNIRS data before estimating the neural activity
             cond_thresh (float or None) - Condition number threshold for falling back to pinv in solve_lstsq
             drop_failed_channels (bool) - If True (default), a channel that errors at any point of
@@ -505,16 +515,33 @@ class montage(tree):
         if lmbda <= 0:
             raise ValueError(f"ERROR: lmbda must be > 0 for Tikhonov regularization, got {lmbda}")
 
-        # Library mode deconvolves every channel with one supplied HRF trace
-        # (e.g. an HRtree selection). Validate + normalize it once up front so
-        # the per-channel loop just orients it by oxygenation.
+        # Library mode deconvolves channels with HRtree-sourced HRF traces.
+        # Two sub-modes:
+        #   - single kernel: every channel uses ``library_trace`` (oriented by
+        #     oxygenation). Back-compat path.
+        #   - per-channel map: ``library_traces`` maps a standardized channel
+        #     name to that channel's own HRtree trace (already oriented by the
+        #     caller's spatial match). Channels absent from the map are
+        #     "uncovered" and handled per ``library_uncovered`` ('skip' drops
+        #     them from the output so coverage is honest; 'canonical' falls back
+        #     to the SPM canonical HRF for them).
+        # Validate + normalize the single kernel up front so the per-channel
+        # loop just orients it by oxygenation.
         library_kernel = None
         if hrf_model == 'library':
-            if library_trace is None or len(library_trace) == 0:
-                raise ValueError("ERROR: hrf_model='library' requires a non-empty library_trace")
-            library_kernel = np.asarray(library_trace, dtype=np.float64)
-            if np.max(np.abs(library_kernel)) == 0:
-                raise ValueError("ERROR: library_trace is all zeros; cannot deconvolve")
+            if library_uncovered not in ('skip', 'canonical'):
+                raise ValueError(
+                    "ERROR: library_uncovered must be 'skip' or 'canonical', "
+                    f"got {library_uncovered!r}"
+                )
+            if library_traces is None:
+                if library_trace is None or len(library_trace) == 0:
+                    raise ValueError("ERROR: hrf_model='library' requires a non-empty library_trace (or a library_traces map)")
+                library_kernel = np.asarray(library_trace, dtype=np.float64)
+                if np.max(np.abs(library_kernel)) == 0:
+                    raise ValueError("ERROR: library_trace is all zeros; cannot deconvolve")
+            elif len(library_traces) == 0:
+                raise ValueError("ERROR: hrf_model='library' with a library_traces map requires at least one channel trace")
 
         # Check montage still needs to be configured
         if self.configured is False:
@@ -610,6 +637,9 @@ class montage(tree):
         # Iterate a snapshot of channel names so we can safely pop orphaned
         # entries inside the loop when deconvolution fails (M4).
         dropped_channels = []
+        # Channels with no per-channel HRtree trace under a library_traces map
+        # and library_uncovered='skip' — dropped from the output and reported.
+        uncovered_channels = []
         all_channels = list(self.channels.keys())
         total_channels = len(all_channels)
         for i, ch_name in enumerate(all_channels):
@@ -649,12 +679,57 @@ class montage(tree):
                 # signs HbO vs HbR. Takes precedence over the canonical fallback.
                 if hrf_model == 'library':
                     estimate_hrf = hrf  # save original; restored after the channel
-                    oriented = (
-                        library_kernel
-                        if _is_oxygenated(ch_name) == bool(library_oxygenation)
-                        else -library_kernel
-                    )
-                    hrf = SimpleNamespace(trace=oriented)
+                    if library_traces is not None:
+                        # Per-channel HRtree map: each channel uses its own
+                        # spatially-matched trace (already oriented by the
+                        # caller). Channels missing from the map are "uncovered".
+                        per_ch = library_traces.get(ch_name)
+                        per_ch_valid = (
+                            per_ch is not None
+                            and len(per_ch) > 0
+                            and np.max(np.abs(np.asarray(per_ch, dtype=np.float64))) > 0
+                        )
+                        if per_ch_valid:
+                            hrf = SimpleNamespace(
+                                trace=np.asarray(per_ch, dtype=np.float64)
+                            )
+                        elif library_uncovered == 'canonical':
+                            # Uncovered → fall back to the SPM canonical HRF for
+                            # this channel (signed per oxygenation by the tree).
+                            print(
+                                f"WARNING: channel {ch_name} has no HRtree HRF in range; "
+                                "falling back to canonical HRF"
+                            )
+                            canonical_duration = float(self.context.get('duration', 30.0))
+                            if _is_oxygenated(ch_name):
+                                hrf = self.hbo_tree.get_canonical_hrf(
+                                    True, self.sfreq, canonical_duration
+                                )
+                            else:
+                                hrf = self.hbr_tree.get_canonical_hrf(
+                                    False, self.sfreq, canonical_duration
+                                )
+                        else:
+                            # Uncovered + skip: drop this channel from the output
+                            # so the activity result only holds channels with a
+                            # real HRtree HRF (honest coverage). Fail loudly.
+                            print(
+                                f"WARNING: channel {ch_name} has no HRtree HRF in range; "
+                                "skipping it (library_uncovered='skip')"
+                            )
+                            for nirx_channel in nirx_obj.info['chs']:
+                                if ch_name == standardize_name(nirx_channel['ch_name']):
+                                    nirx_obj.drop_channels([nirx_channel['ch_name']])
+                                    break
+                            uncovered_channels.append(ch_name)
+                            continue
+                    else:
+                        oriented = (
+                            library_kernel
+                            if _is_oxygenated(ch_name) == bool(library_oxygenation)
+                            else -library_kernel
+                        )
+                        hrf = SimpleNamespace(trace=oriented)
 
                 # If canonical HRF requested (or forced by a degenerate trace)
                 elif hrf_model == 'canonical' or trace_invalid:

--- a/src/hrfunc/hrtree.py
+++ b/src/hrfunc/hrtree.py
@@ -649,7 +649,8 @@ class tree:
                     "sfreq": node.sfreq,
                     "context": node.context,
                     "estimates": node.estimates,
-                    "locations": node.locations
+                    "locations": node.locations,
+                    "estimate_sources": getattr(node, "estimate_sources", []),
                 }
         }
         return hrfs
@@ -908,7 +909,7 @@ class tree:
         return min([node, left_min, right_min], key=lambda n: getattr(n, ["x", "y", "z"][axis]) if n else float('inf'))
 
 class HRF:
-    def __init__(self, doi, ch_name, duration, sfreq, trace, trace_std = None, location = None, estimates = None, locations = None, context = None, **kwargs):
+    def __init__(self, doi, ch_name, duration, sfreq, trace, trace_std = None, location = None, estimates = None, locations = None, context = None, estimate_sources = None, **kwargs):
         """
         Object for storing all information apart of an estimated HRF from an fNIRS optode
 
@@ -986,6 +987,18 @@ class HRF:
 
         self.estimates = list(estimates) if estimates is not None else []
         self.locations = list(locations) if locations is not None else []
+        # Provenance: a source id per estimate (e.g. the scan it came from), so
+        # a saved+reloaded multi-subject montage can still report and remove a
+        # specific subject's contribution. Kept parallel to ``estimates`` — pad
+        # with None for estimates that predate provenance (bundled HRFs, older
+        # saves) so indices always line up.
+        self.estimate_sources = (
+            list(estimate_sources) if estimate_sources is not None else []
+        )
+        if len(self.estimate_sources) < len(self.estimates):
+            self.estimate_sources += [None] * (
+                len(self.estimates) - len(self.estimate_sources)
+            )
 
         # NE-003: process_options must be the same length as hrf_processes
         # and process_names so the zip in build() produces one iteration

--- a/tests/test_estimate_activity_library.py
+++ b/tests/test_estimate_activity_library.py
@@ -1,0 +1,120 @@
+"""Core estimate_activity — per-channel HRtree (library_traces) deconvolution.
+
+Library mode gained a per-channel map (``library_traces``: standardized
+channel name -> that channel's own HRtree trace) plus ``library_uncovered``
+('skip' drops channels with no mapped trace so coverage is honest;
+'canonical' falls back to the SPM canonical HRF for them). The single-kernel
+``library_trace`` path is unchanged when ``library_traces`` is None.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Top-of-function validation (no nirx_obj / configure needed)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def bare_montage():
+    from hrfunc.hrfunc import montage
+    return montage()
+
+
+class TestLibraryValidation:
+    def test_invalid_uncovered_raises(self, bare_montage):
+        with pytest.raises(ValueError, match="library_uncovered"):
+            bare_montage.estimate_activity(
+                None, hrf_model="library",
+                library_traces={"s1_d1_hbo": [1.0, 2.0]},
+                library_uncovered="bogus",
+            )
+
+    def test_library_requires_trace_or_map(self, bare_montage):
+        with pytest.raises(ValueError, match="library_trace"):
+            bare_montage.estimate_activity(None, hrf_model="library")
+
+    def test_empty_traces_map_raises(self, bare_montage):
+        with pytest.raises(ValueError, match="at least one channel"):
+            bare_montage.estimate_activity(
+                None, hrf_model="library", library_traces={},
+            )
+
+
+# ---------------------------------------------------------------------------
+# Behavioural — per-channel routing on a synthetic raw
+# ---------------------------------------------------------------------------
+
+
+def _raw_4ch():
+    import mne
+
+    ch_names = ["S1_D1 hbo", "S1_D1 hbr", "S2_D1 hbo", "S2_D1 hbr"]
+    data = np.random.default_rng(0).standard_normal((4, 200)) * 1e-6
+    raw = mne.io.RawArray(
+        data, mne.create_info(ch_names, 10.0, "hbo"), verbose="ERROR"
+    )
+    for i, ch in enumerate(raw.info["chs"]):
+        ch["loc"][:3] = [i * 0.01, 0.0, 0.0]
+    return raw
+
+
+def _fresh_montage(raw):
+    from hrfunc.hrfunc import montage
+    return montage(nirx_obj=raw)
+
+
+# Cover only the S1 pair; S2 is left uncovered.
+_KERNEL = list(np.exp(-np.linspace(0, 3, 40)))
+_COVER_S1 = {"s1_d1_hbo": _KERNEL, "s1_d1_hbr": _KERNEL}
+
+
+@pytest.mark.integration
+class TestPerChannelDeconvolution:
+    def test_skip_drops_uncovered_channels(self):
+        raw = _raw_4ch()
+        out = _fresh_montage(raw).estimate_activity(
+            raw.copy(), hrf_model="library", library_traces=_COVER_S1,
+            library_uncovered="skip", preprocess=False, timeout=10,
+        )
+        assert out is not None
+        # Only the covered S1 pair survives; uncovered S2 pair is dropped.
+        assert set(out.ch_names) == {"S1_D1 hbo", "S1_D1 hbr"}
+
+    def test_canonical_keeps_all_channels(self):
+        raw = _raw_4ch()
+        out = _fresh_montage(raw).estimate_activity(
+            raw.copy(), hrf_model="library", library_traces=_COVER_S1,
+            library_uncovered="canonical", preprocess=False, timeout=10,
+        )
+        assert out is not None
+        # Uncovered S2 pair falls back to canonical -> all 4 retained.
+        assert set(out.ch_names) == {
+            "S1_D1 hbo", "S1_D1 hbr", "S2_D1 hbo", "S2_D1 hbr"
+        }
+
+    def test_covered_channel_signal_changes(self):
+        """Deconvolution actually transforms covered channels (not a no-op)."""
+        raw = _raw_4ch()
+        before = raw.copy().get_data(picks=["S1_D1 hbo"])
+        out = _fresh_montage(raw).estimate_activity(
+            raw.copy(), hrf_model="library", library_traces=_COVER_S1,
+            library_uncovered="skip", preprocess=False, timeout=10,
+        )
+        after = out.get_data(picks=["S1_D1 hbo"])
+        assert not np.allclose(before, after)
+
+    def test_single_kernel_path_unchanged_when_no_map(self):
+        """library_traces=None keeps the back-compat single-kernel behaviour:
+        every channel deconvolved, none dropped."""
+        raw = _raw_4ch()
+        out = _fresh_montage(raw).estimate_activity(
+            raw.copy(), hrf_model="library", library_trace=_KERNEL,
+            library_oxygenation=True, preprocess=False, timeout=10,
+        )
+        assert out is not None
+        assert set(out.ch_names) == {
+            "S1_D1 hbo", "S1_D1 hbr", "S2_D1 hbo", "S2_D1 hbr"
+        }

--- a/tests/test_gui_activity_per_channel.py
+++ b/tests/test_gui_activity_per_channel.py
@@ -1,0 +1,268 @@
+"""Activity tab — per-channel HRtree deconvolution wiring + UI.
+
+Covers ``_compute_library_traces`` (per-scan matching), ``run_activity_sync``
+forwarding the per-channel map to ``estimate_activity``, and the right-column
+coverage/assignment UI.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+pytest.importorskip("nicegui")
+pytest.importorskip("mne")
+
+import mne  # noqa: E402
+from nicegui import ui  # noqa: E402
+from nicegui.testing import User  # noqa: E402
+
+from hrfunc.gui.components import activity_panel, hrtree_match  # noqa: E402
+from hrfunc.gui.state import AppState  # noqa: E402
+from hrfunc.io.manifest import Manifest, ScanEntry  # noqa: E402
+
+pytest_plugins = ["nicegui.testing.user_plugin"]
+
+
+def _raw():
+    raw = mne.io.RawArray(
+        np.zeros((2, 10)),
+        mne.create_info(["S1_D1 hbo", "S1_D1 hbr"], 10.0, "hbo"),
+        verbose="ERROR",
+    )
+    for i, ch in enumerate(raw.info["chs"]):
+        ch["loc"][:3] = [0.05 + i * 0.001, 0.0, 0.0]
+    return raw
+
+
+def _match_result(covered=True):
+    m = hrtree_match.ChannelMatch(
+        "s1_d1_hbo", True, matched=covered,
+        trace=[0.1, 0.9, 0.3] if covered else None,
+        source="hbo:roi" if covered else None,
+        distance_mm=4.0 if covered else None,
+    )
+    u = hrtree_match.ChannelMatch("s1_d1_hbr", False, matched=False)
+    return hrtree_match.MatchResult(
+        matches=[m, u], n_candidate_hrfs=2, n_rois=1,
+        strategy="individual", radius_mm=20.0,
+    )
+
+
+# ---------------------------------------------------------------------------
+# _compute_library_traces
+# ---------------------------------------------------------------------------
+
+
+class TestComputeLibraryTraces:
+    def test_none_when_not_library(self):
+        opts = activity_panel.ActivityOptions(
+            hrf_model=activity_panel.MODEL_TOEPLITZ, library_per_channel=True,
+        )
+        assert activity_panel._compute_library_traces(AppState(), _raw(), opts) is None
+
+    def test_none_when_per_channel_off(self):
+        opts = activity_panel.ActivityOptions(
+            hrf_model=activity_panel.MODEL_LIBRARY, library_per_channel=False,
+        )
+        assert activity_panel._compute_library_traces(AppState(), _raw(), opts) is None
+
+    def test_returns_map_in_per_channel_mode(self, monkeypatch):
+        monkeypatch.setattr(
+            hrtree_match, "match_channels_to_hrtree",
+            lambda *a, **k: _match_result(covered=True),
+        )
+        opts = activity_panel.ActivityOptions(
+            hrf_model=activity_panel.MODEL_LIBRARY, library_per_channel=True,
+        )
+        traces = activity_panel._compute_library_traces(AppState(), _raw(), opts)
+        assert traces == {"s1_d1_hbo": [0.1, 0.9, 0.3]}
+
+    def test_none_when_no_matches(self, monkeypatch):
+        monkeypatch.setattr(
+            hrtree_match, "match_channels_to_hrtree",
+            lambda *a, **k: _match_result(covered=False),
+        )
+        opts = activity_panel.ActivityOptions(
+            hrf_model=activity_panel.MODEL_LIBRARY, library_per_channel=True,
+        )
+        assert activity_panel._compute_library_traces(AppState(), _raw(), opts) is None
+
+
+# ---------------------------------------------------------------------------
+# run_activity_sync forwards the per-channel map
+# ---------------------------------------------------------------------------
+
+
+class TestRunActivitySyncPerChannel:
+    def test_passes_library_traces_and_uncovered(self, monkeypatch):
+        from hrfunc import hrfunc as hrf_module
+
+        captured = {}
+
+        class _FakeMontage:
+            def __init__(self, nirx_obj=None):
+                self.channels = {}
+
+            def estimate_activity(self, nirx_obj, **kwargs):
+                captured.update(kwargs)
+                return nirx_obj
+
+        monkeypatch.setattr(hrf_module, "montage", _FakeMontage)
+
+        opts = activity_panel.ActivityOptions(
+            hrf_model=activity_panel.MODEL_LIBRARY,
+            library_traces={"s1_d1_hbo": [0.1, 0.2]},
+            library_uncovered="canonical",
+            library_trace=[9.9],  # must be ignored in favour of the map
+        )
+        activity_panel.run_activity_sync(_raw(), opts)
+
+        assert captured["library_traces"] == {"s1_d1_hbo": [0.1, 0.2]}
+        assert captured["library_uncovered"] == "canonical"
+        assert "library_trace" not in captured
+
+    def test_single_kernel_when_no_map(self, monkeypatch):
+        from hrfunc import hrfunc as hrf_module
+
+        captured = {}
+
+        class _FakeMontage:
+            def __init__(self, nirx_obj=None):
+                self.channels = {}
+
+            def estimate_activity(self, nirx_obj, **kwargs):
+                captured.update(kwargs)
+                return nirx_obj
+
+        monkeypatch.setattr(hrf_module, "montage", _FakeMontage)
+
+        opts = activity_panel.ActivityOptions(
+            hrf_model=activity_panel.MODEL_LIBRARY,
+            library_trace=[0.0, 1.0, 0.0],
+            library_oxygenation=True,
+        )
+        activity_panel.run_activity_sync(_raw(), opts)
+
+        assert captured["library_trace"] == [0.0, 1.0, 0.0]
+        assert "library_traces" not in captured
+
+
+# ---------------------------------------------------------------------------
+# UI — coverage counts + per-channel assignment column
+# ---------------------------------------------------------------------------
+
+
+def _project(state, tmp_path):
+    scan = ScanEntry(format="snirf", path=tmp_path / "a.snirf", display_name="A")
+    state.manifest = Manifest(root=tmp_path, scans=(scan,))
+    state.selected_scan = scan
+    raw = _raw()
+    state.processed_cache._cache[scan.path.resolve()] = raw
+    state.processed_deconvolved.add(scan.path.resolve())
+    return scan
+
+
+class TestPerChannelUI:
+    @pytest.mark.asyncio
+    async def test_coverage_counts_and_assignment_render(
+        self, user: User, tmp_path, monkeypatch
+    ):
+        state = AppState()
+        _project(state, tmp_path)
+        state.activity_options = None
+        # Pretend the user has 1 visible ROI and force a known match result.
+        monkeypatch.setattr(activity_panel, "_visible_roi_count", lambda _s: 1)
+        monkeypatch.setattr(
+            hrtree_match, "match_channels_to_hrtree",
+            lambda *a, **k: _match_result(covered=True),
+        )
+
+        opts = activity_panel.ActivityOptions(
+            hrf_model=activity_panel.MODEL_LIBRARY, library_per_channel=True,
+        )
+
+        @ui.page("/_apc")
+        def _p() -> None:
+            activity_panel._render_library_source_status(
+                state, state.selected_scan, opts, bulk_mode=False
+            )
+
+        await user.open("/_apc")
+        await user.should_see("1/2 channels covered")
+        await user.should_see("Per-channel HRF assignment")
+        await user.should_see("uncovered")  # the HbR channel
+
+    @pytest.mark.asyncio
+    async def test_skip_warns_about_dropped_channels(
+        self, user: User, tmp_path, monkeypatch
+    ):
+        state = AppState()
+        _project(state, tmp_path)
+        monkeypatch.setattr(activity_panel, "_visible_roi_count", lambda _s: 1)
+        monkeypatch.setattr(
+            hrtree_match, "match_channels_to_hrtree",
+            lambda *a, **k: _match_result(covered=True),
+        )
+        opts = activity_panel.ActivityOptions(
+            hrf_model=activity_panel.MODEL_LIBRARY,
+            library_per_channel=True, library_uncovered="skip",
+        )
+
+        @ui.page("/_apc_skip")
+        def _p() -> None:
+            activity_panel._render_library_source_status(
+                state, state.selected_scan, opts, bulk_mode=False
+            )
+
+        await user.open("/_apc_skip")
+        await user.should_see("DROPPED")
+
+
+# ---------------------------------------------------------------------------
+# Group-montage mode (Phase 3): deconvolve every scan with the pooled HRFs
+# ---------------------------------------------------------------------------
+
+
+class TestActivityGroupMode:
+    def test_group_count_skips_canonical(self):
+        from pathlib import Path
+        state = AppState()
+        state.montage_cache[Path("/a")] = object()
+        state.montage_cache[Path("/b")] = object()
+        state.montage_cache[Path("/c")] = activity_panel._CanonicalResult(
+            canonical_trace=np.zeros(3), duration=1.0, sfreq=10.0
+        )
+        assert activity_panel._group_subject_count(state) == 2
+
+    def test_montage_for_scan_returns_group_when_enabled(self, tmp_path):
+        scan = ScanEntry(format="snirf", path=tmp_path / "x.snirf")
+        state = AppState()
+        group = object()  # stand-in non-canonical montage
+        state.project_montage = group
+        state.activity_use_group_hrfs = True
+        # Scan was never individually estimated, yet group mode supplies HRFs.
+        assert activity_panel._montage_for_scan(state, scan) is group
+
+    def test_group_off_uses_scans_own_montage(self, tmp_path):
+        scan = ScanEntry(format="snirf", path=tmp_path / "x.snirf")
+        state = AppState()
+        own = object()
+        state.montage_cache[scan.path.resolve()] = own
+        state.project_montage = object()
+        state.activity_use_group_hrfs = False
+        assert activity_panel._montage_for_scan(state, scan) is own
+
+    @pytest.mark.asyncio
+    async def test_group_toggle_renders_when_two_subjects(self, user, tmp_path):
+        from pathlib import Path
+        state = AppState()
+        state.montage_cache[Path("/a")] = object()
+        state.montage_cache[Path("/b")] = object()
+        state.project_montage = object()
+
+        @ui.page("/_agroup")
+        def _p() -> None:
+            activity_panel._render_estimated_source_status(state, None, False)
+
+        await user.open("/_agroup")
+        await user.should_see("Group HRFs (2)")

--- a/tests/test_gui_bulk_preprocess.py
+++ b/tests/test_gui_bulk_preprocess.py
@@ -1,0 +1,200 @@
+"""Bulk preprocess affordance — shared helper + HRFs / Activity integration.
+
+Background: ticking scans selects them for a bulk RUN, but the per-scan
+config + preprocess controls used to be gated on ``selected_scan`` (a
+row-click). With only checkboxes ticked the HRFs tab showed "Pick one of
+the checked scans…" and no preprocess button, which read as "the checkbox
+didn't fully select the file." Both panels' bulk runs already preprocess
+each scan on demand (``ensure_deconvolved_raw``), so the fix is a shared
+bulk affordance — readiness summary + one-click "Preprocess all checked" —
+that renders on tick alone.
+
+These tests lock:
+- the shared ``scan_is_deconvolved`` readiness gate,
+- ``render_preprocess_all_checked`` showing the right state (not-ready →
+  button; all-ready → confirmation),
+- HRFs bulk mode rendering global params + the affordance on tick-only
+  (no "Pick one of the checked scans" prompt),
+- Activity bulk mode rendering the affordance on tick-only.
+"""
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("nicegui")
+
+from nicegui import ui  # noqa: E402
+from nicegui.testing import User  # noqa: E402
+
+from hrfunc.gui.components import preprocess_panel  # noqa: E402
+from hrfunc.gui.state import AppState  # noqa: E402
+from hrfunc.io.manifest import Manifest, ScanEntry  # noqa: E402
+
+pytest_plugins = ["nicegui.testing.user_plugin"]
+
+
+def _manifest(tmp_path):
+    scans = (
+        ScanEntry(format="snirf",
+                  path=tmp_path / "sub-01" / "a.snirf",
+                  bids_subject="01", display_name="SCANALPHA"),
+        ScanEntry(format="snirf",
+                  path=tmp_path / "sub-02" / "b.snirf",
+                  bids_subject="02", display_name="SCANBETA"),
+    )
+    return Manifest(root=tmp_path, scans=scans)
+
+
+def _mark_deconvolved(state: AppState, scan: ScanEntry) -> None:
+    """Make ``scan_is_deconvolved`` true without a real Raw: stub the cache
+    entry (RawCache.__contains__ only checks the resolved path key) and record
+    the deconvolution flag."""
+    key = scan.path.resolve()
+    state.processed_cache._cache[key] = object()
+    state.processed_deconvolved.add(key)
+
+
+def _tick(user: User, *paths) -> None:
+    user.find(ui.tree).trigger("update:ticked", [str(p) for p in paths])
+
+
+# ---------------------------------------------------------------------------
+# Shared readiness gate
+# ---------------------------------------------------------------------------
+
+
+class TestScanIsDeconvolved:
+    def test_false_when_uncached(self, tmp_path):
+        state = AppState()
+        state.manifest = _manifest(tmp_path)
+        assert not preprocess_panel.scan_is_deconvolved(
+            state, state.manifest.scans[0]
+        )
+
+    def test_false_when_cached_but_glm_only(self, tmp_path):
+        """In processed_cache but NOT processed_deconvolved (GLM mode) → not
+        ready for HRF/activity estimation."""
+        state = AppState()
+        state.manifest = _manifest(tmp_path)
+        scan = state.manifest.scans[0]
+        state.processed_cache._cache[scan.path.resolve()] = object()
+        assert not preprocess_panel.scan_is_deconvolved(state, scan)
+
+    def test_true_when_cached_and_deconvolved(self, tmp_path):
+        state = AppState()
+        state.manifest = _manifest(tmp_path)
+        scan = state.manifest.scans[0]
+        _mark_deconvolved(state, scan)
+        assert preprocess_panel.scan_is_deconvolved(state, scan)
+
+
+# ---------------------------------------------------------------------------
+# render_preprocess_all_checked — direct render states
+# ---------------------------------------------------------------------------
+
+
+class TestRenderPreprocessAllChecked:
+    @pytest.mark.asyncio
+    async def test_not_ready_shows_button(self, user: User, tmp_path):
+        state = AppState()
+        state.manifest = _manifest(tmp_path)
+        scans = list(state.manifest.scans)
+
+        @ui.page("/_ppc_not_ready")
+        def _p() -> None:
+            preprocess_panel.render_preprocess_all_checked(state, scans)
+
+        await user.open("/_ppc_not_ready")
+        await user.should_see("Preprocess all checked")
+        await user.should_see("2 of 2 checked scans aren't")
+
+    @pytest.mark.asyncio
+    async def test_all_ready_shows_confirmation_no_button(
+        self, user: User, tmp_path
+    ):
+        state = AppState()
+        state.manifest = _manifest(tmp_path)
+        scans = list(state.manifest.scans)
+        for s in scans:
+            _mark_deconvolved(state, s)
+
+        @ui.page("/_ppc_ready")
+        def _p() -> None:
+            preprocess_panel.render_preprocess_all_checked(state, scans)
+
+        await user.open("/_ppc_ready")
+        await user.should_see("ready")
+        await user.should_not_see("Preprocess all checked")
+
+    @pytest.mark.asyncio
+    async def test_partial_counts_only_not_ready(self, user: User, tmp_path):
+        state = AppState()
+        state.manifest = _manifest(tmp_path)
+        scans = list(state.manifest.scans)
+        _mark_deconvolved(state, scans[0])  # one ready, one not
+
+        @ui.page("/_ppc_partial")
+        def _p() -> None:
+            preprocess_panel.render_preprocess_all_checked(state, scans)
+
+        await user.open("/_ppc_partial")
+        await user.should_see("1 of 2 checked scans aren't")
+        await user.should_see("Preprocess all checked")
+
+
+# ---------------------------------------------------------------------------
+# Panel integration: tick-only (no row click) engages the affordance
+# ---------------------------------------------------------------------------
+
+
+class TestHrfBulkAffordance:
+    @pytest.mark.asyncio
+    async def test_tick_only_shows_affordance_and_params(
+        self, user: User, tmp_path
+    ):
+        from hrfunc.gui.components import dataset_tree, hrf_panel
+
+        state = AppState()
+        state.manifest = _manifest(tmp_path)
+        a, b = state.manifest.scans
+
+        @ui.page("/_hrf_bulk")
+        def _p() -> None:
+            with ui.row():
+                dataset_tree.render(state)
+                hrf_panel.render(state)
+
+        await user.open("/_hrf_bulk")
+        _tick(user, a.path, b.path)
+
+        assert state.selected_scan is None  # no row click
+        await user.should_see("Bulk run on 2 checked scan")
+        await user.should_see("Preprocess all checked")
+        # Global params now render in bulk too (were row-click-only before).
+        await user.should_see("Regularization (lambda)")
+        await user.should_see("Duration (seconds)")
+        # The old dead-end prompt is gone.
+        await user.should_not_see("Pick one of the checked scans")
+
+
+class TestActivityBulkAffordance:
+    @pytest.mark.asyncio
+    async def test_tick_only_shows_affordance(self, user: User, tmp_path):
+        from hrfunc.gui.components import activity_panel, dataset_tree
+
+        state = AppState()
+        state.manifest = _manifest(tmp_path)
+        a, b = state.manifest.scans
+
+        @ui.page("/_act_bulk")
+        def _p() -> None:
+            with ui.row():
+                dataset_tree.render(state)
+                activity_panel.render(state)
+
+        await user.open("/_act_bulk")
+        _tick(user, a.path, b.path)
+
+        assert state.selected_scan is None
+        await user.should_see("Bulk run on 2 checked scan")
+        await user.should_see("Preprocess all checked")

--- a/tests/test_gui_dataset_tree_tick.py
+++ b/tests/test_gui_dataset_tree_tick.py
@@ -1,0 +1,319 @@
+"""Interaction tests for the dataset-tree checkbox (tick) pipeline.
+
+The sync tests in ``test_gui_dataset_tree.py`` cover ``build_nodes`` /
+``find_scan`` only — the pure data transforms. They never exercise the
+*interactive* tick path: ``ui.tree(on_tick=...)`` → ``_on_tick`` →
+``state.checked_scan_paths`` → ``checked_changed`` → action-panel bulk
+mode. That gap let two separate "ticking is broken" fixes ship without a
+regression guard:
+
+- ``bbff389`` ("ticking scans now makes them eligible to estimate") wired
+  the ``checked_changed`` publish so the Preprocess / HRF / Activity panels
+  recompute bulk mode when the checked set changes.
+- ``d17a6c4`` ("checkboxes stay in sync across tabs") subscribed each tree
+  to ``checked_changed`` so the per-tab trees re-render their visual ticks
+  off the shared set.
+
+These tests drive the REAL pipeline in-process via NiceGUI's ``User``
+fixture: ``user.find(ui.tree).trigger("update:ticked", [...])`` dispatches
+the exact ``GenericEventArguments`` the Quasar ``q-tree`` sends on a
+checkbox click, so ``_on_tick`` runs with a faithful payload (including its
+mid-handler ``_tree_body.refresh()``).
+
+Scope note: the ``User`` fixture calls the registered Python handlers
+directly — it does NOT run the browser/Quasar client. So these tests lock
+the server-side contract (tick → state → bulk mode). A purely client-side
+rendering regression would need the Selenium ``Screen`` fixture instead.
+"""
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("nicegui")
+
+from nicegui import ui  # noqa: E402
+from nicegui.testing import User  # noqa: E402
+
+from hrfunc.gui.components import dataset_tree  # noqa: E402
+from hrfunc.gui.state import AppState  # noqa: E402
+from hrfunc.io.manifest import Manifest, ScanEntry  # noqa: E402
+
+pytest_plugins = ["nicegui.testing.user_plugin"]
+
+
+def _manifest(tmp_path) -> Manifest:
+    """Two BIDS subjects, one scan each — leaf ids are stringified paths."""
+    scans = (
+        ScanEntry(
+            format="snirf",
+            path=tmp_path / "sub-01" / "ses-01" / "a.snirf",
+            bids_subject="01", bids_session="01", display_name="A",
+        ),
+        ScanEntry(
+            format="snirf",
+            path=tmp_path / "sub-02" / "ses-01" / "b.snirf",
+            bids_subject="02", bids_session="01", display_name="B",
+        ),
+    )
+    return Manifest(root=tmp_path, scans=scans)
+
+
+def _tick(user: User, *paths) -> None:
+    """Simulate the q-tree emitting its full ticked-id list after a click.
+
+    Quasar sends the COMPLETE set of ticked leaf ids on every change (not a
+    delta); the leaf id is ``str(scan.path)``.
+    """
+    user.find(ui.tree).trigger("update:ticked", [str(p) for p in paths])
+
+
+def _dispatch_tick(element, client, *paths) -> None:
+    """Fire ``update:ticked`` on ONE specific tree element (not every match).
+
+    Used by the cross-tree sync test where two trees coexist and we must
+    tick exactly one to prove the other re-syncs off the shared state.
+    """
+    from nicegui import events
+
+    for listener in element._event_listeners.values():
+        if listener.type == "update:ticked":
+            events.handle_event(
+                listener.handler,
+                events.GenericEventArguments(
+                    sender=element, client=client,
+                    args=[str(p) for p in paths],
+                ),
+            )
+
+
+# ---------------------------------------------------------------------------
+# Core tick → checked_scan_paths round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestTickUpdatesCheckedSet:
+    @pytest.mark.asyncio
+    async def test_ticking_a_leaf_adds_resolved_path(self, user: User, tmp_path):
+        state = AppState()
+        state.manifest = _manifest(tmp_path)
+        a = state.manifest.scans[0]
+
+        @ui.page("/_tt_add")
+        def _p() -> None:
+            dataset_tree.render(state)
+
+        await user.open("/_tt_add")
+        assert state.checked_scan_paths == set()
+
+        _tick(user, a.path)
+        # Stored as a RESOLVED path so equality is filesystem-stable across
+        # manifest re-walks (the on-disk path is the constant identity).
+        assert state.checked_scan_paths == {a.path.resolve()}
+
+    @pytest.mark.asyncio
+    async def test_ticking_second_leaf_accumulates(self, user: User, tmp_path):
+        state = AppState()
+        state.manifest = _manifest(tmp_path)
+        a, b = state.manifest.scans
+
+        @ui.page("/_tt_acc")
+        def _p() -> None:
+            dataset_tree.render(state)
+
+        await user.open("/_tt_acc")
+        _tick(user, a.path)
+        _tick(user, a.path, b.path)
+        assert state.checked_scan_paths == {a.path.resolve(), b.path.resolve()}
+
+    @pytest.mark.asyncio
+    async def test_unticking_removes_only_that_leaf(self, user: User, tmp_path):
+        state = AppState()
+        state.manifest = _manifest(tmp_path)
+        a, b = state.manifest.scans
+
+        @ui.page("/_tt_untick")
+        def _p() -> None:
+            dataset_tree.render(state)
+
+        await user.open("/_tt_untick")
+        _tick(user, a.path, b.path)
+        _tick(user, b.path)  # untick A
+        assert state.checked_scan_paths == {b.path.resolve()}
+
+    @pytest.mark.asyncio
+    async def test_tick_publishes_checked_changed(self, user: User, tmp_path):
+        """Panels recompute bulk mode off this event (bbff389). Without the
+        publish, ticking would update the set but leave the action buttons
+        stuck in single-scan mode until some other event fired."""
+        state = AppState()
+        state.manifest = _manifest(tmp_path)
+        a = state.manifest.scans[0]
+
+        seen = []
+        state.subscribe("checked_changed", lambda payload=None: seen.append(payload))
+
+        @ui.page("/_tt_pub")
+        def _p() -> None:
+            dataset_tree.render(state)
+
+        await user.open("/_tt_pub")
+        _tick(user, a.path)
+        assert seen, "ticking a scan did not publish 'checked_changed'"
+        assert seen[-1] == {a.path.resolve()}
+
+
+# ---------------------------------------------------------------------------
+# Select-all checkbox
+# ---------------------------------------------------------------------------
+
+
+class TestSelectAll:
+    @pytest.mark.asyncio
+    async def test_select_all_ticks_every_visible_scan(self, user: User, tmp_path):
+        state = AppState()
+        state.manifest = _manifest(tmp_path)
+
+        @ui.page("/_tt_all")
+        def _p() -> None:
+            dataset_tree.render(state)
+
+        await user.open("/_tt_all")
+        # The "Select all" checkbox is the only top-level ui.checkbox.
+        user.find(ui.checkbox).trigger("update:modelValue", True)
+        assert state.checked_scan_paths == {
+            s.path.resolve() for s in state.manifest.scans
+        }
+
+    @pytest.mark.asyncio
+    async def test_select_all_off_clears_visible_scans(self, user: User, tmp_path):
+        state = AppState()
+        state.manifest = _manifest(tmp_path)
+        for s in state.manifest.scans:
+            state.checked_scan_paths.add(s.path.resolve())
+
+        @ui.page("/_tt_all_off")
+        def _p() -> None:
+            dataset_tree.render(state)
+
+        await user.open("/_tt_all_off")
+        user.find(ui.checkbox).trigger("update:modelValue", False)
+        assert state.checked_scan_paths == set()
+
+
+# ---------------------------------------------------------------------------
+# Cross-tab sync (d17a6c4): a second tree on the shared state reflects ticks
+# ---------------------------------------------------------------------------
+
+
+class TestCrossTreeSync:
+    @pytest.mark.asyncio
+    async def test_second_tree_reflects_shared_checked_set(self, user: User, tmp_path):
+        """Two trees, one shared AppState (the real shell mounts one tree per
+        data tab). Ticking in the first must leave the second's ticks in sync
+        via the ``checked_changed`` refresh — no split-brain between a panel's
+        "1 selected" label and an unchecked tree."""
+        state = AppState()
+        state.manifest = _manifest(tmp_path)
+        a = state.manifest.scans[0]
+
+        @ui.page("/_tt_two")
+        def _p() -> None:
+            with ui.row():
+                dataset_tree.render(state)
+                dataset_tree.render(state)
+
+        await user.open("/_tt_two")
+        trees = list(user.find(ui.tree).elements)
+        assert len(trees) == 2, "expected two independent tree instances"
+
+        # Tick on the FIRST tree only. Both trees share one AppState, so the
+        # checked set must update regardless of which tree originated the tick.
+        _dispatch_tick(trees[0], user.client, a.path)
+        assert state.checked_scan_paths == {a.path.resolve()}
+
+        # The originating tree re-applies its own ticks (its _on_tick refreshes
+        # its body before the cross-tree publish), so the active-tab tree the
+        # user is looking at always reflects the click.
+        live_ticks = [
+            t._props.get("ticked", [])
+            for t in user.find(ui.tree).elements
+            if not t.is_deleted
+        ]
+        assert any(str(a.path) in ticked for ticked in live_ticks), (
+            "no live tree reflected the tick in its visual ticked state"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Integration: ticking alone makes the action panels eligible (no row click)
+# ---------------------------------------------------------------------------
+#
+# This is the user-facing contract behind the "disjointed selection" report:
+# a checkbox tick — with NO row click setting state.selected_scan — must put
+# the Preprocess / HRF / Activity panels into bulk mode so the action engages
+# the checked file. Locked per-panel so a regression in any one surfaces.
+
+
+def _render_tab(state: AppState, panel_render):
+    with ui.row():
+        with ui.column():
+            dataset_tree.render(state)
+        with ui.column():
+            panel_render(state)
+
+
+class TestTickEngagesBulkModeWithoutRowClick:
+    @pytest.mark.asyncio
+    async def test_preprocess_panel(self, user: User, tmp_path):
+        from hrfunc.gui.components import preprocess_panel
+
+        state = AppState()
+        state.manifest = _manifest(tmp_path)
+        a = state.manifest.scans[0]
+
+        @ui.page("/_tt_pre")
+        def _p() -> None:
+            _render_tab(state, preprocess_panel.render)
+
+        await user.open("/_tt_pre")
+        await user.should_see("Select a scan from the dataset tree")
+        assert state.selected_scan is None  # no row click
+
+        _tick(user, a.path)
+        await user.should_see("Bulk run on 1 checked scan")
+
+    @pytest.mark.asyncio
+    async def test_hrf_panel(self, user: User, tmp_path):
+        from hrfunc.gui.components import hrf_panel
+
+        state = AppState()
+        state.manifest = _manifest(tmp_path)
+        a = state.manifest.scans[0]
+
+        @ui.page("/_tt_hrf")
+        def _p() -> None:
+            _render_tab(state, hrf_panel.render)
+
+        await user.open("/_tt_hrf")
+        assert state.selected_scan is None
+
+        _tick(user, a.path)
+        await user.should_see("Bulk run on 1 checked scan")
+
+    @pytest.mark.asyncio
+    async def test_activity_panel(self, user: User, tmp_path):
+        from hrfunc.gui.components import activity_panel
+
+        state = AppState()
+        state.manifest = _manifest(tmp_path)
+        a = state.manifest.scans[0]
+
+        @ui.page("/_tt_act")
+        def _p() -> None:
+            _render_tab(state, activity_panel.render)
+
+        await user.open("/_tt_act")
+        assert state.selected_scan is None
+
+        _tick(user, a.path)
+        await user.should_see("Bulk run on 1 checked scan")

--- a/tests/test_gui_hrf_edge_expansion.py
+++ b/tests/test_gui_hrf_edge_expansion.py
@@ -1,0 +1,201 @@
+"""HRFs tab — edge-expansion control + edge-instability QC.
+
+The HRFs tab exposes ``edge_expansion`` (default 0.2) and forwards it to
+``montage.estimate_hrf``. After estimation it flags channels whose HRF is much
+noisier at the window edges than its center (a sign edge_expansion is too
+small) and nudges the user to raise it.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+pytest.importorskip("nicegui")
+
+from nicegui import ui  # noqa: E402
+from nicegui.testing import User  # noqa: E402
+
+from hrfunc.gui.components import hrf_panel  # noqa: E402
+
+pytest_plugins = ["nicegui.testing.user_plugin"]
+
+
+def _montage(channels):
+    return SimpleNamespace(channels=channels)
+
+
+# ---------------------------------------------------------------------------
+# Option default + wiring to estimate_hrf
+# ---------------------------------------------------------------------------
+
+
+def test_default_edge_expansion_is_point_two():
+    assert hrf_panel.EstimationOptions().edge_expansion == 0.2
+
+
+def test_run_toeplitz_forwards_edge_expansion(monkeypatch):
+    import mne
+    from hrfunc import hrfunc as hrf_module
+
+    captured = {}
+
+    class _FakeMontage:
+        def __init__(self, nirx_obj=None):
+            self.channels = {}
+
+        def estimate_hrf(self, raw, **kwargs):
+            captured.update(kwargs)
+
+        def generate_distribution(self):
+            pass
+
+    monkeypatch.setattr(hrf_module, "montage", _FakeMontage)
+
+    raw = mne.io.RawArray(
+        np.zeros((1, 50)),
+        mne.create_info(["S1_D1 hbo"], 10.0, "hbo"),
+        verbose="ERROR",
+    )
+    opts = hrf_panel.EstimationOptions(
+        edge_expansion=0.35, selected_events=("a",)
+    )
+    impulse = [0] * 50
+    impulse[10] = 1
+
+    hrf_panel.run_toeplitz_sync(raw, opts, None, None, impulse)
+    assert captured["edge_expansion"] == 0.35
+
+
+# ---------------------------------------------------------------------------
+# Edge-instability heuristic
+# ---------------------------------------------------------------------------
+
+
+# Heuristic reads node.trace (NOT trace_std, which is across-subject = 0 for a
+# single-scan estimate). n=20, edge frac 0.15 -> 3 samples each end.
+# Noisy edges: edges oscillate hard (high local std), center is a gentle bump
+# (low local std). Clean: the response sits in the center (high std), edges flat.
+_NOISY_EDGES = np.array(
+    [6.0, -6.0, 6.0]
+    + [0.0, 0.4, 0.8, 1.0, 1.2, 1.0, 0.8, 0.4, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+    + [6.0, -6.0, 6.0]
+)
+_CLEAN = np.array(
+    [0.0, 0.0, 0.05]
+    + [0.0, 2.0, 5.0, 8.0, 10.0, 8.0, 5.0, 2.0, 0.0, -1.0, -2.0, -1.0, 0.0, 0.0]
+    + [0.05, 0.0, 0.0]
+)
+
+
+class TestEdgeUnstableChannels:
+    def test_flags_channel_with_noisy_edges(self):
+        m = _montage({
+            "s1_d1_hbo": SimpleNamespace(trace=_NOISY_EDGES),
+            "s2_d1_hbo": SimpleNamespace(trace=_CLEAN),
+        })
+        flagged = hrf_panel._edge_unstable_channels(m)
+        assert "s1_d1_hbo" in flagged   # noisy edges > 2× center
+        assert "s2_d1_hbo" not in flagged  # response in center, flat edges
+
+    def test_ratio_threshold_is_respected(self):
+        m = _montage({"s1_d1_hbo": SimpleNamespace(trace=_NOISY_EDGES)})
+        # A high ratio makes the same channel pass (not flagged).
+        assert hrf_panel._edge_unstable_channels(m, ratio=50.0) == []
+        # The default ratio flags it.
+        assert "s1_d1_hbo" in hrf_panel._edge_unstable_channels(m)
+
+    def test_skips_missing_short_and_global(self):
+        m = _montage({
+            "no_trace": SimpleNamespace(trace=None),
+            "too_short": SimpleNamespace(trace=np.array([1.0, 9.0])),
+            "global_hbo": SimpleNamespace(trace=_NOISY_EDGES),
+        })
+        # None / too-short skipped; 'global' channels excluded.
+        assert hrf_panel._edge_unstable_channels(m) == []
+
+    def test_flat_center_not_flagged(self):
+        # Center std is 0 (constant) -> can't judge -> skipped, no crash.
+        flat_center = np.array([5.0, -5.0, 5.0] + [1.0] * 14 + [5.0, -5.0, 5.0])
+        m = _montage({"s1_d1_hbo": SimpleNamespace(trace=flat_center)})
+        assert hrf_panel._edge_unstable_channels(m) == []
+
+
+# ---------------------------------------------------------------------------
+# QC callout rendering
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeQcRender:
+    @pytest.mark.asyncio
+    async def test_warns_when_channels_flagged(self, user: User):
+        m = _montage({"s1_d1_hbo": SimpleNamespace(trace=_NOISY_EDGES)})
+        opts = hrf_panel.EstimationOptions(edge_expansion=0.2)
+
+        @ui.page("/_edge_qc")
+        def _p() -> None:
+            hrf_panel._render_edge_qc(m, opts)
+
+        await user.open("/_edge_qc")
+        await user.should_see("fluctuate more at the edges")
+        await user.should_see("Edge expansion")
+
+    @pytest.mark.asyncio
+    async def test_silent_when_all_stable(self, user: User):
+        m = _montage({"s1_d1_hbo": SimpleNamespace(trace=_CLEAN)})
+        opts = hrf_panel.EstimationOptions()
+
+        @ui.page("/_edge_qc_ok")
+        def _p() -> None:
+            hrf_panel._render_edge_qc(m, opts)
+            ui.label("sentinel-no-warning")
+
+        await user.open("/_edge_qc_ok")
+        await user.should_see("sentinel-no-warning")
+        await user.should_not_see("fluctuate more at the edges")
+
+    @pytest.mark.asyncio
+    async def test_sensitivity_is_configurable(self, user: User):
+        """A high flag-ratio silences the warning for the same montage."""
+        m = _montage({"s1_d1_hbo": SimpleNamespace(trace=_NOISY_EDGES)})
+        opts = hrf_panel.EstimationOptions(edge_std_ratio=50.0)
+
+        @ui.page("/_edge_qc_ratio")
+        def _p() -> None:
+            hrf_panel._render_edge_qc(m, opts)
+            ui.label("sentinel-ratio")
+
+        await user.open("/_edge_qc_ratio")
+        await user.should_see("sentinel-ratio")
+        await user.should_not_see("fluctuate more at the edges")
+
+
+# ---------------------------------------------------------------------------
+# Single-scan std-band note
+# ---------------------------------------------------------------------------
+
+
+class TestStdBandNote:
+    def test_all_zero_std_detected(self):
+        z = SimpleNamespace(trace=_CLEAN, trace_std=np.zeros(_CLEAN.size))
+        assert hrf_panel._std_is_all_zero(_montage({"s1_d1_hbo": z})) is True
+
+    def test_nonzero_std_detected(self):
+        nz = SimpleNamespace(trace=_CLEAN, trace_std=np.abs(_CLEAN) + 0.1)
+        assert hrf_panel._std_is_all_zero(_montage({"s1_d1_hbo": nz})) is False
+
+    @pytest.mark.asyncio
+    async def test_gallery_notes_absent_band_for_single_scan(self, user: User):
+        node = SimpleNamespace(
+            trace=_CLEAN, trace_std=np.zeros(_CLEAN.size), sfreq=10.0,
+        )
+        m = _montage({"s1_d1_hbo": node})
+
+        @ui.page("/_std_note")
+        def _p() -> None:
+            # The gallery only reads montage data, so state is unused here.
+            hrf_panel._render_toeplitz_gallery(None, m)
+
+        await user.open("/_std_note")
+        await user.should_see("No ±std band shown")

--- a/tests/test_gui_hrf_group_montage.py
+++ b/tests/test_gui_hrf_group_montage.py
@@ -1,0 +1,162 @@
+"""HRFs tab — project-wide GROUP montage (between-subject mean + std).
+
+A single scan's montage has one estimate per channel, so ``trace_std`` (the
+across-subject std) is 0. Pooling every estimated scan's montage into one group
+montage and re-distributing gives a real between-subject std band. Phase 1 does
+this in the GUI layer from the per-scan ``montage_cache`` (no core change).
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+pytest.importorskip("nicegui")
+
+from nicegui import ui  # noqa: E402
+from nicegui.testing import User  # noqa: E402
+
+from hrfunc.gui.components import hrf_panel  # noqa: E402
+from hrfunc.gui.state import AppState  # noqa: E402
+
+pytest_plugins = ["nicegui.testing.user_plugin"]
+
+
+class _FakeNode:
+    def __init__(self, estimate):
+        self.estimates = [list(estimate)] if estimate is not None else []
+        self.trace = None
+        self.trace_std = None
+        self.sfreq = 10.0
+
+
+class _FakeMontage:
+    """Duck-typed montage: just what _build_project_montage touches."""
+
+    def __init__(self, ch_to_estimate):
+        self.channels = {c: _FakeNode(e) for c, e in ch_to_estimate.items()}
+
+    def generate_distribution(self):
+        for n in self.channels.values():
+            if n.estimates:
+                n.trace = np.mean(n.estimates, axis=0)
+                n.trace_std = np.std(n.estimates, axis=0)
+
+
+# ---------------------------------------------------------------------------
+# Pooling
+# ---------------------------------------------------------------------------
+
+
+class TestBuildProjectMontage:
+    def test_pools_estimates_and_makes_std_nonzero(self):
+        m1 = _FakeMontage({"s1_d1_hbo": [1.0, 2.0, 3.0]})
+        m2 = _FakeMontage({"s1_d1_hbo": [3.0, 4.0, 5.0]})
+        group = hrf_panel._build_project_montage([m1, m2])
+        node = group.channels["s1_d1_hbo"]
+        assert len(node.estimates) == 2          # both subjects pooled
+        assert np.allclose(node.trace, [2.0, 3.0, 4.0])   # between-subject mean
+        assert np.all(node.trace_std > 0)        # real between-subject std
+
+    def test_unions_channels_across_subjects(self):
+        m1 = _FakeMontage({"s1_d1_hbo": [1.0, 1.0]})
+        m2 = _FakeMontage({"s1_d1_hbo": [3.0, 3.0], "s2_d1_hbo": [9.0, 9.0]})
+        group = hrf_panel._build_project_montage([m1, m2])
+        # Channel only subject 2 had still appears (with its one estimate).
+        assert "s2_d1_hbo" in group.channels
+        assert len(group.channels["s2_d1_hbo"].estimates) == 1
+
+    def test_none_when_empty_or_canonical_only(self):
+        assert hrf_panel._build_project_montage([]) is None
+        canon = hrf_panel._CanonicalResult(
+            canonical_trace=np.zeros(5), duration=1.0, sfreq=10.0
+        )
+        assert hrf_panel._build_project_montage([canon]) is None
+
+    def test_does_not_mutate_source_montages(self):
+        m1 = _FakeMontage({"s1_d1_hbo": [1.0, 2.0]})
+        m2 = _FakeMontage({"s1_d1_hbo": [3.0, 4.0]})
+        hrf_panel._build_project_montage([m1, m2])
+        # Sources keep their single estimate (pooling worked on a copy).
+        assert len(m1.channels["s1_d1_hbo"].estimates) == 1
+        assert len(m2.channels["s1_d1_hbo"].estimates) == 1
+
+
+class TestRebuildFromCache:
+    def test_rebuild_reads_cache_and_skips_reestimated_duplicates(self):
+        state = AppState()
+        from pathlib import Path
+        # Two scans cached; re-estimating scan A replaces its cache entry,
+        # so the rebuilt group always has exactly one estimate per scan.
+        state.montage_cache[Path("/a")] = _FakeMontage({"c": [1.0, 1.0]})
+        state.montage_cache[Path("/b")] = _FakeMontage({"c": [3.0, 3.0]})
+        hrf_panel._rebuild_project_montage(state)
+        assert len(state.project_montage.channels["c"].estimates) == 2
+        # "Re-estimate" scan A -> overwrite its cache entry, rebuild.
+        state.montage_cache[Path("/a")] = _FakeMontage({"c": [2.0, 2.0]})
+        hrf_panel._rebuild_project_montage(state)
+        assert len(state.project_montage.channels["c"].estimates) == 2  # not 3
+
+
+# ---------------------------------------------------------------------------
+# Group preview rendering
+# ---------------------------------------------------------------------------
+
+
+class TestGroupPreview:
+    @pytest.mark.asyncio
+    async def test_group_view_shows_between_subject_band(self, user: User):
+        state = AppState()
+        from pathlib import Path
+        state.montage_cache[Path("/a")] = _FakeMontage(
+            {"s1_d1_hbo": [0.0, 2.0, 5.0, 2.0, 0.0]}
+        )
+        state.montage_cache[Path("/b")] = _FakeMontage(
+            {"s1_d1_hbo": [0.0, 1.0, 4.0, 3.0, 1.0]}
+        )
+        hrf_panel._rebuild_project_montage(state)
+        # Rely on the default (group view shown automatically when available).
+        assert AppState().hrf_preview_group is True
+        opts = hrf_panel.EstimationOptions()
+
+        @ui.page("/_group")
+        def _p() -> None:
+            hrf_panel._render_preview_column(
+                state, None, opts, bulk_mode=False
+            )
+
+        await user.open("/_group")
+        await user.should_see("Group (2 subjects)")        # the toggle
+        await user.should_see("between-subject ± std")     # group header
+        await user.should_see("Save group HRFs")           # save action
+        # The single-scan "no band" note must NOT appear (std is real now).
+        await user.should_not_see("No ±std band shown")
+
+
+class TestGroupSubjects:
+    def test_subject_names_map_to_manifest(self, tmp_path):
+        from hrfunc.io.manifest import Manifest, ScanEntry
+
+        state = AppState()
+        s1 = ScanEntry(format="snirf", path=tmp_path / "a.snirf",
+                       display_name="subj-A")
+        s2 = ScanEntry(format="snirf", path=tmp_path / "b.snirf",
+                       display_name="subj-B")
+        state.manifest = Manifest(root=tmp_path, scans=(s1, s2))
+        state.montage_cache[s1.path.resolve()] = _FakeMontage({"c": [1.0]})
+        state.montage_cache[s2.path.resolve()] = _FakeMontage({"c": [2.0]})
+        assert hrf_panel._group_subject_names(state) == ["subj-A", "subj-B"]
+
+    def test_canonical_entries_excluded_from_names(self, tmp_path):
+        from hrfunc.io.manifest import Manifest, ScanEntry
+
+        state = AppState()
+        s1 = ScanEntry(format="snirf", path=tmp_path / "a.snirf",
+                       display_name="subj-A")
+        state.manifest = Manifest(root=tmp_path, scans=(s1,))
+        state.montage_cache[s1.path.resolve()] = _FakeMontage({"c": [1.0]})
+        state.montage_cache[(tmp_path / "canon.snirf").resolve()] = (
+            hrf_panel._CanonicalResult(
+                canonical_trace=np.zeros(3), duration=1.0, sfreq=10.0
+            )
+        )
+        assert hrf_panel._group_subject_names(state) == ["subj-A"]

--- a/tests/test_gui_hrf_group_montage.py
+++ b/tests/test_gui_hrf_group_montage.py
@@ -51,31 +51,34 @@ class TestBuildProjectMontage:
     def test_pools_estimates_and_makes_std_nonzero(self):
         m1 = _FakeMontage({"s1_d1_hbo": [1.0, 2.0, 3.0]})
         m2 = _FakeMontage({"s1_d1_hbo": [3.0, 4.0, 5.0]})
-        group = hrf_panel._build_project_montage([m1, m2])
+        group = hrf_panel._build_project_montage([("subjA", m1), ("subjB", m2)])
         node = group.channels["s1_d1_hbo"]
         assert len(node.estimates) == 2          # both subjects pooled
         assert np.allclose(node.trace, [2.0, 3.0, 4.0])   # between-subject mean
         assert np.all(node.trace_std > 0)        # real between-subject std
+        # Provenance: each pooled estimate tagged by its source scan.
+        assert node.estimate_sources == ["subjA", "subjB"]
 
     def test_unions_channels_across_subjects(self):
         m1 = _FakeMontage({"s1_d1_hbo": [1.0, 1.0]})
         m2 = _FakeMontage({"s1_d1_hbo": [3.0, 3.0], "s2_d1_hbo": [9.0, 9.0]})
-        group = hrf_panel._build_project_montage([m1, m2])
+        group = hrf_panel._build_project_montage([("a", m1), ("b", m2)])
         # Channel only subject 2 had still appears (with its one estimate).
         assert "s2_d1_hbo" in group.channels
         assert len(group.channels["s2_d1_hbo"].estimates) == 1
+        assert group.channels["s2_d1_hbo"].estimate_sources == ["b"]
 
     def test_none_when_empty_or_canonical_only(self):
         assert hrf_panel._build_project_montage([]) is None
         canon = hrf_panel._CanonicalResult(
             canonical_trace=np.zeros(5), duration=1.0, sfreq=10.0
         )
-        assert hrf_panel._build_project_montage([canon]) is None
+        assert hrf_panel._build_project_montage([("c", canon)]) is None
 
     def test_does_not_mutate_source_montages(self):
         m1 = _FakeMontage({"s1_d1_hbo": [1.0, 2.0]})
         m2 = _FakeMontage({"s1_d1_hbo": [3.0, 4.0]})
-        hrf_panel._build_project_montage([m1, m2])
+        hrf_panel._build_project_montage([("a", m1), ("b", m2)])
         # Sources keep their single estimate (pooling worked on a copy).
         assert len(m1.channels["s1_d1_hbo"].estimates) == 1
         assert len(m2.channels["s1_d1_hbo"].estimates) == 1
@@ -160,3 +163,20 @@ class TestGroupSubjects:
             )
         )
         assert hrf_panel._group_subject_names(state) == ["subj-A"]
+
+
+class TestGroupExclusion:
+    def test_excluding_a_subject_drops_it_from_the_pool(self):
+        from pathlib import Path
+        state = AppState()
+        state.montage_cache[Path("/a")] = _FakeMontage({"c": [1.0, 1.0]})
+        state.montage_cache[Path("/b")] = _FakeMontage({"c": [3.0, 3.0]})
+        state.montage_cache[Path("/c")] = _FakeMontage({"c": [5.0, 5.0]})
+        hrf_panel._rebuild_project_montage(state)
+        assert len(state.project_montage.channels["c"].estimates) == 3
+
+        state.project_group_excluded.add(Path("/b"))
+        hrf_panel._rebuild_project_montage(state)
+        node = state.project_montage.channels["c"]
+        assert len(node.estimates) == 2
+        assert "/b" not in node.estimate_sources   # provenance reflects removal

--- a/tests/test_gui_hrf_save_submit.py
+++ b/tests/test_gui_hrf_save_submit.py
@@ -1,0 +1,122 @@
+"""HRFs tab — Save button + submission section placement.
+
+Layout change: the Save button moved next to the Estimate button (popping in
+only when there's a real montage to save), and the submission form moved
+directly below Estimate and is now ALWAYS present — including the no-scan
+empty state — so a user can share an existing HRF JSON without estimating
+first.
+
+Helpers are rendered in isolation (rather than through the full shell)
+because the submission form also appears on the Export tab, so a whole-page
+assertion couldn't tell the two placements apart; and because the right-
+column preview can't render against a stub montage.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+pytest.importorskip("nicegui")
+
+from nicegui import ui  # noqa: E402
+from nicegui.testing import User  # noqa: E402
+
+from hrfunc.gui.components import hrf_panel  # noqa: E402
+from hrfunc.gui.state import AppState  # noqa: E402
+from hrfunc.io.manifest import Manifest, ScanEntry  # noqa: E402
+
+pytest_plugins = ["nicegui.testing.user_plugin"]
+
+
+def _scan(tmp_path):
+    return ScanEntry(format="snirf", path=tmp_path / "a.snirf",
+                     display_name="SCANALPHA")
+
+
+# ---------------------------------------------------------------------------
+# Submission section — always present, including the empty state
+# ---------------------------------------------------------------------------
+
+
+class TestSubmissionAlwaysPresent:
+    @pytest.mark.asyncio
+    async def test_present_in_no_scan_empty_state(self, user: User, tmp_path):
+        state = AppState()
+        state.manifest = Manifest(root=tmp_path, scans=(_scan(tmp_path),))
+        # No selected scan, nothing ticked -> empty state.
+
+        @ui.page("/_hrf_empty")
+        def _p() -> None:
+            hrf_panel.render(state)
+
+        await user.open("/_hrf_empty")
+        await user.should_see("Select a scan to start estimating HRFs")
+        # The submission form is rendered even with no scan selected.
+        await user.should_see("Submit HRFs to the HRtree")
+
+
+# ---------------------------------------------------------------------------
+# Save button — pops in beside Estimate only when there's a montage to save
+# ---------------------------------------------------------------------------
+
+
+def _run_row_page(state: AppState, scan, route: str) -> None:
+    opts = hrf_panel.EstimationOptions()
+
+    @ui.page(route)
+    def _p() -> None:
+        hrf_panel._render_run_row(state, scan, [], opts)
+
+
+class TestSaveButtonBesideEstimate:
+    @pytest.mark.asyncio
+    async def test_hidden_without_montage(self, user: User, tmp_path):
+        state = AppState()
+        scan = _scan(tmp_path)
+        state.selected_scan = scan
+        assert state.montage is None
+        _run_row_page(state, scan, "/_rr_none")
+
+        await user.open("/_rr_none")
+        await user.should_see("Estimate HRFs")
+        await user.should_not_see("Save")
+
+    @pytest.mark.asyncio
+    async def test_shown_with_real_montage(self, user: User, tmp_path):
+        state = AppState()
+        scan = _scan(tmp_path)
+        state.selected_scan = scan
+        # A non-None, non-canonical montage stub is enough to surface Save
+        # (the click handler resolves the real montage lazily).
+        state.montage = object()
+        _run_row_page(state, scan, "/_rr_real")
+
+        await user.open("/_rr_real")
+        await user.should_see("Estimate HRFs")
+        await user.should_see("Save")
+
+    @pytest.mark.asyncio
+    async def test_hidden_for_canonical_result(self, user: User, tmp_path):
+        state = AppState()
+        scan = _scan(tmp_path)
+        state.selected_scan = scan
+        # Canonical mode has no per-channel estimates to save.
+        state.montage = hrf_panel._CanonicalResult(
+            canonical_trace=np.zeros(10), duration=1.0, sfreq=10.0
+        )
+        _run_row_page(state, scan, "/_rr_canon")
+
+        await user.open("/_rr_canon")
+        await user.should_not_see("Save")
+
+    @pytest.mark.asyncio
+    async def test_hidden_while_busy(self, user: User, tmp_path):
+        state = AppState()
+        scan = _scan(tmp_path)
+        state.selected_scan = scan
+        state.montage = object()
+        state.busy = True  # mid-run: Save shouldn't appear yet
+        _run_row_page(state, scan, "/_rr_busy")
+
+        await user.open("/_rr_busy")
+        await user.should_not_see("Save")

--- a/tests/test_gui_hrtree_roi_detail.py
+++ b/tests/test_gui_hrtree_roi_detail.py
@@ -1,0 +1,56 @@
+"""HRtree detail pane — lead with the active ROI's HRF when an ROI is selected.
+
+The detail right column used to always show the single clicked HRF (with the
+ROI average tucked below). Now, when the user SELECTS an ROI, it leads with
+the ROI's aggregate HRF instead. ``_showing_active_roi`` is the gate that
+distinguishes "an ROI is selected" from "a lone HRF was clicked".
+"""
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("nicegui")
+
+from hrfunc.gui.components import hrtree_panel  # noqa: E402
+from hrfunc.gui.state import AppState, ROISlot  # noqa: E402
+
+
+class TestShowingActiveRoi:
+    def test_false_when_no_rois(self):
+        state = AppState()
+        assert hrtree_panel._showing_active_roi(state) is False
+
+    def test_true_when_selection_is_active_anchor(self):
+        state = AppState()
+        anchor = {"_key": "hbo:roi1", "oxygenation": True, "hrf_mean": [1.0]}
+        state.cluster_rois = [ROISlot(name="ROI 1", anchor=anchor)]
+        state.cluster_active_index = 0
+        # Selecting an ROI re-seeds the selection to its anchor (same object).
+        state.library_selected_hrf = anchor
+        assert hrtree_panel._showing_active_roi(state) is True
+
+    def test_true_when_anchorless_roi_and_no_selection(self):
+        state = AppState()
+        # Shape-only ROI with no anchor; selecting it leaves selection None.
+        state.cluster_rois = [ROISlot(name="ROI 1", anchor=None)]
+        state.cluster_active_index = 0
+        state.library_selected_hrf = None
+        assert hrtree_panel._showing_active_roi(state) is True
+
+    def test_false_when_inspecting_a_different_hrf(self):
+        state = AppState()
+        anchor = {"_key": "hbo:roi1", "oxygenation": True, "hrf_mean": [1.0]}
+        state.cluster_rois = [ROISlot(name="ROI 1", anchor=anchor)]
+        state.cluster_active_index = 0
+        # User clicked a DIFFERENT individual HRF (a fresh dict, not the anchor).
+        state.library_selected_hrf = {
+            "_key": "hbo:other", "oxygenation": True, "hrf_mean": [2.0]
+        }
+        assert hrtree_panel._showing_active_roi(state) is False
+
+
+class TestRenderActiveRoiDetailGuard:
+    def test_returns_false_when_no_active_roi(self):
+        # No rendering context needed: bails before any ui.* call.
+        state = AppState()
+        assert hrtree_panel._render_active_roi_detail(state) is False

--- a/tests/test_gui_library.py
+++ b/tests/test_gui_library.py
@@ -1289,6 +1289,35 @@ async def test_viz_pane_refreshes_on_selection_change(user: User):
     assert len(selection_subs) >= 1
 
 
+async def test_rapid_selection_changes_do_not_orphan_viz_timer(
+    user: User, caplog
+):
+    """Regression: clicking through HRFs faster than the 0.05 s deferred viz
+    refresh used to orphan a ``once=True`` timer — an intervening
+    ``_viz_body.refresh()`` deleted the slot the pending timer was parented to,
+    so it fired into a dead slot and raised "parent slot of the element has
+    been deleted". The deferred timer now lives on a stable anchor element
+    (outside the refreshable body) and dedupes, so the churn can't orphan it.
+
+    The deferred refresh fires ``_viz_body.refresh()``; publishing the event in
+    a rapid burst then letting the timers run exercises that path.
+    """
+    import asyncio
+    import logging
+
+    global_state.reset()
+    _silent(library._load_trees, global_state)
+    _mount_hrtree_route()
+    await user.open("/_test_hrtree")
+
+    with caplog.at_level(logging.ERROR):
+        for _ in range(6):
+            global_state.publish("hrtree_selection_changed", [])
+        await asyncio.sleep(0.2)  # let the 0.05 s deferred timer(s) fire
+
+    assert "parent slot" not in caplog.text
+
+
 async def test_cluster_subtab_exposes_atlas_shape_option(user: User):
     """When the bundled Harvard-Oxford atlas loads, the per-row shape
     dropdown lets each ROI pick between Sphere and Atlas region.

--- a/tests/test_gui_shell.py
+++ b/tests/test_gui_shell.py
@@ -145,10 +145,27 @@ async def test_empty_state_appears_on_data_tabs(user: User):
 
 
 async def test_empty_state_has_open_folder_button(user: User):
-    """The empty-state's single CTA is "Open folder" — same picker as
+    """The empty-state's primary CTA is "Open folder" — same picker as
     the toolbar dropdown."""
     await user.open("/")
     await user.should_see("Open folder")
+
+
+def test_demo_data_path_resolves_to_bundled_snirf():
+    """In a source checkout, the demo button targets the bundled SNIRF folder."""
+    from hrfunc.gui.pages import shell
+
+    path = shell._demo_data_path()
+    assert path is not None
+    assert path.name == "sNIRF_formatted"
+    assert any(path.glob("*.snirf"))
+
+
+async def test_empty_state_shows_demo_button(user: User):
+    """When the bundled sample data is present, the empty-state offers a
+    rock-paper-scissors demo alongside Open folder."""
+    await user.open("/")
+    await user.should_see("rock-paper-scissors demo")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_hrtree_match.py
+++ b/tests/test_hrtree_match.py
@@ -1,0 +1,231 @@
+"""Channel -> HRtree HRF matching for per-channel Activity deconvolution."""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+pytest.importorskip("mne")
+import mne  # noqa: E402
+
+from hrfunc.gui.components import hrtree_match  # noqa: E402
+from hrfunc.gui.state import AppState  # noqa: E402
+
+
+def _raw(locs):
+    """4 fNIRS channels (S1/S2 × hbo/hbr) at the given source-pair locations
+    (meters). ``locs`` is {'S1': (x,y,z), 'S2': (x,y,z)}."""
+    ch_names = ["S1_D1 hbo", "S1_D1 hbr", "S2_D1 hbo", "S2_D1 hbr"]
+    raw = mne.io.RawArray(
+        np.zeros((4, 10)), mne.create_info(ch_names, 10.0, "hbo"),
+        verbose="ERROR",
+    )
+    pair = {0: "S1", 1: "S1", 2: "S2", 3: "S2"}
+    for i, ch in enumerate(raw.info["chs"]):
+        ch["loc"][:3] = locs[pair[i]]
+    return raw
+
+
+def _hrf(loc, oxygenation, trace=(0.0, 0.5, 1.0, 0.5)):
+    return {"location": list(loc), "hrf_mean": list(trace),
+            "oxygenation": oxygenation}
+
+
+@pytest.fixture
+def patched(monkeypatch):
+    """Stub the HRtree data sources so only the matching geometry is tested."""
+    from hrfunc.gui.components import hrtree_panel
+
+    state = AppState()
+
+    # One HbO and one HbR HRF 5 mm from the S1 source pair (which sits at
+    # 0.05 m below — origin is treated as "unplaced", so keep it non-zero).
+    hrfs = {
+        "hbo:near_s1": _hrf((0.055, 0.0, 0.0), True, (0.1, 0.9, 0.3)),
+        "hbr:near_s1": _hrf((0.055, 0.0, 0.0), False, (0.2, 0.8, 0.2)),
+    }
+    monkeypatch.setattr(hrtree_panel, "gather_library_hrfs",
+                        lambda _st: hrfs)
+    monkeypatch.setattr(
+        hrtree_panel, "_visible_roi_keys",
+        lambda _st, _matched: (set(hrfs.keys()), [("slot", "shape")]),
+    )
+    return state
+
+
+class TestIndividualStrategy:
+    def test_near_channels_covered_far_uncovered(self, patched):
+        # S1 at origin (5 mm from the HRFs), S2 100 mm away.
+        raw = _raw({"S1": (0.05, 0.0, 0.0), "S2": (0.15, 0.0, 0.0)})
+        res = hrtree_match.match_channels_to_hrtree(
+            patched, raw, strategy="individual", radius_mm=20.0,
+        )
+        covered = {m.ch_name for m in res.covered}
+        uncovered = {m.ch_name for m in res.uncovered}
+        assert covered == {"s1_d1_hbo", "s1_d1_hbr"}
+        assert uncovered == {"s2_d1_hbo", "s2_d1_hbr"}
+        assert res.n_candidate_hrfs == 2
+
+    def test_oxygenation_respected_in_trace(self, patched):
+        raw = _raw({"S1": (0.05, 0.0, 0.0), "S2": (0.15, 0.0, 0.0)})
+        res = hrtree_match.match_channels_to_hrtree(
+            patched, raw, strategy="individual", radius_mm=20.0,
+        )
+        traces = res.library_traces()
+        # HbO channel got the HbO HRF's trace, HbR got the HbR's.
+        assert traces["s1_d1_hbo"] == [0.1, 0.9, 0.3]
+        assert traces["s1_d1_hbr"] == [0.2, 0.8, 0.2]
+
+    def test_radius_controls_coverage(self, patched):
+        raw = _raw({"S1": (0.05, 0.0, 0.0), "S2": (0.15, 0.0, 0.0)})
+        # 100 mm radius now reaches S2 (95 mm away).
+        res = hrtree_match.match_channels_to_hrtree(
+            patched, raw, strategy="individual", radius_mm=100.0,
+        )
+        assert {m.ch_name for m in res.covered} == {
+            "s1_d1_hbo", "s1_d1_hbr", "s2_d1_hbo", "s2_d1_hbr"
+        }
+
+    def test_channel_without_location_is_uncovered(self, patched):
+        raw = _raw({"S1": (0.0, 0.0, 0.0), "S2": (0.0, 0.0, 0.0)})
+        # Zero out S2's location entirely -> unmatched on geometry grounds.
+        for ch in raw.info["chs"]:
+            if "S2" in ch["ch_name"]:
+                ch["loc"][:3] = [0.0, 0.0, 0.0]
+        res = hrtree_match.match_channels_to_hrtree(
+            patched, raw, strategy="individual", radius_mm=500.0,
+        )
+        uncovered = {m.ch_name for m in res.uncovered}
+        assert "s2_d1_hbo" in uncovered and "s2_d1_hbr" in uncovered
+
+    def test_library_traces_only_covered(self, patched):
+        raw = _raw({"S1": (0.05, 0.0, 0.0), "S2": (0.15, 0.0, 0.0)})
+        res = hrtree_match.match_channels_to_hrtree(
+            patched, raw, strategy="individual", radius_mm=20.0,
+        )
+        assert set(res.library_traces().keys()) == {"s1_d1_hbo", "s1_d1_hbr"}
+
+
+class TestRoiMeanStrategy:
+    def test_roi_mean_assigns_roi_trace(self, monkeypatch):
+        from hrfunc.gui.components import hrtree_panel
+
+        state = AppState()
+        hrfs = {
+            "hbo:a": _hrf((0.0, 0.0, 0.0), True),
+            "hbo:b": _hrf((0.01, 0.0, 0.0), True),
+        }
+        monkeypatch.setattr(hrtree_panel, "gather_library_hrfs",
+                            lambda _st: hrfs)
+
+        class _Slot:
+            name = "ROI 1"
+            anchor = {"oxygenation": True, "hrf_mean": [9.0, 9.0]}
+            painted = set()
+
+        monkeypatch.setattr(hrtree_panel, "_visible_shapes",
+                            lambda _st: [(_Slot(), "shape")])
+        monkeypatch.setattr(hrtree_panel, "_alignment_for_shape",
+                            lambda _st, _sh: None)
+        monkeypatch.setattr(hrtree_panel, "compute_roi_keys_by_shape",
+                            lambda *a, **k: set(hrfs.keys()))
+        # Pretend subject-weighted averaging isn't available -> anchor fallback.
+        monkeypatch.setattr(hrtree_panel, "compute_roi_average",
+                            lambda *a, **k: None)
+
+        raw = _raw({"S1": (0.005, 0.0, 0.0), "S2": (0.5, 0.0, 0.0)})
+        res = hrtree_match.match_channels_to_hrtree(
+            state, raw, strategy="roi_mean", radius_mm=50.0,
+        )
+        # S1 hbo is within 50 mm of the ROI centroid (~5 mm); gets anchor trace.
+        traces = res.library_traces()
+        assert traces.get("s1_d1_hbo") == [9.0, 9.0]
+        assert res.n_rois == 1
+
+    def test_roi_mean_is_oxygenation_pure(self, monkeypatch):
+        """An ROI spanning both haemoglobins yields a SEPARATE mean per
+        oxygenation; HbO channels get the HbO mean, HbR channels the HbR mean
+        — never a mix (HbO/HbR are inverses; pooling cancels them)."""
+        from hrfunc.gui.components import hrtree_panel
+
+        state = AppState()
+        hrfs = {
+            "hbo:a": _hrf((0.05, 0.0, 0.0), True, (1.0, 1.0)),
+            "hbr:a": _hrf((0.05, 0.0, 0.0), False, (2.0, 2.0)),
+        }
+        monkeypatch.setattr(hrtree_panel, "gather_library_hrfs",
+                            lambda _st: hrfs)
+
+        class _Slot:
+            name = "ROI 1"
+            anchor = None
+            painted = set()
+
+        monkeypatch.setattr(hrtree_panel, "_visible_shapes",
+                            lambda _st: [(_Slot(), "shape")])
+        monkeypatch.setattr(hrtree_panel, "_alignment_for_shape",
+                            lambda _st, _sh: None)
+
+        def _keys(_all, _shape, _painted, oxygenation_filter=None, **_k):
+            if oxygenation_filter is True:
+                return {"hbo:a"}
+            if oxygenation_filter is False:
+                return {"hbr:a"}
+            return set(hrfs.keys())
+
+        monkeypatch.setattr(hrtree_panel, "compute_roi_keys_by_shape", _keys)
+
+        def _avg(all_hrfs, keys):
+            traces = [all_hrfs[k]["hrf_mean"] for k in keys]
+            arr = np.mean(np.asarray(traces, dtype=float), axis=0)
+            return arr, None, len(traces), len(traces)
+
+        monkeypatch.setattr(hrtree_panel, "compute_roi_average", _avg)
+
+        raw = _raw({"S1": (0.05, 0.0, 0.0), "S2": (0.5, 0.0, 0.0)})
+        res = hrtree_match.match_channels_to_hrtree(
+            state, raw, strategy="roi_mean", radius_mm=50.0,
+        )
+        traces = res.library_traces()
+        assert traces["s1_d1_hbo"] == [1.0, 1.0]   # HbO-only mean
+        assert traces["s1_d1_hbr"] == [2.0, 2.0]   # HbR-only mean, not mixed
+
+
+class TestFiltersScopeCandidates:
+    def test_oxygenation_filter_excludes_other_haemoglobin(self, patched):
+        """'HbR only' drops the HbO HRF from the candidate set, so the HbO
+        channel becomes uncovered — the oxygenation choice scopes matching."""
+        patched.library_oxygenation = "hbr"
+        raw = _raw({"S1": (0.05, 0.0, 0.0), "S2": (0.5, 0.0, 0.0)})
+        res = hrtree_match.match_channels_to_hrtree(
+            patched, raw, strategy="individual", radius_mm=20.0,
+        )
+        covered = {m.ch_name for m in res.covered}
+        assert "s1_d1_hbo" not in covered
+        assert "s1_d1_hbr" in covered
+
+    def test_context_filter_excludes_nonmatching_hrfs(self, monkeypatch):
+        """A context filter (e.g. task) constrains the candidate HRFs exactly
+        as it constrains the Cluster view — Filter and Cluster are
+        complementary."""
+        from hrfunc.gui.components import hrtree_panel
+
+        state = AppState()
+        state.library_filter = {"task": "flanker"}
+        hrfs = {
+            "hbo:rest": {
+                **_hrf((0.055, 0.0, 0.0), True),
+                "context": {"task": "rest"},  # does NOT match 'flanker'
+            },
+        }
+        monkeypatch.setattr(hrtree_panel, "gather_library_hrfs",
+                            lambda _st: hrfs)
+        monkeypatch.setattr(
+            hrtree_panel, "_visible_roi_keys",
+            lambda _st, _m: (set(hrfs.keys()), [("slot", "shape")]),
+        )
+        raw = _raw({"S1": (0.05, 0.0, 0.0), "S2": (0.5, 0.0, 0.0)})
+        res = hrtree_match.match_channels_to_hrtree(
+            state, raw, strategy="individual", radius_mm=50.0,
+        )
+        assert res.n_candidate_hrfs == 0
+        assert all(not m.matched for m in res.matches)

--- a/tests/test_montage_provenance.py
+++ b/tests/test_montage_provenance.py
@@ -1,0 +1,142 @@
+"""Core HRF estimate provenance — estimate_sources keyed per scan.
+
+Each estimate carries a ``source_id`` so a multi-subject (group) montage can
+report and remove a specific subject's contribution, including after a
+save/load round-trip. Re-estimating the same source replaces (not duplicates)
+its estimate.
+"""
+from __future__ import annotations
+
+import io
+import sys
+
+import numpy as np
+import pytest
+
+pytest.importorskip("mne")
+import mne  # noqa: E402
+
+from hrfunc.hrtree import HRF  # noqa: E402
+
+
+def _silence(fn, *a, **k):
+    out = sys.stdout
+    sys.stdout = io.StringIO()
+    try:
+        return fn(*a, **k)
+    finally:
+        sys.stdout = out
+
+
+# ---------------------------------------------------------------------------
+# HRF node storage
+# ---------------------------------------------------------------------------
+
+
+class TestHrfNodeSources:
+    def test_sources_stored(self):
+        n = HRF("doi", "S1_D1 hbo", 10.0, 10.0, [0.0, 1.0, 2.0],
+                estimates=[[1.0, 2.0]], estimate_sources=["subjA"])
+        assert n.estimate_sources == ["subjA"]
+
+    def test_sources_pad_to_estimate_length(self):
+        # Estimates predating provenance (e.g. bundled HRFs) -> pad with None.
+        n = HRF("doi", "S1_D1 hbo", 10.0, 10.0, [0.0, 1.0],
+                estimates=[[1.0], [2.0], [3.0]], estimate_sources=["subjA"])
+        assert n.estimate_sources == ["subjA", None, None]
+
+    def test_default_empty(self):
+        n = HRF("doi", "S1_D1 hbo", 10.0, 10.0, [0.0, 1.0])
+        assert n.estimate_sources == []
+
+
+# ---------------------------------------------------------------------------
+# Integration: estimate_hrf provenance + remove_source + save/load
+# ---------------------------------------------------------------------------
+
+
+def _raw(seed=0):
+    raw = mne.io.RawArray(
+        np.random.default_rng(seed).standard_normal((2, 200)) * 1e-6,
+        mne.create_info(["S1_D1 hbo", "S1_D1 hbr"], 10.0, "hbo"),
+        verbose="ERROR",
+    )
+    for i, ch in enumerate(raw.info["chs"]):
+        ch["loc"][:3] = [i * 0.01, 0.0, 0.0]
+    return raw
+
+
+def _events(n=200):
+    e = [0] * n
+    for t in (20, 80, 140):
+        e[t] = 1
+    return e
+
+
+def _two_subject_montage():
+    from hrfunc.hrfunc import montage
+
+    raw_a, raw_b = _raw(seed=0), _raw(seed=1)  # distinct subjects
+    m = _silence(montage, nirx_obj=raw_a)
+    _silence(m.estimate_hrf, raw_a, _events(), duration=10.0,
+             source_id="subjA", preprocess=False)
+    _silence(m.estimate_hrf, raw_b, _events(), duration=10.0,
+             source_id="subjB", preprocess=False)
+    return m
+
+
+@pytest.mark.integration
+class TestEstimateHrfProvenance:
+    def test_reestimating_same_source_replaces(self):
+        from hrfunc.hrfunc import montage
+
+        raw = _raw()
+        m = _silence(montage, nirx_obj=raw)
+        _silence(m.estimate_hrf, raw, _events(), duration=10.0,
+                 source_id="subjA", preprocess=False)
+        _silence(m.estimate_hrf, raw, _events(), duration=10.0,
+                 source_id="subjA", preprocess=False)  # same source again
+        node = m.channels["s1_d1_hbo"]
+        assert len(node.estimates) == 1                 # not double-counted
+        assert node.estimate_sources == ["subjA"]
+
+    def test_different_sources_accumulate(self):
+        node = _two_subject_montage().channels["s1_d1_hbo"]
+        assert len(node.estimates) == 2
+        assert node.estimate_sources == ["subjA", "subjB"]
+
+
+@pytest.mark.integration
+class TestRemoveSource:
+    def test_remove_drops_subject_and_regenerates(self):
+        m = _two_subject_montage()
+        _silence(m.generate_distribution)
+        before = np.array(m.channels["s1_d1_hbo"].trace_std)
+        assert np.any(before > 0)                       # 2 subjects -> real std
+
+        removed = m.remove_source("subjA")
+        assert removed >= 1
+        node = m.channels["s1_d1_hbo"]
+        assert node.estimate_sources == ["subjB"]
+        assert len(node.estimates) == 1
+        # Down to one subject -> std collapses to 0 after the regenerate.
+        assert np.allclose(node.trace_std, 0.0)
+
+
+@pytest.mark.integration
+class TestSaveLoadProvenance:
+    def test_round_trip_preserves_sources(self, tmp_path):
+        from hrfunc.hrfunc import load_montage
+
+        m = _two_subject_montage()
+        _silence(m.generate_distribution)
+        path = tmp_path / "group_hrfs.json"
+        _silence(m.save, str(path))
+
+        loaded = _silence(load_montage, str(path), rich=True)
+        all_sources = [
+            s for node in loaded.channels.values()
+            for s in getattr(node, "estimate_sources", [])
+        ]
+        assert "subjA" in all_sources
+        assert "subjB" in all_sources


### PR DESCRIPTION
A cohesive arc of HRFs / Activity / HRtree work. Full test suite green except the 4 long-standing pre-existing failures (event-picker `processed_deconvolved` gap, `automatch_bids_strict`, 2× `progress_callback` last-param). New code is lint-clean.

> **Heads-up:** this branch also contains the HRtree deferred-timer fix that's up separately as **#73**. Merge #73 first, then I'll rebase this on `main` and the duplicate timer-fix hunks drop out cleanly.

## Per-channel HRtree deconvolution (core + GUI)
- `estimate_activity` gains `library_traces` (per-channel HRtree map) + `library_uncovered` (`skip` drops unmatched channels for honest coverage; `canonical` falls back). The single-kernel `library_trace` path is unchanged.
- **New** `gui/components/hrtree_match.py`: matches each scan channel to a nearby HRtree HRF in head coords (no MNI alignment) — **Nearest-HRF** or **ROI-mean** strategy, oxygenation-pure, scoped by the context filter + HbO/HbR choice.
- Activity right column: coverage counts (`X/Y covered`), a per-channel assignment column, and strategy / radius / skip-vs-canonical controls.

## Project-wide GROUP montage (Phases 1–3)
- `state.project_montage` pools the per-scan `montage_cache` into one montage and re-distributes, so `trace_std` becomes the genuine **between-subject** std. (Root cause: the GUI estimated each scan into its own throwaway montage, so the cross-subject `generate_distribution` never happened — single-scan `trace_std` is always 0.)
- HRFs preview: **"This scan / Group (N subjects)"** toggle (group is the **default** when ≥2 subjects), contributing-scans readout, **Save group HRFs**.
- Activity: **"Each scan's own HRFs / Group HRFs (N)"** mode (via a `_montage_for_scan` short-circuit), so a group HRF can deconvolve scans never individually estimated.

## HRtree page
- HbO/HbR/Both oxygenation control moved **above** the Filter/Cluster sub-tabs so it scopes both; the matcher honors the same filters (Filter and Cluster are complementary).
- Detail pane leads with the **active ROI's aggregate HRF** when an ROI is selected.

## HRFs-page UX
- Bulk **"Preprocess all checked"** affordance; **Save** beside Estimate; submission form below Estimate, always present.
- **Edge-expansion** control (default 0.2) wired to `estimate_hrf`; post-estimation **edge-instability QC** (configurable window/ratio) measuring the trace's own edge-vs-center variability; single-scan "no ±std band" explanatory note.
- Empty-state "Select a scan" disclaimer; **"Try the rock-paper-scissors demo"** button loading the bundled sample SNIRF data.

## Deferred (follow-up)
Core estimate **provenance** (estimates keyed by scan) — only needed for *cross-session* group management once a saved group montage is reloaded; in-session re-estimation already de-dups via the cache key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
