### PR TITLE
fix: land HRtree oxygenation + Activity group-only tail (stranded from #74)

### DIFF
--- a/src/hrfunc/gui/components/activity_panel.py
+++ b/src/hrfunc/gui/components/activity_panel.py
@@ -761,99 +761,35 @@ def _render_estimated_source_status(
 ) -> None:
     """Status + preview for the "Estimated HRFs" (toeplitz) source.
 
-    HRFs are cached per scan (``state.montage_cache``), so each scan is
-    deconvolved with its OWN HRFs — single or bulk. Reports this scan's
-    readiness (single mode) or a batch summary (bulk mode).
-
-    When a pooled group montage exists (≥2 subjects estimated on the HRFs
-    tab), a toggle lets the user deconvolve every scan with the GROUP HRFs
-    instead — matched by channel name, so it also covers scans that weren't
-    individually estimated.
+    Deconvolution with estimated HRFs uses the GROUP montage — the >=2-subject
+    pool built on the HRFs tab — matched by channel name. Deconvolving a scan
+    with its OWN single-subject HRFs is intentionally NOT offered (not
+    validated/recommended in the paper). With fewer than two estimated
+    subjects there's no group, so we point the user at the HRtree library or
+    canonical source instead.
     """
-    n_group = _group_subject_count(state)
-    group_available = (
-        state.project_montage is not None
-        and not isinstance(state.project_montage, _CanonicalResult)
-        and n_group >= 2
-    )
-    if group_available:
-        def _set_group(event) -> None:
-            state.activity_use_group_hrfs = bool(event.value)
-            state.publish("scan_selected", state.selected_scan)
-
-        ui.radio(
-            {False: "Each scan's own HRFs", True: f"Group HRFs ({n_group})"},
-            value=state.activity_use_group_hrfs,
-            on_change=_set_group,
-        ).props("inline dense").classes("text-xs")
-    elif state.activity_use_group_hrfs:
-        # Group montage went away (project reset / re-estimate) — fall back.
-        state.activity_use_group_hrfs = False
-
-    if state.activity_use_group_hrfs and group_available:
+    montage = _montage_for_scan(state, scan)  # group (>=2 subjects) or None
+    if montage is not None:
+        n_group = _group_subject_count(state)
         ui.label(
             f"Deconvolving every scan with the GROUP HRFs ({n_group} subjects), "
             "matched by channel name."
         ).classes("text-sm opacity-70")
-        _safe_render_gallery(state, state.project_montage)
-        return
-
-    if bulk_mode:
-        n_cached = len(state.montage_cache)
-        ui.label(
-            "Each checked scan is deconvolved with its own estimated HRFs. "
-            f"{n_cached} scan(s) currently have estimated HRFs; checked scans "
-            "without them are skipped — estimate HRFs for them first."
-        ).classes("text-xs opacity-70 italic")
-        if n_cached == 0:
-            _go_to_hrfs_button(state)
-        montage = _montage_for_scan(state, scan)
-        if montage is not None:
-            _safe_render_gallery(state, montage)
-        return
-
-    montage = _montage_for_scan(state, scan)
-    if montage is not None:
-        ui.label("Using HRFs estimated for this scan.").classes(
-            "text-sm opacity-70"
-        )
         _safe_render_gallery(state, montage)
         return
 
-    # Not ready for this scan — tailor the message.
-    if isinstance(state.montage, _CanonicalResult) and not state.montage_cache:
-        ui.label(
-            "Toeplitz mode requires real per-channel HRFs, but the HRFs tab "
-            "last produced a canonical reference shape."
-        ).classes("text-sm opacity-70")
-        ui.label(
-            "Re-run the HRFs tab in toeplitz mode, or switch the source above "
-            "to canonical."
-        ).classes("text-xs opacity-60")
-        _go_to_hrfs_button(state)
-        return
-
-    any_estimated = bool(state.montage_cache) or (
-        state.montage is not None
-        and not isinstance(state.montage, _CanonicalResult)
-    )
-    if not any_estimated:
-        ui.label(
-            "Toeplitz mode requires estimated HRFs — none have been estimated "
-            "yet."
-        ).classes("text-sm opacity-70")
-        ui.label(
-            "Estimate per-channel HRFs first, then return here to deconvolve "
-            "activity with them."
-        ).classes("text-xs opacity-60")
-    else:
-        ui.label(
-            "No estimated HRFs for this scan."
-        ).classes("text-sm opacity-70")
-        ui.label(
-            "Estimate HRFs for this scan (toeplitz), or switch the source "
-            "above to canonical."
-        ).classes("text-xs opacity-60")
+    # Not enough subjects for a validated group HRF.
+    ui.label(
+        "Estimated-HRF deconvolution uses a GROUP HRF — the average across "
+        "≥2 subjects' estimates. Deconvolving a scan with its own HRFs isn't "
+        "offered (not validated in the paper)."
+    ).classes("text-sm opacity-70")
+    n_cached = _group_subject_count(state)
+    ui.label(
+        f"{n_cached} scan{'s' if n_cached != 1 else ''} estimated so far — "
+        "estimate HRFs for at least 2 on the HRFs tab, or switch the source "
+        "above to the HRtree library or canonical."
+    ).classes("text-xs opacity-60")
     _go_to_hrfs_button(state)
 
 
@@ -1120,34 +1056,25 @@ def _group_subject_count(state: AppState) -> int:
 
 
 def _montage_for_scan(state: AppState, scan: Optional[ScanEntry]):
-    """The per-channel Montage to use for toeplitz activity on ``scan``.
+    """The per-channel Montage for toeplitz ("Estimated HRFs") activity.
 
-    Prefers the scan's own cached montage (``state.montage_cache``, populated
-    by every HRF estimate), so toeplitz works per-scan across single and bulk
-    runs. Falls back to the single most-recent ``state.montage`` when it was
-    estimated for this exact scan. Returns None when neither applies.
+    Deconvolution with estimated HRFs uses the GROUP montage — the pooled,
+    >=2-subject project montage (matched by channel name in estimate_activity).
+    Deconvolving a scan with its OWN single-subject HRFs is intentionally NOT
+    offered: it wasn't validated/recommended in the paper. With fewer than two
+    estimated subjects there is no group, so this returns None and the user is
+    pointed at the HRtree library or canonical sources instead.
+
+    ``scan`` is accepted for call-site compatibility but unused — the group
+    HRF applies to every scan by channel name.
     """
-    # Group mode: deconvolve EVERY scan with the pooled project montage
-    # (matched by channel name in estimate_activity), so a group HRF can be
-    # applied even to scans that weren't individually estimated.
+    group = state.project_montage
     if (
-        getattr(state, "activity_use_group_hrfs", False)
-        and state.project_montage is not None
-        and not isinstance(state.project_montage, _CanonicalResult)
+        group is not None
+        and not isinstance(group, _CanonicalResult)
+        and _group_subject_count(state) >= 2
     ):
-        return state.project_montage
-    if scan is None:
-        return None
-    cached = state.montage_cache.get(scan.path.resolve())
-    if cached is not None:
-        return cached
-    if (
-        state.montage is not None
-        and not isinstance(state.montage, _CanonicalResult)
-        and state.montage_source_scan is not None
-        and state.montage_source_scan.path == scan.path
-    ):
-        return state.montage
+        return group
     return None
 
 

--- a/src/hrfunc/gui/components/hrtree_panel.py
+++ b/src/hrfunc/gui/components/hrtree_panel.py
@@ -865,11 +865,11 @@ def _render_cluster_subtab(state: AppState) -> None:
             # Add ROI / Add Montage buttons), so there's no standalone
             # button here anymore.
 
-            # --- MNI + atlas readouts --------------------------------
+            # --- Atlas readout ---------------------------------------
+            # (The shape/MNI coords readout was removed — it just repeated the
+            # centre inputs + radius slider above. The atlas Region-at-centre
+            # stays as real, non-redundant provenance.)
             ui.separator()
-            ui.label(_format_shape_readout(state)).classes(
-                "text-xs font-mono opacity-80 break-all"
-            )
             if atlas is not None:
                 # Atlas readout is shown in BOTH modes so sphere users
                 # can see "my centre sits in: Frontal Pole" without
@@ -921,9 +921,11 @@ def _render_cluster_subtab(state: AppState) -> None:
                 alignment_affine=alignment,
             )
             roi_result = compute_roi_average(matched, roi_keys)
-            excluded_count = compute_roi_excluded_count(matched, roi_keys)
             can_save = roi_result is not None
 
+            # The "averaging N subjects across M channels" readout moved to the
+            # detail pane (right). Only the can't-save gate stays here so a
+            # disabled Save button still explains itself.
             if roi_result is None:
                 ui.label(
                     "Active ROI has fewer than 2 averageable subject "
@@ -932,19 +934,6 @@ def _render_cluster_subtab(state: AppState) -> None:
                     "centre. (Note: HRFs without per-subject estimates "
                     "are excluded.)"
                 ).classes("text-xs opacity-60 italic")
-            else:
-                _, _, n_subjects, n_channels = roi_result
-                ui.label(
-                    f"Active ROI: averaging {n_subjects} subject "
-                    f"estimates across {n_channels} channel"
-                    f"{'s' if n_channels != 1 else ''}."
-                ).classes("text-xs opacity-70")
-                if excluded_count > 0:
-                    ui.label(
-                        f"  ({excluded_count} HRF"
-                        f"{'s' if excluded_count != 1 else ''} excluded "
-                        f"for lacking subject-level estimates.)"
-                    ).classes("text-xs opacity-50 italic")
 
             # Visibility summary for the multi-ROI case so the user
             # knows the save button reflects fewer than the list shows.

--- a/src/hrfunc/gui/components/hrtree_panel.py
+++ b/src/hrfunc/gui/components/hrtree_panel.py
@@ -2193,9 +2193,9 @@ def _render_detail_pane(state: AppState) -> None:
 
             if trace:
                 ui.separator()
-                ui.label("Trace").classes(
-                    "text-xs uppercase opacity-60 tracking-wide"
-                )
+                ui.label(
+                    f"Trace · {'HbO' if hrf.get('oxygenation') else 'HbR'}"
+                ).classes("text-xs uppercase opacity-60 tracking-wide")
                 png = _render_trace_png(hrf)
                 if png is not None:
                     # shrink-0 so the plot keeps its natural size regardless
@@ -2239,14 +2239,57 @@ def _showing_active_roi(state: AppState) -> bool:
     return sel is None or sel is active.anchor
 
 
+def _roi_average_oxygenations(state: AppState) -> "list":
+    """Oxygenations to render ROI averages for — NEVER a mixed pool.
+
+    Averaging HbO and HbR traces together is scientifically wrong (they are
+    inverse responses, so the pool cancels into a meaningless trace). So:
+    - a determinate oxygenation (the clicked anchor's, or the HbO/HbR filter)
+      → that single value;
+    - indeterminate ("Both" with no anchor) → BOTH, rendered as separate,
+      labelled HbO and HbR averages rather than one pooled trace.
+    """
+    oxy = _resolve_cluster_oxygenation(state)
+    if oxy is not None:
+        return [bool(oxy)]
+    return [True, False]
+
+
+def _render_one_roi_average(
+    state: AppState, matched, shape, alignment, oxy: bool, *, header: str
+) -> bool:
+    """Render a single oxygenation-pure ROI average, labelled HbO/HbR.
+
+    Returns True when something rendered (the ROI had ≥2 averageable
+    same-oxygenation members), False otherwise.
+    """
+    roi_keys = compute_roi_keys_by_shape(
+        matched, shape, state.library_roi_painted,
+        oxygenation_filter=oxy,
+        alignment_affine=alignment,
+    )
+    result = compute_roi_average(matched, roi_keys)
+    if result is None:
+        return False
+    mean, std, n_subjects, n_channels = result
+    sfreq = _resolve_roi_sfreq(state.library_selected_hrf, matched, roi_keys)
+    tag = "HbO" if oxy else "HbR"
+    ui.label(
+        f"{header} · {tag} ({n_subjects} subjects, {n_channels} channels)"
+    ).classes("text-xs uppercase opacity-60 tracking-wide")
+    png = _render_roi_average_png(mean, std, sfreq, n_subjects)
+    if png is not None:
+        ui.image(png).classes("max-w-md shrink-0")
+    return True
+
+
 def _render_active_roi_detail(state: AppState) -> bool:
-    """Render the active ROI's aggregate HRF as the primary detail.
+    """Render the active ROI's aggregate HRF(s) as the primary detail.
 
     Returns True when it rendered (the ROI has an averageable HRF), False when
     there's nothing to show — the caller then falls back to the single-HRF
-    detail. Mirrors :func:`_render_roi_average`'s membership computation but
-    leads with ROI-level metadata (name, member/pool counts) instead of a
-    single optode's location/context.
+    detail. Renders one labelled average PER oxygenation so HbO and HbR are
+    never pooled together.
     """
     active = state.active_roi
     if active is None:
@@ -2257,56 +2300,31 @@ def _render_active_roi_detail(state: AppState) -> bool:
         state.library_oxygenation,
     )
     shape = _build_current_shape(state)
-    oxy_filter = _resolve_cluster_oxygenation(state)
     alignment = _alignment_for_shape(state, shape)
-    roi_keys = compute_roi_keys_by_shape(
-        matched, shape, state.library_roi_painted,
-        oxygenation_filter=oxy_filter,
-        alignment_affine=alignment,
-    )
-    result = compute_roi_average(matched, roi_keys)
-    if result is None:
-        return False
-    mean, std, n_subjects, n_channels = result
-    anchor = state.library_selected_hrf
-    sfreq = _resolve_roi_sfreq(anchor, matched, roi_keys)
+    oxygenations = _roi_average_oxygenations(state)
 
     name = getattr(active, "name", None) or "ROI"
-    ui.label(name).classes("text-lg font-mono break-all")
-    if oxy_filter is True:
-        oxy_text = "HbO"
-    elif oxy_filter is False:
-        oxy_text = "HbR"
-    else:
-        oxy_text = "HbO + HbR"
-    _kv("oxygenation", oxy_text)
-    _kv("members", f"{len(roi_keys)} HRF{'s' if len(roi_keys) != 1 else ''}")
-    _kv("pooled", f"{n_subjects} subjects · {n_channels} channels")
-    if isinstance(anchor, dict) and anchor.get("_key"):
-        _kv("anchored on", anchor["_key"])
-
-    ui.separator()
-    ui.label("ROI HRF (averaged trace)").classes(
-        "text-xs uppercase opacity-60 tracking-wide"
-    )
-    png = _render_roi_average_png(mean, std, sfreq, n_subjects)
-    if png is not None:
-        ui.image(png).classes("max-w-md shrink-0")
-    return True
+    rendered = False
+    for oxy in oxygenations:
+        if not rendered:
+            ui.label(name).classes("text-lg font-mono break-all")
+            ui.separator()
+            ui.label("ROI HRF (averaged trace)").classes(
+                "text-xs uppercase opacity-60 tracking-wide"
+            )
+        rendered |= _render_one_roi_average(
+            state, matched, shape, alignment, oxy, header="ROI HRF",
+        )
+    return rendered
 
 
 def _render_roi_average(state: AppState) -> None:
-    """Render the averaged-trace plot for the current ROI.
+    """Render the averaged-trace plot(s) for the current ROI.
 
-    Read-only display: shows the averaged trace PNG with the ROI
-    member count. The Save-to-workspace action lives in the Cluster
-    sub-tab on the left (Phase 6); the detail pane is for viewing,
-    not for committing state to disk.
-
-    Uses the Cluster sub-tab's current Shape (box or sphere) plus
-    the visible-filter context to compute ROI membership, so this
-    panel stays in sync with the cluster shape even when the user
-    has no anchor HRF clicked.
+    Read-only display below the single-HRF detail. Renders one labelled
+    average per oxygenation (HbO and HbR are never pooled together — see
+    :func:`_roi_average_oxygenations`), staying in sync with the Cluster
+    sub-tab's current shape + filters.
     """
     all_hrfs = gather_library_hrfs(state)
     matched = filter_by_oxygenation(
@@ -2314,29 +2332,21 @@ def _render_roi_average(state: AppState) -> None:
         state.library_oxygenation,
     )
     shape = _build_current_shape(state)
-    oxy_filter = _resolve_cluster_oxygenation(state)
     alignment = _alignment_for_shape(state, shape)
-    roi_keys = compute_roi_keys_by_shape(
-        matched, shape, state.library_roi_painted,
-        oxygenation_filter=oxy_filter,
-        alignment_affine=alignment,
-    )
-    result = compute_roi_average(matched, roi_keys)
-    if result is None:
-        return
-    mean, std, n_subjects, n_channels = result
-    # Sfreq: prefer the anchor's when present (legacy behaviour);
-    # otherwise default to the first ROI member's sfreq, falling back
-    # to 1.0 if even that's missing. The save flow does the same.
-    anchor = state.library_selected_hrf
-    sfreq = _resolve_roi_sfreq(anchor, matched, roi_keys)
-    ui.separator()
-    ui.label(
-        f"ROI average ({n_subjects} subjects, {n_channels} channels)"
-    ).classes("text-xs uppercase opacity-60 tracking-wide")
-    png = _render_roi_average_png(mean, std, sfreq, n_subjects)
-    if png is not None:
-        ui.image(png).classes("max-w-md")
+    sep_done = False
+    for oxy in _roi_average_oxygenations(state):
+        roi_keys = compute_roi_keys_by_shape(
+            matched, shape, state.library_roi_painted,
+            oxygenation_filter=oxy, alignment_affine=alignment,
+        )
+        if compute_roi_average(matched, roi_keys) is None:
+            continue
+        if not sep_done:
+            ui.separator()
+            sep_done = True
+        _render_one_roi_average(
+            state, matched, shape, alignment, oxy, header="ROI average",
+        )
 
 
 def _render_roi_average_png(

--- a/src/hrfunc/gui/pages/shell.py
+++ b/src/hrfunc/gui/pages/shell.py
@@ -156,6 +156,13 @@ def _render(state: AppState) -> None:
     ui.query(".nicegui-content").classes(
         "h-screen w-screen overflow-hidden"
     ).style("padding: 0; gap: 0;")
+    # Let the Activity tab's label wrap to two centered lines ("Neural" /
+    # "Activity"). Quasar's q-tab__label is white-space:nowrap by default, so
+    # the embedded newline needs pre-line to take effect.
+    ui.add_head_html(
+        "<style>.hrf-twoline-tab .q-tab__label{white-space:pre-line;"
+        "line-height:1.05;text-align:center}</style>"
+    )
 
     initial_tab = TAB_HRTREE
     if state.preload_path is not None:
@@ -226,7 +233,15 @@ def _render_toolbar(state: AppState, tabs_holder: dict) -> None:
         # proper noun some users will see for the first time)
         with ui.tabs().classes("flex-1") as tabs:
             for name in TAB_NAMES:
-                tab = ui.tab(name)
+                # Keep the internal tab NAME stable (panel routing keys off it),
+                # but give Activity a more explanatory two-line "Neural Activity"
+                # LABEL.
+                if name == TAB_ACTIVITY:
+                    tab = ui.tab(name, label="Neural\nActivity").classes(
+                        "hrf-twoline-tab"
+                    )
+                else:
+                    tab = ui.tab(name)
                 tooltip_text = TAB_TOOLTIPS.get(name, "")
                 if tooltip_text:
                     tab.tooltip(tooltip_text)

--- a/src/hrfunc/gui/state.py
+++ b/src/hrfunc/gui/state.py
@@ -308,11 +308,6 @@ class AppState:
     # group montage is rebuilt; kept separate from ``montage_cache`` so the
     # per-scan HRFs stay available for single-scan / Activity use.
     project_group_excluded: Set[Path] = field(default_factory=set)
-    # When True, the Activity tab's toeplitz source deconvolves EVERY scan with
-    # the pooled ``project_montage`` (group HRFs, matched by channel name)
-    # instead of each scan's own estimated HRFs. Lets a user apply a group HRF
-    # to scans that weren't individually estimated.
-    activity_use_group_hrfs: bool = False
     # Deconvolved Raw from the most recent estimate_activity call (Sprint 3.4).
     # Typed Any for the same import-graph reason. The Activity panel reads
     # the data + annotations for the lens-style preproc/deconv overlay plot.
@@ -848,7 +843,6 @@ class AppState:
         self.project_montage = None
         self.hrf_preview_group = True
         self.project_group_excluded.clear()
-        self.activity_use_group_hrfs = False
         self.preload_path = None
         self.busy = False
         self.estimation_progress = None

--- a/src/hrfunc/gui/submission.py
+++ b/src/hrfunc/gui/submission.py
@@ -495,6 +495,10 @@ def render_submission_panel(state, *, default_path: Optional[Path] = None) -> No
             "are reviewed before they appear in the HRtree library. "
             "You'll receive a confirmation email at the address below."
         ).classes("text-xs opacity-70")
+        ui.label(
+            "All fields are required. For an experimental context or area "
+            "code that doesn't apply to your study, enter N/A."
+        ).classes("text-xs opacity-60 italic")
 
         # --- HRServ health pill ---------------------------------------
         # Mirrors the hrfunc-web JS pill at the top of /hrf_upload.
@@ -817,9 +821,15 @@ def _text_input(
     def _on_change(event) -> None:
         setattr(metadata, attr, str(event.value or ""))
 
+    # Every field is required, but experimental-context fields and the area
+    # codes may genuinely not apply to a study — so they accept an explicit
+    # "N/A". Surface that as a placeholder so users fill it deliberately
+    # instead of being stuck on a required field that doesn't apply.
+    na_ok = attr in EXPERIMENTAL_CONTEXT_ANCHORS or attr == "area_codes"
     ui.input(
         label=label_text,
         value=getattr(metadata, attr),
+        placeholder="value, or N/A if not applicable" if na_ok else None,
         on_change=_on_change,
     ).props("dense outlined").classes("w-full")
 

--- a/tests/test_gui_activity_panel.py
+++ b/tests/test_gui_activity_panel.py
@@ -403,32 +403,6 @@ class TestStateMontageSourceScan:
         assert s.montage_source_scan is None
 
 
-async def test_panel_toeplitz_rejects_cross_scan_montage(
-    user: User, tmp_path
-):
-    """Toeplitz mode must refuse when only ANOTHER scan's HRFs exist —
-    applying scan A's HRFs to scan B's Raw would silently produce wrong
-    results. With per-scan montage caching, selecting scan B (whose HRFs
-    aren't cached) reports it has no estimated HRFs of its own."""
-    scan_a = ScanEntry(
-        format="snirf", path=tmp_path / "a.snirf", display_name="scan_a"
-    )
-    scan_b = ScanEntry(
-        format="snirf", path=tmp_path / "b.snirf", display_name="scan_b"
-    )
-    raw = _make_fake_raw()
-    global_state.reset()
-    global_state.manifest = Manifest(root=tmp_path, scans=(scan_a, scan_b))
-    global_state.selected_scan = scan_b
-    global_state.processed_cache._cache[scan_b.path.resolve()] = raw
-    # A real montage tagged to scan A only (not in scan B's cache).
-    global_state.montage = object()  # Stand-in for a real Montage
-    global_state.montage_source_scan = scan_a
-
-    await user.open("/")
-    await user.should_see("No estimated HRFs for this scan")
-
-
 # ---------------------------------------------------------------------------
 # Panel rendering — User fixture
 # ---------------------------------------------------------------------------
@@ -472,32 +446,11 @@ async def test_panel_toeplitz_needs_hrfs_first(user: User, tmp_path):
     global_state.manifest = Manifest(root=tmp_path, scans=(scan,))
     global_state.selected_scan = scan
     global_state.processed_cache._cache[scan.path.resolve()] = raw
-    # No montage set → toeplitz mode should prompt for HRFs first, and offer
-    # a jump to the HRFs tab so the user can accomplish it.
+    # No GROUP montage (≥2 subjects) → estimated-HRF mode prompts for it and
+    # offers a jump to the HRFs tab. (A scan's own HRFs are not an option.)
     await user.open("/")
-    await user.should_see("Toeplitz mode requires estimated HRFs")
+    await user.should_see("average across ≥2 subjects")
     await user.should_see("Go to HRFs tab")
-
-
-async def test_panel_toeplitz_rejects_canonical_result_montage(
-    user: User, tmp_path
-):
-    """If the HRFs tab last produced a canonical reference (not a real
-    Montage with traces), toeplitz Activity mode tells the user to re-run
-    HRFs in toeplitz mode."""
-    scan = ScanEntry(
-        format="snirf", path=tmp_path / "a.snirf", display_name="a"
-    )
-    raw = _make_fake_raw()
-    global_state.reset()
-    global_state.manifest = Manifest(root=tmp_path, scans=(scan,))
-    global_state.selected_scan = scan
-    global_state.processed_cache._cache[scan.path.resolve()] = raw
-    global_state.montage = hrf_panel._CanonicalResult(
-        canonical_trace=np.zeros(10), duration=30.0, sfreq=10.0
-    )
-    await user.open("/")
-    await user.should_see("Toeplitz mode requires real per-channel HRFs")
 
 
 async def test_panel_shows_lambda_control(user: User, tmp_path):
@@ -533,7 +486,8 @@ async def test_workspace_subscribes_activity_panel(user: User, tmp_path):
 
 
 class TestMontageForScan:
-    """Per-scan montage resolution backing toeplitz activity."""
+    """Estimated-HRF (toeplitz) activity uses the GROUP montage only — a
+    scan's own single-subject HRFs are intentionally NOT offered."""
 
     def _scan(self, p):
         return ScanEntry(format="snirf", path=Path(p), display_name=Path(p).stem)
@@ -542,26 +496,20 @@ class TestMontageForScan:
         st = AppState()
         assert activity_panel._montage_for_scan(st, self._scan("/tmp/x.snirf")) is None
 
-    def test_uses_cached_montage(self):
+    def test_none_with_single_subject_cached(self):
+        # One estimated scan is not a group -> own-HRF deconvolution unavailable.
         st = AppState()
-        scan = self._scan("/tmp/x.snirf")
-        m = object()
-        st.montage_cache[scan.path.resolve()] = m
-        assert activity_panel._montage_for_scan(st, scan) is m
+        st.project_montage = object()
+        st.montage_cache[Path("/tmp/a.snirf")] = object()
+        assert activity_panel._montage_for_scan(st, self._scan("/tmp/a.snirf")) is None
 
-    def test_falls_back_to_single_montage_when_source_matches(self):
+    def test_returns_group_with_two_subjects(self):
         st = AppState()
-        scan = self._scan("/tmp/x.snirf")
-        m = object()
-        st.montage = m
-        st.montage_source_scan = scan
-        assert activity_panel._montage_for_scan(st, scan) is m
-
-    def test_ignores_single_montage_for_other_scan(self):
-        st = AppState()
-        st.montage = object()
-        st.montage_source_scan = self._scan("/tmp/a.snirf")
-        assert activity_panel._montage_for_scan(st, self._scan("/tmp/b.snirf")) is None
+        group = object()
+        st.project_montage = group
+        st.montage_cache[Path("/tmp/a.snirf")] = object()
+        st.montage_cache[Path("/tmp/b.snirf")] = object()
+        assert activity_panel._montage_for_scan(st, self._scan("/tmp/x.snirf")) is group
 
     def test_montage_cache_cleared_on_reset(self):
         st = AppState()

--- a/tests/test_gui_activity_per_channel.py
+++ b/tests/test_gui_activity_per_channel.py
@@ -234,26 +234,29 @@ class TestActivityGroupMode:
         )
         assert activity_panel._group_subject_count(state) == 2
 
-    def test_montage_for_scan_returns_group_when_enabled(self, tmp_path):
+    def test_montage_for_scan_returns_group_with_two_subjects(self, tmp_path):
+        from pathlib import Path
         scan = ScanEntry(format="snirf", path=tmp_path / "x.snirf")
         state = AppState()
         group = object()  # stand-in non-canonical montage
         state.project_montage = group
-        state.activity_use_group_hrfs = True
-        # Scan was never individually estimated, yet group mode supplies HRFs.
+        state.montage_cache[Path("/a")] = object()
+        state.montage_cache[Path("/b")] = object()
+        # Group HRF applies to any scan (even one never individually estimated).
         assert activity_panel._montage_for_scan(state, scan) is group
 
-    def test_group_off_uses_scans_own_montage(self, tmp_path):
+    def test_montage_for_scan_none_with_single_subject(self, tmp_path):
+        # "A scan's own HRFs" is NOT offered — fewer than 2 subjects => no
+        # toeplitz montage (use library / canonical instead).
+        from pathlib import Path
         scan = ScanEntry(format="snirf", path=tmp_path / "x.snirf")
         state = AppState()
-        own = object()
-        state.montage_cache[scan.path.resolve()] = own
         state.project_montage = object()
-        state.activity_use_group_hrfs = False
-        assert activity_panel._montage_for_scan(state, scan) is own
+        state.montage_cache[Path("/a")] = object()  # only 1 subject
+        assert activity_panel._montage_for_scan(state, scan) is None
 
     @pytest.mark.asyncio
-    async def test_group_toggle_renders_when_two_subjects(self, user, tmp_path):
+    async def test_group_status_renders_with_two_subjects(self, user, tmp_path):
         from pathlib import Path
         state = AppState()
         state.montage_cache[Path("/a")] = object()
@@ -265,4 +268,18 @@ class TestActivityGroupMode:
             activity_panel._render_estimated_source_status(state, None, False)
 
         await user.open("/_agroup")
-        await user.should_see("Group HRFs (2)")
+        await user.should_see("GROUP HRFs (2 subjects)")
+
+    @pytest.mark.asyncio
+    async def test_prompts_when_fewer_than_two_subjects(self, user, tmp_path):
+        from pathlib import Path
+        state = AppState()
+        state.montage_cache[Path("/a")] = object()  # only 1 subject
+
+        @ui.page("/_agroup_one")
+        def _p() -> None:
+            activity_panel._render_estimated_source_status(state, None, False)
+
+        await user.open("/_agroup_one")
+        await user.should_see("average across ≥2 subjects")
+        await user.should_see("not validated in the paper")

--- a/tests/test_gui_hrtree_roi_detail.py
+++ b/tests/test_gui_hrtree_roi_detail.py
@@ -54,3 +54,29 @@ class TestRenderActiveRoiDetailGuard:
         # No rendering context needed: bails before any ui.* call.
         state = AppState()
         assert hrtree_panel._render_active_roi_detail(state) is False
+
+
+class TestRoiAverageOxygenationPure:
+    """ROI averages must NEVER pool HbO + HbR together (inverse responses)."""
+
+    def test_indeterminate_returns_both_separately(self):
+        st = AppState()
+        st.library_oxygenation = "both"
+        st.library_selected_hrf = None
+        assert hrtree_panel._roi_average_oxygenations(st) == [True, False]
+
+    def test_anchor_oxygenation_determines_single(self):
+        st = AppState()
+        st.library_oxygenation = "both"
+        st.library_selected_hrf = {"oxygenation": True}
+        assert hrtree_panel._roi_average_oxygenations(st) == [True]
+        st.library_selected_hrf = {"oxygenation": False}
+        assert hrtree_panel._roi_average_oxygenations(st) == [False]
+
+    def test_panel_filter_determines_single(self):
+        st = AppState()
+        st.library_selected_hrf = None
+        st.library_oxygenation = "hbo"
+        assert hrtree_panel._roi_average_oxygenations(st) == [True]
+        st.library_oxygenation = "hbr"
+        assert hrtree_panel._roi_average_oxygenations(st) == [False]

--- a/tests/test_gui_library.py
+++ b/tests/test_gui_library.py
@@ -1251,7 +1251,6 @@ async def test_cluster_subtab_owns_radius_and_clear_roi(user: User):
     # pre-refactor "Clear ROI" / "Delete active ROI".
     await user.should_see("Clear")
     await user.should_see("Centre (MNI mm)")
-    await user.should_see("Sphere r=")
 
 
 async def test_viz_pane_refreshes_on_selection_change(user: User):
@@ -1423,7 +1422,7 @@ async def test_cluster_subtab_does_not_expose_box_shape(user: User):
     global_state.add_roi()
     _mount_hrtree_route()
     await user.open("/_test_hrtree")
-    await user.should_see("Sphere r=")
+    await user.should_see("ROI radius")  # sphere mode renders the radius slider
     await user.should_not_see("Box half-extents")
     # No half-extent inputs in the sub-tab body.
     await user.should_not_see("half-extents (mm)")


### PR DESCRIPTION
## Why this PR

PR #74 was merged while its branch was at `b78baf4`, so the two commits I pushed afterward never reached `main`. This PR lands that tail so `main` reflects the full session.

## What's included

**`cef81dd` — HRtree ROI averages never pool HbO+HbR**
- Root cause: `_resolve_cluster_oxygenation` → `None` (mode "Both" + no anchor) let `compute_roi_keys_by_shape` pool HbO and HbR together, which cancel and surfaced the wrong-oxygenation HRF in the detail/ROI-average panes.
- `_roi_average_oxygenations` now returns one determinate oxygenation, or renders HbO and HbR **separately** — never mixed. Every detail/average plot is labelled `HbO`/`HbR`.
- Activity tab relabelled to a two-line **"Neural Activity"** (internal name unchanged).

**`2a98aee` — Activity group-HRFs-only + submission + Cluster trim**
- Removed deconvolving a scan with its **own** single-subject HRFs (not validated in the paper). `_montage_for_scan` returns the project group montage iff ≥2 subjects, else `None`.
- Submission: context fields + area code accept a strategic **"N/A"** (placeholder + form note); all fields otherwise required.
- Cluster sub-tab: removed the redundant shape/coords readout + "averaging N subjects" status line.

## Tests

Full suite at this tip: **1116 passed**, 4 pre-existing failures (event-picker test omits `processed_deconvolved`; `automatch_bids_strict`; 2× progress-callback last-param) — unrelated to these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
